### PR TITLE
feat(compile): add --format and --selector flags, consistent with fetch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,15 @@ enum Commands {
         /// Output file (defaults to stdout)
         #[arg(long, short)]
         output: Option<String>,
+        /// Output format: "json" (default, full SOM), "text" (plain extracted
+        /// text), or "markdown" (structured Markdown). Same as `plasmate fetch
+        /// --format`.
+        #[arg(long, default_value = "json")]
+        format: String,
+        /// Filter output to a specific SOM region or element — same syntax as
+        /// `plasmate fetch --selector` (e.g. `main`, `nav`, `#my-id`).
+        #[arg(long)]
+        selector: Option<String>,
     },
     /// Start the MCP (Model Context Protocol) server over stdio
     Mcp,
@@ -573,8 +582,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        Commands::Compile { file, url, output } => {
-            cmd_compile(file, url, output)?;
+        Commands::Compile { file, url, output, format, selector } => {
+            cmd_compile(file, url, output, &format, selector.as_deref())?;
         }
         Commands::Mcp => {
             mcp::run_server().await?;
@@ -600,6 +609,8 @@ fn cmd_compile(
     file: Option<String>,
     url: String,
     output: Option<String>,
+    format: &str,
+    selector: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Read;
 
@@ -621,17 +632,26 @@ fn cmd_compile(
     // Compile HTML to SOM
     let compiled = som::compiler::compile(&html, &url)?;
 
-    // Serialize to JSON
-    let json = serde_json::to_string_pretty(&compiled)?;
+    // Apply selector filter (if requested)
+    let filtered;
+    let som_to_render = if let Some(sel) = selector {
+        filtered = apply_selector(&compiled, sel);
+        &filtered
+    } else {
+        &compiled
+    };
+
+    // Render to requested format
+    let out = render_som_output(som_to_render, format)?;
 
     // Write output
     if let Some(out_path) = output {
-        std::fs::write(&out_path, &json)?;
+        std::fs::write(&out_path, &out)?;
         eprintln!("Wrote SOM to {} ({} bytes, {:.1}x compression)",
             out_path, compiled.meta.som_bytes,
             compiled.meta.html_bytes as f64 / compiled.meta.som_bytes as f64);
     } else {
-        println!("{}", json);
+        println!("{}", out);
     }
 
     Ok(())


### PR DESCRIPTION
Builds on #26 (add `apply_selector` + `render_som_output` with markdown). Can be merged after that lands.

## Summary

Brings `plasmate compile` to feature-parity with `plasmate fetch` for output control:

```
--format json|text|markdown   (default: json, same as fetch)
--selector <role|#id>         (same semantics as fetch --selector)
```

No new logic — just wires the existing `apply_selector()` and `render_som_output()` helpers (from #26) into `cmd_compile`.

## Motivation

`compile` is the offline/testing counterpart to `fetch`. Before this change, it always output JSON regardless of what the caller needed, making it awkward in pipelines:

```bash
# Save a page, inspect offline with same flags as live fetch
curl https://example.com > page.html
plasmate compile --file page.html --selector main --format markdown

# Pipe directly from a script or test fixture
echo "<html>..." | plasmate compile --selector nav --format text

# Test selector behaviour against a saved SOM snapshot
plasmate compile --file snapshot.html --selector "#toc" --format json
```

## Files changed

`src/main.rs` only (+26/-6): `Commands::Compile` struct, match arm, `cmd_compile` signature and body.