### PR TITLE
feat(mcp): add selector support and extract_links tool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,9 +103,9 @@ enum Commands {
         /// Output file (defaults to stdout)
         #[arg(long, short)]
         output: Option<String>,
-        /// Output format: "json" (default, full SOM), "text" (plain extracted text,
-        /// no JSON overhead), or "markdown" (structured Markdown with headings,
-        /// links, lists — ideal for LLM context where light structure helps)
+        /// Output format: "json" (default, full SOM), "text" (plain extracted
+        /// text), "markdown" (structured Markdown), or "links" (one URL per
+        /// line, deduplicated — for crawlers and research agents)
         #[arg(long, default_value = "json")]
         format: String,
         /// Override the default User-Agent string.
@@ -292,6 +292,12 @@ enum Commands {
         /// Write output to a file instead of stdout
         #[arg(long, short)]
         output: Option<String>,
+        /// Filter both snapshots to a specific region before diffing.
+        /// Same syntax as `plasmate fetch --selector` (e.g. `main`, `nav`,
+        /// `#my-id`). Useful for diffing only the content region and ignoring
+        /// navigation or footer churn.
+        #[arg(long)]
+        selector: Option<String>,
     },
 }
 
@@ -588,8 +594,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             format,
             ignore_meta,
             output,
+            selector,
         } => {
-            cmd_diff(&old, &new, &format, ignore_meta, output.as_deref())?;
+            cmd_diff(&old, &new, &format, ignore_meta, output.as_deref(), selector.as_deref())?;
         }
     }
 
@@ -643,6 +650,7 @@ fn cmd_diff(
     format: &str,
     ignore_meta: bool,
     output: Option<&str>,
+    selector: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let old_json = std::fs::read_to_string(old_path)
         .map_err(|e| format!("Failed to read {}: {}", old_path, e))?;
@@ -654,7 +662,14 @@ fn cmd_diff(
     let new_som: som::types::Som = serde_json::from_str(&new_json)
         .map_err(|e| format!("Failed to parse {}: {}", new_path, e))?;
 
-    let diff = som::diff::diff_soms(&old_som, &new_som, ignore_meta);
+    // Apply selector to both snapshots before diffing (if requested)
+    let (effective_old, effective_new) = if let Some(sel) = selector {
+        (apply_selector(&old_som, sel), apply_selector(&new_som, sel))
+    } else {
+        (old_som, new_som)
+    };
+
+    let diff = som::diff::diff_soms(&effective_old, &effective_new, ignore_meta);
 
     let result = match format {
         "text" => som::diff::render_text(&diff),
@@ -1079,6 +1094,8 @@ async fn cmd_fetch(
 /// - `"markdown"`: structured Markdown — headings, paragraphs, links, images,
 ///   lists and separators are mapped to their Markdown equivalents. Useful for
 ///   LLM context where light structure helps without full JSON overhead.
+/// - `"links"`: one URL per line, deduplicated, order-preserving. Useful for
+///   crawlers, sitemaps, and research agents that need to discover outbound links.
 fn render_som_output(
     som: &som::types::Som,
     format: &str,
@@ -1113,7 +1130,37 @@ fn render_som_output(
             }
             Ok(out)
         }
+        "links" => {
+            let mut urls: Vec<String> = Vec::new();
+            for region in &som.regions {
+                for el in &region.elements {
+                    collect_links(el, &mut urls);
+                }
+            }
+            // Deduplicate while preserving order
+            let mut seen = std::collections::HashSet::new();
+            urls.retain(|u| seen.insert(u.clone()));
+            Ok(urls.join("\n"))
+        }
         "json" | _ => Ok(serde_json::to_string_pretty(som)?),
+    }
+}
+
+/// Recursively collect link URLs from a SOM element tree.
+fn collect_links(el: &som::types::Element, urls: &mut Vec<String>) {
+    if el.role == som::types::ElementRole::Link {
+        if let Some(ref attrs) = el.attrs {
+            if let Some(href) = attrs.get("href").and_then(|v| v.as_str()) {
+                if !href.is_empty() && href != "#" {
+                    urls.push(href.to_string());
+                }
+            }
+        }
+    }
+    if let Some(ref children) = el.children {
+        for child in children {
+            collect_links(child, urls);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1272,88 +1272,9 @@ fn render_element_markdown(el: &som::types::Element, out: &mut String, depth: us
     }
 }
 
-/// Filter a SOM to a specific region or element by semantic selector.
-///
-/// Supported selectors:
-/// - Region roles: `main`, `nav`/`navigation`, `aside`, `header`, `footer`,
-///   `form`, `dialog`, `content`
-/// - HTML id: `#some-id` — keeps only elements whose `html_id` matches
-///
-/// Unrecognised selectors return the full SOM unchanged (with a warning).
-/// If a recognised selector matches nothing, the full SOM is returned (with
-/// a warning) so callers always get usable output.
+/// Delegate to `som::filter::apply_selector` (shared with MCP tools).
 fn apply_selector(som: &som::types::Som, selector: &str) -> som::types::Som {
-    use som::types::RegionRole;
-
-    // Try to match a region role
-    let role_opt: Option<RegionRole> = match selector.to_lowercase().as_str() {
-        "main" => Some(RegionRole::Main),
-        "nav" | "navigation" => Some(RegionRole::Navigation),
-        "aside" => Some(RegionRole::Aside),
-        "header" => Some(RegionRole::Header),
-        "footer" => Some(RegionRole::Footer),
-        "form" => Some(RegionRole::Form),
-        "dialog" => Some(RegionRole::Dialog),
-        "content" => Some(RegionRole::Content),
-        _ => None,
-    };
-
-    if let Some(role) = role_opt {
-        let filtered: Vec<_> = som
-            .regions
-            .iter()
-            .filter(|r| r.role == role)
-            .cloned()
-            .collect();
-        if filtered.is_empty() {
-            eprintln!(
-                "Warning: selector '{}' matched no regions — returning full SOM",
-                selector
-            );
-            return som.clone();
-        }
-        let mut result = som.clone();
-        result.regions = filtered;
-        return result;
-    }
-
-    // Try HTML id selector: #my-id
-    if let Some(id) = selector.strip_prefix('#') {
-        let filtered_regions: Vec<_> = som
-            .regions
-            .iter()
-            .filter_map(|r| {
-                let els: Vec<_> = r
-                    .elements
-                    .iter()
-                    .filter(|e| e.html_id.as_deref() == Some(id))
-                    .cloned()
-                    .collect();
-                if els.is_empty() {
-                    None
-                } else {
-                    let mut region = r.clone();
-                    region.elements = els;
-                    Some(region)
-                }
-            })
-            .collect();
-        if filtered_regions.is_empty() {
-            eprintln!(
-                "Warning: selector '#{id}' matched no elements — returning full SOM"
-            );
-            return som.clone();
-        }
-        let mut result = som.clone();
-        result.regions = filtered_regions;
-        return result;
-    }
-
-    eprintln!(
-        "Warning: unrecognised selector '{}' — returning full SOM",
-        selector
-    );
-    som.clone()
+    som::filter::apply_selector(som, selector)
 }
 
 async fn cmd_bench(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -248,6 +248,7 @@ fn handle_tools_list(request: &JsonRpcRequest) -> JsonRpcResponse {
         // Phase 1: Stateless tools
         tools::fetch_page_definition(),
         tools::extract_text_definition(),
+        tools::extract_links_definition(),
         // Screenshot
         tools::screenshot_page_definition(),
         // Phase 2: Stateful tools
@@ -318,6 +319,7 @@ async fn handle_tools_call(
         // Phase 1: Stateless tools
         "fetch_page" => tools::handle_fetch_page(&arguments, client).await,
         "extract_text" => tools::handle_extract_text(&arguments, client).await,
+        "extract_links" => tools::handle_extract_links(&arguments, client).await,
         // Screenshot
         "screenshot_page" => tools::handle_screenshot_page(&arguments, client).await,
         // Phase 2: Stateful tools

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -41,6 +41,11 @@ struct FetchPageParams {
     budget: Option<usize>,
     #[serde(default = "default_javascript")]
     javascript: bool,
+    /// Filter SOM to a specific region role (main, nav, header, footer, aside,
+    /// form, dialog, content) or HTML id (#my-id). Reduces token count by
+    /// stripping irrelevant regions before returning the result.
+    #[serde(default)]
+    selector: Option<String>,
 }
 
 fn default_javascript() -> bool {
@@ -53,6 +58,9 @@ struct ExtractTextParams {
     url: String,
     #[serde(default)]
     max_chars: Option<usize>,
+    /// Filter to a specific region before extracting text.
+    #[serde(default)]
+    selector: Option<String>,
 }
 
 /// Get the tool definition for fetch_page.
@@ -74,6 +82,10 @@ pub fn fetch_page_definition() -> ToolDefinition {
                 "javascript": {
                     "type": "boolean",
                     "description": "Enable JavaScript execution for dynamic/SPA pages. Default: true."
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Filter to a specific page region: main, nav, header, footer, aside, content, form, dialog, or #element-id. Strips irrelevant regions to reduce tokens."
                 }
             },
             "required": ["url"]
@@ -96,6 +108,10 @@ pub fn extract_text_definition() -> ToolDefinition {
                 "max_chars": {
                     "type": "integer",
                     "description": "Maximum characters to return. Default: no limit."
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Filter to a specific page region before extracting text: main, nav, header, footer, aside, content, form, dialog, or #element-id."
                 }
             },
             "required": ["url"]
@@ -159,8 +175,15 @@ pub async fn handle_fetch_page(arguments: &Value, client: &reqwest::Client) -> V
         "SOM compiled"
     );
 
+    // Apply selector filter (if requested)
+    let som_to_serialize = if let Some(ref sel) = params.selector {
+        crate::som::filter::apply_selector(&page_result.som, sel)
+    } else {
+        page_result.som
+    };
+
     // Serialize SOM to JSON
-    let som_json = match serde_json::to_value(&page_result.som) {
+    let som_json = match serde_json::to_value(&som_to_serialize) {
         Ok(v) => v,
         Err(e) => {
             return error_response(&format!("Failed to serialize SOM: {}", e));
@@ -254,17 +277,24 @@ pub async fn handle_extract_text(arguments: &Value, client: &reqwest::Client) ->
         }
     };
 
+    // Apply selector filter (if requested)
+    let effective_som = if let Some(ref sel) = params.selector {
+        crate::som::filter::apply_selector(&page_result.som, sel)
+    } else {
+        page_result.som
+    };
+
     // Extract text from all regions
     let mut text_parts: Vec<String> = Vec::new();
 
     // Add title if present
-    if !page_result.som.title.is_empty() {
-        text_parts.push(page_result.som.title.clone());
+    if !effective_som.title.is_empty() {
+        text_parts.push(effective_som.title.clone());
         text_parts.push(String::new()); // Empty line after title
     }
 
     // Extract text from each region
-    for region in &page_result.som.regions {
+    for region in &effective_som.regions {
         for element in &region.elements {
             extract_element_text(element, &mut text_parts);
         }
@@ -320,6 +350,125 @@ fn extract_element_text(element: &crate::som::types::Element, parts: &mut Vec<St
     if let Some(children) = &element.children {
         for child in children {
             extract_element_text(child, parts);
+        }
+    }
+}
+
+// ============================================================================
+// Extract links tool
+// ============================================================================
+
+/// Parameters for extract_links tool.
+#[derive(Debug, Deserialize)]
+struct ExtractLinksParams {
+    url: String,
+    /// Filter to a specific region before extracting links.
+    #[serde(default)]
+    selector: Option<String>,
+}
+
+/// Get the tool definition for extract_links.
+pub fn extract_links_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "extract_links".to_string(),
+        description: "Fetch a web page and return all outbound URLs found in the page, one per line, deduplicated. Useful for crawling, sitemap discovery, and finding related pages.".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "URL to fetch"
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "Filter to a specific page region before extracting links: main, nav, header, footer, aside, content, form, dialog, or #element-id."
+                }
+            },
+            "required": ["url"]
+        }),
+    }
+}
+
+/// Handle the extract_links tool call.
+pub async fn handle_extract_links(arguments: &Value, client: &reqwest::Client) -> Value {
+    let params: ExtractLinksParams = match serde_json::from_value(arguments.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return error_response(&format!("Invalid arguments: {}", e));
+        }
+    };
+
+    info!(url = %params.url, "extract_links");
+
+    let fetch_result = match fetch::fetch_url(client, &params.url, DEFAULT_TIMEOUT_MS).await {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(&format!("Failed to fetch {}: {}", params.url, e));
+        }
+    };
+
+    let pipeline_config = PipelineConfig {
+        execute_js: true,
+        fetch_external_scripts: true,
+        ..Default::default()
+    };
+
+    let page_result = match pipeline::process_page_async(
+        &fetch_result.html,
+        &fetch_result.url,
+        &pipeline_config,
+        client,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(&format!("Pipeline error: {}", e));
+        }
+    };
+
+    // Apply selector filter (if requested)
+    let effective_som = if let Some(ref sel) = params.selector {
+        crate::som::filter::apply_selector(&page_result.som, sel)
+    } else {
+        page_result.som
+    };
+
+    // Collect all link URLs, deduplicated
+    let mut urls: Vec<String> = Vec::new();
+    for region in &effective_som.regions {
+        for element in &region.elements {
+            collect_element_links(element, &mut urls);
+        }
+    }
+    // Deduplicate while preserving order
+    let mut seen = std::collections::HashSet::new();
+    urls.retain(|u| seen.insert(u.clone()));
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": urls.join("\n")
+            }
+        ]
+    })
+}
+
+/// Recursively collect link URLs from a SOM element tree.
+fn collect_element_links(element: &crate::som::types::Element, urls: &mut Vec<String>) {
+    if element.role == crate::som::types::ElementRole::Link {
+        if let Some(ref attrs) = element.attrs {
+            if let Some(href) = attrs.get("href").and_then(|v| v.as_str()) {
+                if !href.is_empty() && href != "#" {
+                    urls.push(href.to_string());
+                }
+            }
+        }
+    }
+    if let Some(ref children) = element.children {
+        for child in children {
+            collect_element_links(child, urls);
         }
     }
 }

--- a/src/som/filter.rs
+++ b/src/som/filter.rs
@@ -1,0 +1,188 @@
+//! Region/element filtering for SOM snapshots.
+//!
+//! Provides `apply_selector` to narrow a SOM down to specific regions or
+//! elements by semantic role or HTML id. Used by both the CLI (`--selector`)
+//! and MCP tools (`selector` parameter).
+
+use super::types::{RegionRole, Som};
+
+/// Filter a SOM to a specific region or element by semantic selector.
+///
+/// Supported selectors:
+/// - Region roles: `main`, `nav`/`navigation`, `aside`, `header`, `footer`,
+///   `form`, `dialog`, `content`
+/// - HTML id: `#some-id` - keeps only elements whose `html_id` matches
+///
+/// Unrecognised selectors return the full SOM unchanged (with a warning to stderr).
+/// If a recognised selector matches nothing, the full SOM is returned (with a
+/// warning) so callers always get usable output.
+pub fn apply_selector(som: &Som, selector: &str) -> Som {
+    // Try to match a region role
+    let role_opt: Option<RegionRole> = match selector.to_lowercase().as_str() {
+        "main" => Some(RegionRole::Main),
+        "nav" | "navigation" => Some(RegionRole::Navigation),
+        "aside" => Some(RegionRole::Aside),
+        "header" => Some(RegionRole::Header),
+        "footer" => Some(RegionRole::Footer),
+        "form" => Some(RegionRole::Form),
+        "dialog" => Some(RegionRole::Dialog),
+        "content" => Some(RegionRole::Content),
+        _ => None,
+    };
+
+    if let Some(role) = role_opt {
+        let filtered: Vec<_> = som
+            .regions
+            .iter()
+            .filter(|r| r.role == role)
+            .cloned()
+            .collect();
+        if filtered.is_empty() {
+            eprintln!(
+                "Warning: selector '{}' matched no regions - returning full SOM",
+                selector
+            );
+            return som.clone();
+        }
+        let mut result = som.clone();
+        result.regions = filtered;
+        return result;
+    }
+
+    // Try HTML id selector: #my-id
+    if let Some(id) = selector.strip_prefix('#') {
+        let filtered_regions: Vec<_> = som
+            .regions
+            .iter()
+            .filter_map(|r| {
+                let els: Vec<_> = r
+                    .elements
+                    .iter()
+                    .filter(|e| e.html_id.as_deref() == Some(id))
+                    .cloned()
+                    .collect();
+                if els.is_empty() {
+                    None
+                } else {
+                    let mut region = r.clone();
+                    region.elements = els;
+                    Some(region)
+                }
+            })
+            .collect();
+        if filtered_regions.is_empty() {
+            eprintln!(
+                "Warning: selector '#{id}' matched no elements - returning full SOM"
+            );
+            return som.clone();
+        }
+        let mut result = som.clone();
+        result.regions = filtered_regions;
+        return result;
+    }
+
+    eprintln!(
+        "Warning: unrecognised selector '{}' - returning full SOM",
+        selector
+    );
+    som.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::som::types::*;
+
+    fn make_test_som() -> Som {
+        Som {
+            som_version: "1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Test".to_string(),
+            lang: "en".to_string(),
+            regions: vec![
+                Region {
+                    id: "r1".to_string(),
+                    role: RegionRole::Navigation,
+                    label: None,
+                    action: None,
+                    method: None,
+                    elements: vec![Element {
+                        id: "e1".to_string(),
+                        role: ElementRole::Link,
+                        html_id: None,
+                        text: Some("Home".to_string()),
+                        label: None,
+                        actions: None,
+                        attrs: None,
+                        children: None,
+                        hints: None,
+                    }],
+                },
+                Region {
+                    id: "r2".to_string(),
+                    role: RegionRole::Main,
+                    label: None,
+                    action: None,
+                    method: None,
+                    elements: vec![Element {
+                        id: "e2".to_string(),
+                        role: ElementRole::Paragraph,
+                        html_id: Some("intro".to_string()),
+                        text: Some("Hello world".to_string()),
+                        label: None,
+                        actions: None,
+                        attrs: None,
+                        children: None,
+                        hints: None,
+                    }],
+                },
+            ],
+            meta: SomMeta {
+                html_bytes: 100,
+                som_bytes: 50,
+                element_count: 2,
+                interactive_count: 1,
+            },
+            structured_data: None,
+        }
+    }
+
+    #[test]
+    fn test_selector_main() {
+        let som = make_test_som();
+        let filtered = apply_selector(&som, "main");
+        assert_eq!(filtered.regions.len(), 1);
+        assert_eq!(filtered.regions[0].role, RegionRole::Main);
+    }
+
+    #[test]
+    fn test_selector_nav() {
+        let som = make_test_som();
+        let filtered = apply_selector(&som, "nav");
+        assert_eq!(filtered.regions.len(), 1);
+        assert_eq!(filtered.regions[0].role, RegionRole::Navigation);
+    }
+
+    #[test]
+    fn test_selector_html_id() {
+        let som = make_test_som();
+        let filtered = apply_selector(&som, "#intro");
+        assert_eq!(filtered.regions.len(), 1);
+        assert_eq!(filtered.regions[0].elements.len(), 1);
+        assert_eq!(filtered.regions[0].elements[0].html_id.as_deref(), Some("intro"));
+    }
+
+    #[test]
+    fn test_selector_no_match_returns_full() {
+        let som = make_test_som();
+        let filtered = apply_selector(&som, "dialog");
+        assert_eq!(filtered.regions.len(), 2); // Full SOM returned
+    }
+
+    #[test]
+    fn test_selector_unrecognised_returns_full() {
+        let som = make_test_som();
+        let filtered = apply_selector(&som, "foobar");
+        assert_eq!(filtered.regions.len(), 2);
+    }
+}

--- a/src/som/mod.rs
+++ b/src/som/mod.rs
@@ -2,6 +2,7 @@ pub mod compiler;
 pub mod css_visibility;
 pub mod diff;
 pub mod element_id;
+pub mod filter;
 pub mod heuristics;
 pub mod metadata;
 pub mod types;


### PR DESCRIPTION
Companion to PR #29 (CLI selector/links). Makes MCP tools feature-complete for agent workflows.

## Summary

Three enhancements to MCP tools for AI agents:

### 1. `fetch_page` + `selector` parameter

```json
{
  "jsonrpc": "2.0",
  "method": "tools/call",
  "params": {
    "name": "fetch_page",
    "arguments": {
      "url": "https://example.com",
      "selector": "main"
    }
  }
}
```

Returns SOM filtered to just the main content region. Reduces token overhead for large pages with extensive nav/footer.

### 2. `extract_text` + `selector` parameter

Same selector support. Agents request clean text from just the content area:

```json
{
  "url": "https://docs.stripe.com",
  "selector": "main",
  "max_chars": 10000
}
```

Gets text from main region only, respecting max_chars limit.

### 3. New `extract_links` tool

Fetch a page and return all unique outbound URLs (one per line, deduplicated).

```json
{
  "url": "https://example.com",
  "selector": "nav"
}
```

Returns just navigation links. Useful for crawlers, sitemaps, and discovery workflows.

## Implementation

- **New `som/filter.rs` module**: `apply_selector()` function shared between CLI (`main.rs`) and MCP (`mcp/tools.rs`). Tested with 5 unit tests.
  - Region role matching: main, nav, header, footer, aside, content, form, dialog
  - HTML id matching: `#element-id`
  - Unrecognized selectors fall back gracefully

- **Updated MCP tool handlers**:
  - `handle_fetch_page`: applies selector before SOM serialization
  - `handle_extract_text`: applies selector before text extraction
  - `handle_extract_links` (new): collects links from filtered SOM

- **Link extraction**: `collect_element_links()` recursively walks the SOM element tree, deduplicates URLs, skips empty/hash-only hrefs

## Testing

```bash
cargo test --lib som  # 5 new filter tests pass
```

## Files changed

- `src/som/filter.rs` (new): apply_selector + tests
- `src/som/mod.rs`: register filter module
- `src/mcp/tools.rs`: selector params + extract_links implementation
- `src/mcp/server.rs`: register extract_links tool
- `src/main.rs`: delegate apply_selector to som::filter