### PR TITLE
feat: add toggle/clear MCP tools + AWP parity + scroll tracking

### DIFF
--- a/src/awp/handler.rs
+++ b/src/awp/handler.rs
@@ -491,15 +491,90 @@ async fn handle_page_act(
             )
         }
         "scroll" => {
-            // No-op in v0.1
+            let direction = intent
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("down");
+
+            let delta: i64 = match direction {
+                "up" => -300,
+                "down" => 300,
+                "top" => {
+                    // Reset to 0
+                    session.scroll_y = Some(0);
+                    0
+                }
+                "bottom" => {
+                    // Set a large value to represent bottom
+                    session.scroll_y = Some(i64::MAX);
+                    0
+                }
+                _ => 300,
+            };
+
+            if direction != "top" && direction != "bottom" {
+                let current = session.scroll_y.unwrap_or(0);
+                let new_y = (current + delta).max(0);
+                session.scroll_y = Some(new_y);
+            }
+
             Response::success(
                 id,
                 json!({
                     "status": "ok",
-                    "resolved": null,
+                    "resolved": {
+                        "element_id": element.id,
+                        "role": element.role,
+                        "text": element.text
+                    },
                     "effects": {
                         "navigated": false,
-                        "som_changed": false
+                        "som_changed": false,
+                        "scroll_y": session.scroll_y
+                    }
+                }),
+            )
+        }
+        "toggle" => {
+            // Toggle checkbox/radio checked state or details open state in SOM
+            if let Some(som) = &mut session.current_som {
+                toggle_element(som, &element.id);
+            }
+
+            Response::success(
+                id,
+                json!({
+                    "status": "ok",
+                    "resolved": {
+                        "element_id": element.id,
+                        "role": element.role,
+                        "text": element.text
+                    },
+                    "effects": {
+                        "navigated": false,
+                        "som_changed": true
+                    }
+                }),
+            )
+        }
+        "clear" => {
+            // Clear the element value in SOM
+            if let Some(som) = &mut session.current_som {
+                update_element_value(som, &element.id, "");
+            }
+
+            Response::success(
+                id,
+                json!({
+                    "status": "ok",
+                    "resolved": {
+                        "element_id": element.id,
+                        "role": element.role,
+                        "text": element.text
+                    },
+                    "effects": {
+                        "navigated": false,
+                        "som_changed": true
                     }
                 }),
             )
@@ -1203,6 +1278,36 @@ fn update_element_value_in_list(elements: &mut [Element], element_id: &str, valu
         }
         if let Some(children) = &mut el.children {
             update_element_value_in_list(children, element_id, value);
+        }
+    }
+}
+
+fn toggle_element(som: &mut crate::som::types::Som, element_id: &str) {
+    for region in &mut som.regions {
+        toggle_element_in_list(&mut region.elements, element_id);
+    }
+}
+
+fn toggle_element_in_list(elements: &mut [Element], element_id: &str) {
+    for el in elements.iter_mut() {
+        if el.id == element_id {
+            let attrs = el.attrs.get_or_insert_with(|| json!({}));
+            if let Some(obj) = attrs.as_object_mut() {
+                // Toggle "checked" for checkboxes/radios, "open" for details
+                if let Some(checked) = obj.get("checked").and_then(|v| v.as_bool()) {
+                    obj.insert("checked".into(), json!(!checked));
+                } else if obj.contains_key("open") {
+                    let open = obj.get("open").and_then(|v| v.as_bool()).unwrap_or(false);
+                    obj.insert("open".into(), json!(!open));
+                } else {
+                    // Default: set checked to true (first toggle)
+                    obj.insert("checked".into(), json!(true));
+                }
+            }
+            return;
+        }
+        if let Some(children) = &mut el.children {
+            toggle_element_in_list(children, element_id);
         }
     }
 }

--- a/src/awp/session.rs
+++ b/src/awp/session.rs
@@ -28,6 +28,8 @@ pub struct Session {
     pub current_html: Option<String>,
     pub current_url: Option<String>,
     pub current_structured_data: Option<StructuredData>,
+    /// Current vertical scroll position.
+    pub scroll_y: Option<i64>,
     /// Navigation history (URLs visited in this session).
     pub history: Vec<HistoryEntry>,
     /// Pipeline configuration for this session.
@@ -108,6 +110,7 @@ impl Session {
             current_html: None,
             current_url: None,
             current_structured_data: None,
+            scroll_y: None,
             history: Vec::new(),
             pipeline_config: PipelineConfig {
                 execute_js: true,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -260,6 +260,8 @@ fn handle_tools_list(request: &JsonRpcRequest) -> JsonRpcResponse {
         tools::type_text_definition(),
         tools::select_option_definition(),
         tools::scroll_definition(),
+        tools::toggle_definition(),
+        tools::clear_definition(),
     ];
 
     JsonRpcResponse {
@@ -328,6 +330,8 @@ async fn handle_tools_call(
         "type_text" => tools::handle_type_text(&arguments, client, sessions).await,
         "select_option" => tools::handle_select_option(&arguments, client, sessions).await,
         "scroll" => tools::handle_scroll(&arguments, client, sessions).await,
+        "toggle" => tools::handle_toggle(&arguments, client, sessions).await,
+        "clear" => tools::handle_clear(&arguments, client, sessions).await,
         _ => {
             return JsonRpcResponse {
                 jsonrpc: "2.0".to_string(),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1043,6 +1043,20 @@ struct SelectOptionParams {
     value: String,
 }
 
+/// Parameters for toggle tool.
+#[derive(Debug, Deserialize)]
+struct ToggleParams {
+    session_id: String,
+    element_id: String,
+}
+
+/// Parameters for clear tool.
+#[derive(Debug, Deserialize)]
+struct ClearParams {
+    session_id: String,
+    element_id: String,
+}
+
 /// Parameters for scroll tool.
 #[derive(Debug, Deserialize)]
 struct ScrollParams {
@@ -1168,6 +1182,50 @@ pub fn scroll_definition() -> ToolDefinition {
                 }
             },
             "required": ["session_id"]
+        }),
+    }
+}
+
+/// Get the tool definition for toggle.
+pub fn toggle_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "toggle".to_string(),
+        description: "Toggle a checkbox, radio button, or details/summary widget by its SOM element ID. Returns the updated page SOM.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID from open_page"
+                },
+                "element_id": {
+                    "type": "string",
+                    "description": "Element ID from SOM (e.g. 'e5')"
+                }
+            },
+            "required": ["session_id", "element_id"]
+        }),
+    }
+}
+
+/// Get the tool definition for clear.
+pub fn clear_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "clear".to_string(),
+        description: "Clear the value of a text input or textarea by its SOM element ID. Returns the updated page SOM.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID from open_page"
+                },
+                "element_id": {
+                    "type": "string",
+                    "description": "Element ID from SOM (e.g. 'e5')"
+                }
+            },
+            "required": ["session_id", "element_id"]
         }),
     }
 }
@@ -1716,6 +1774,288 @@ pub async fn handle_scroll(
                     "title": page_result.som.title,
                     "url": url,
                     "scroll_position": scroll_top,
+                    "regions": som_json.get("regions")
+                }).to_string()
+            }
+        ]
+    })
+}
+
+/// Handle the toggle tool call.
+pub async fn handle_toggle(
+    arguments: &Value,
+    client: &reqwest::Client,
+    sessions: &Arc<SessionManager>,
+) -> Value {
+    let params: ToggleParams = match serde_json::from_value(arguments.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return error_response(&format!("Invalid arguments: {}", e));
+        }
+    };
+
+    info!(session_id = %params.session_id, element_id = %params.element_id, "toggle");
+
+    // Get session data
+    let session_data = sessions
+        .with_session(&params.session_id, |session| {
+            let effective_html = session.target.effective_html.clone();
+            let url = session.target.current_url.clone();
+            (effective_html, url)
+        })
+        .await;
+
+    let (effective_html, url) = match session_data {
+        Some((Some(html), Some(url))) => (html, url),
+        Some((None, _)) | Some((_, None)) => {
+            return error_response("No page loaded in session");
+        }
+        None => {
+            return error_response(&format!("Session not found: {}", params.session_id));
+        }
+    };
+
+    // Run JS to toggle the element
+    let element_id = params.element_id.clone();
+    let url_clone = url.clone();
+    let toggle_result = tokio::task::spawn_blocking(move || {
+        let mut runtime = JsRuntime::new(RuntimeConfig {
+            inject_dom_shim: true,
+            execute_inline_scripts: false,
+            ..Default::default()
+        });
+
+        runtime.bootstrap_dom(&effective_html, &url_clone);
+
+        let toggle_js = format!(
+            r#"
+            (function() {{
+                var el = document.querySelector('[data-plasmate-id="{}"]');
+                if (!el) {{
+                    return JSON.stringify({{ error: 'Element not found in DOM' }});
+                }}
+                var tag = el.tagName.toUpperCase();
+                if (tag === 'INPUT' && (el.type === 'checkbox' || el.type === 'radio')) {{
+                    el.checked = !el.checked;
+                    var changeEvt = new Event('change', {{ bubbles: true }});
+                    el.dispatchEvent(changeEvt);
+                    return JSON.stringify({{ toggled: true, checked: el.checked }});
+                }} else if (tag === 'DETAILS') {{
+                    el.open = !el.open;
+                    var toggleEvt = new Event('toggle', {{ bubbles: true }});
+                    el.dispatchEvent(toggleEvt);
+                    return JSON.stringify({{ toggled: true, open: el.open }});
+                }} else {{
+                    return JSON.stringify({{ error: 'Element is not a checkbox, radio button, or details element' }});
+                }}
+            }})()
+            "#,
+            element_id
+        );
+
+        let result = runtime.eval(&toggle_js).map_err(|e| e.to_string())?;
+        let updated_html = runtime
+            .eval("document.documentElement.outerHTML")
+            .map_err(|e| e.to_string())?;
+
+        Ok::<(String, String), String>((result, updated_html))
+    })
+    .await;
+
+    let (result_json, updated_html) = match toggle_result {
+        Ok(Ok((result, html))) => (result, html),
+        Ok(Err(e)) => {
+            return error_response(&format!("Toggle failed: {}", e));
+        }
+        Err(e) => {
+            return error_response(&format!("Execution error: {}", e));
+        }
+    };
+
+    // Check for errors from JS
+    let result_data: Value = serde_json::from_str(&result_json).unwrap_or(json!({}));
+    if let Some(err) = result_data.get("error").and_then(|v| v.as_str()) {
+        return error_response(err);
+    }
+
+    // Re-process the page to get updated SOM
+    let pipeline_config = PipelineConfig {
+        execute_js: true,
+        fetch_external_scripts: true,
+        ..Default::default()
+    };
+
+    let page_result =
+        match pipeline::process_page_async(&updated_html, &url, &pipeline_config, client).await {
+            Ok(r) => r,
+            Err(e) => {
+                return error_response(&format!("Pipeline error: {}", e));
+            }
+        };
+
+    // Update session
+    let som_json = sessions
+        .with_session(&params.session_id, |session| {
+            session.target.current_url = Some(url.clone());
+            session.target.current_html = Some(updated_html.clone());
+            session.target.effective_html = Some(page_result.effective_html.clone());
+            session.target.current_som = Some(page_result.som.clone());
+
+            serde_json::to_value(&page_result.som).ok()
+        })
+        .await;
+
+    let som_json = match som_json.flatten() {
+        Some(v) => v,
+        None => {
+            return error_response("Failed to serialize SOM");
+        }
+    };
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": json!({
+                    "title": page_result.som.title,
+                    "url": url,
+                    "regions": som_json.get("regions")
+                }).to_string()
+            }
+        ]
+    })
+}
+
+/// Handle the clear tool call.
+pub async fn handle_clear(
+    arguments: &Value,
+    client: &reqwest::Client,
+    sessions: &Arc<SessionManager>,
+) -> Value {
+    let params: ClearParams = match serde_json::from_value(arguments.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return error_response(&format!("Invalid arguments: {}", e));
+        }
+    };
+
+    info!(session_id = %params.session_id, element_id = %params.element_id, "clear");
+
+    // Get session data
+    let session_data = sessions
+        .with_session(&params.session_id, |session| {
+            let effective_html = session.target.effective_html.clone();
+            let url = session.target.current_url.clone();
+            (effective_html, url)
+        })
+        .await;
+
+    let (effective_html, url) = match session_data {
+        Some((Some(html), Some(url))) => (html, url),
+        Some((None, _)) | Some((_, None)) => {
+            return error_response("No page loaded in session");
+        }
+        None => {
+            return error_response(&format!("Session not found: {}", params.session_id));
+        }
+    };
+
+    // Run JS to clear the element value
+    let element_id = params.element_id.clone();
+    let url_clone = url.clone();
+    let clear_result = tokio::task::spawn_blocking(move || {
+        let mut runtime = JsRuntime::new(RuntimeConfig {
+            inject_dom_shim: true,
+            execute_inline_scripts: false,
+            ..Default::default()
+        });
+
+        runtime.bootstrap_dom(&effective_html, &url_clone);
+
+        let clear_js = format!(
+            r#"
+            (function() {{
+                var el = document.querySelector('[data-plasmate-id="{}"]');
+                if (!el) {{
+                    return JSON.stringify({{ error: 'Element not found in DOM' }});
+                }}
+                el.value = '';
+                var inputEvt = new Event('input', {{ bubbles: true }});
+                el.dispatchEvent(inputEvt);
+                var changeEvt = new Event('change', {{ bubbles: true }});
+                el.dispatchEvent(changeEvt);
+                return JSON.stringify({{ cleared: true }});
+            }})()
+            "#,
+            element_id
+        );
+
+        let result = runtime.eval(&clear_js).map_err(|e| e.to_string())?;
+        let updated_html = runtime
+            .eval("document.documentElement.outerHTML")
+            .map_err(|e| e.to_string())?;
+
+        Ok::<(String, String), String>((result, updated_html))
+    })
+    .await;
+
+    let (result_json, updated_html) = match clear_result {
+        Ok(Ok((result, html))) => (result, html),
+        Ok(Err(e)) => {
+            return error_response(&format!("Clear failed: {}", e));
+        }
+        Err(e) => {
+            return error_response(&format!("Execution error: {}", e));
+        }
+    };
+
+    // Check for errors from JS
+    let result_data: Value = serde_json::from_str(&result_json).unwrap_or(json!({}));
+    if let Some(err) = result_data.get("error").and_then(|v| v.as_str()) {
+        return error_response(err);
+    }
+
+    // Re-process the page to get updated SOM
+    let pipeline_config = PipelineConfig {
+        execute_js: true,
+        fetch_external_scripts: true,
+        ..Default::default()
+    };
+
+    let page_result =
+        match pipeline::process_page_async(&updated_html, &url, &pipeline_config, client).await {
+            Ok(r) => r,
+            Err(e) => {
+                return error_response(&format!("Pipeline error: {}", e));
+            }
+        };
+
+    // Update session
+    let som_json = sessions
+        .with_session(&params.session_id, |session| {
+            session.target.current_url = Some(url.clone());
+            session.target.current_html = Some(updated_html.clone());
+            session.target.effective_html = Some(page_result.effective_html.clone());
+            session.target.current_som = Some(page_result.som.clone());
+
+            serde_json::to_value(&page_result.som).ok()
+        })
+        .await;
+
+    let som_json = match som_json.flatten() {
+        Some(v) => v,
+        None => {
+            return error_response("Failed to serialize SOM");
+        }
+    };
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": json!({
+                    "title": page_result.som.title,
+                    "url": url,
                     "regions": som_json.get("regions")
                 }).to_string()
             }


### PR DESCRIPTION
Completes interaction tool coverage after #16.

## Changes

**MCP tools** (2 new):
- `toggle` — Checkbox checked, radio selected, details open/close via V8 + SOM recompile
- `clear` — Reset text input/textarea value via V8 + SOM recompile

**AWP page.act** (3 fixes):
- `toggle` — Flips checked/open attrs in SOM
- `clear` — Clears element value in SOM
- `scroll` — Replaced no-op stub with direction-aware scroll_y tracking

**Session**: Added `scroll_y: Option<i64>` field

## Result

All `default_actions()` in SOM now have working implementations in both MCP and AWP:

| Action | MCP | AWP | SOM declares |
|--------|-----|-----|-------------|
| click | ✅ | ✅ | ✅ |
| type | ✅ (#16) | ✅ | ✅ |
| select | ✅ (#16) | ✅ | ✅ |
| scroll | ✅ (#16) | ✅ (was no-op) | N/A |
| navigate | ✅ (#16) | ✅ | N/A |
| toggle | ✅ (this PR) | ✅ (this PR) | ✅ |
| clear | ✅ (this PR) | ✅ (this PR) | ✅ |

`cargo check` passes cleanly.