### PR TITLE
feat: --profile flag on serve for authenticated sessions

### DIFF
--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -1,0 +1,17 @@
+//! Global auth profile configuration.
+//!
+//! Set once at startup, read by session constructors.
+
+use std::sync::OnceLock;
+
+static AUTH_PROFILES: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Set the global auth profiles (call once at startup).
+pub fn set_profiles(profiles: Vec<String>) {
+    let _ = AUTH_PROFILES.set(profiles);
+}
+
+/// Get the configured auth profiles.
+pub fn profiles() -> &'static [String] {
+    AUTH_PROFILES.get().map(|v| v.as_slice()).unwrap_or(&[])
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod store;

--- a/src/awp/session.rs
+++ b/src/awp/session.rs
@@ -51,10 +51,28 @@ impl Session {
         locale: Option<String>,
         timeout_ms: Option<u64>,
     ) -> Result<Self, String> {
+        Self::new_with_profiles(id, user_agent, locale, timeout_ms, crate::auth::config::profiles())
+    }
+
+    pub fn new_with_profiles(
+        id: String,
+        user_agent: Option<String>,
+        locale: Option<String>,
+        timeout_ms: Option<u64>,
+        auth_profiles: &[String],
+    ) -> Result<Self, String> {
         let ua = user_agent.unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
         let locale = locale.unwrap_or_else(|| "en-US".to_string());
         let timeout = timeout_ms.unwrap_or(30000);
         let jar = Arc::new(Jar::default());
+
+        // Load auth cookies from profiles
+        for domain in auth_profiles {
+            if let Err(e) = crate::auth::store::load_into_jar(domain, &jar) {
+                tracing::warn!(domain = %domain, error = %e, "Failed to load auth profile");
+            }
+        }
+
         let client =
             fetch::build_client_h1_fallback(Some(&ua), jar.clone()).map_err(|e| e.to_string())?;
 

--- a/src/cdp/session.rs
+++ b/src/cdp/session.rs
@@ -69,6 +69,10 @@ const DEFAULT_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7
 
 impl CdpTarget {
     pub fn new() -> Result<Self, String> {
+        Self::new_with_profiles(crate::auth::config::profiles())
+    }
+
+    pub fn new_with_profiles(auth_profiles: &[String]) -> Result<Self, String> {
         let target_num = TARGET_COUNTER.fetch_add(1, Ordering::Relaxed);
         let target_id = format!("{:032X}", target_num);
         let session_id = format!("{:032X}", target_num + 1000);
@@ -76,6 +80,14 @@ impl CdpTarget {
         let loader_id = format!("{:032X}", target_num + 3000);
 
         let jar = Arc::new(Jar::default());
+
+        // Load auth cookies from profiles
+        for domain in auth_profiles {
+            if let Err(e) = crate::auth::store::load_into_jar(domain, &jar) {
+                tracing::warn!(domain = %domain, error = %e, "Failed to load auth profile");
+            }
+        }
+
         let client = fetch::build_client_h1_fallback(Some(DEFAULT_USER_AGENT), jar.clone())
             .map_err(|e| e.to_string())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod awp;
 pub mod bench;
 pub mod cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,16 @@ use std::sync::Arc;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-mod auth;
-mod awp;
-mod bench;
-mod cache;
-mod cdp;
-mod js;
 mod mcp;
-mod network;
-mod som;
+
+use plasmate::auth;
+use plasmate::awp;
+use plasmate::bench;
+use plasmate::cache;
+use plasmate::cdp;
+use plasmate::js;
+use plasmate::network;
+use plasmate::som;
 
 #[derive(Parser)]
 #[command(name = "plasmate")]
@@ -52,6 +53,9 @@ enum Commands {
         /// Protocol: awp (default), cdp (Puppeteer/Playwright compatible), or both
         #[arg(long, default_value = "cdp")]
         protocol: String,
+        /// Load cookies from stored auth profile(s) (comma-separated domain names)
+        #[arg(long)]
+        profile: Option<String>,
     },
     /// Run SOM benchmarks against a list of URLs
     Bench {
@@ -143,7 +147,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             host,
             port,
             protocol,
+            profile,
         } => {
+            // Set global auth profiles for all sessions
+            if let Some(ref profile_str) = profile {
+                let domains: Vec<String> = profile_str.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+                if !domains.is_empty() {
+                    info!(profiles = ?domains, "Loading auth profiles for server sessions");
+                    auth::config::set_profiles(domains);
+                }
+            }
+
             match protocol.as_str() {
                 "awp" => {
                     info!("Starting AWP protocol server");


### PR DESCRIPTION
## Summary

Adds `--profile` flag to `plasmate serve` so persistent server sessions automatically load stored auth cookies.

```bash
plasmate serve --profile x.com
plasmate serve --profile x.com,github.com --protocol awp
```

## Changes

- `--profile` on serve: comma-separated domain list, cookies loaded at startup
- Global auth config: OnceLock-based, set once, read by all session constructors
- Auth module moved to lib crate: AWP and CDP session code can access auth::store and auth::config
- Backwards compatible: Session::new() and CdpTarget::new() unchanged

## How it works

1. `--profile x.com` parses domains and calls `auth::config::set_profiles()`
2. Session constructors read `auth::config::profiles()` and load cookies into reqwest jar
3. Zero per-request overhead

All 167 tests pass.