### PR TITLE
fix(python): harden JSON parsing in SDK and browser-use extractor

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -7,9 +7,47 @@ Browser Use's default DOM serialization, reducing token costs by 90%+.
 import asyncio
 import json
 import subprocess
-from typing import Optional
+from typing import Any, Optional
 
 from som_parser import parse_som, get_links, get_interactive_elements, get_text, to_markdown
+
+
+def _extract_last_json(text: str) -> Any:
+    """Extract the last complete JSON object from potentially mixed output.
+
+    Handles cases where Plasmate emits progress/log lines alongside the
+    JSON payload.  Returns None if no valid JSON object is found.
+    """
+    if not text:
+        return None
+
+    stripped = text.strip()
+
+    # Fast path: clean output
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Line scan: JSON on its own line (progress line before payload)
+    for line in reversed(stripped.splitlines()):
+        line = line.strip()
+        if line.startswith(("{", "[")):
+            try:
+                return json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+    # Brace walk: JSON embedded in a longer string
+    decoder = json.JSONDecoder()
+    for pos in reversed([i for i, ch in enumerate(stripped) if ch == "{"]):
+        try:
+            value, _ = decoder.raw_decode(stripped, pos)
+            return value
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    return None
 
 
 class PlasmateExtractor:
@@ -49,7 +87,12 @@ class PlasmateExtractor:
         )
         if result.returncode != 0:
             raise RuntimeError(f"plasmate fetch failed: {result.stderr}")
-        return json.loads(result.stdout)
+        som = _extract_last_json(result.stdout)
+        if som is None:
+            raise RuntimeError(
+                f"plasmate returned no valid JSON for {url}: {result.stdout[:200]}"
+            )
+        return som
 
     async def extract_async(self, url: str) -> dict:
         """Async version of extract."""
@@ -61,7 +104,12 @@ class PlasmateExtractor:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
         if proc.returncode != 0:
             raise RuntimeError(f"plasmate fetch failed: {stderr.decode()}")
-        return json.loads(stdout.decode())
+        som = _extract_last_json(stdout.decode())
+        if som is None:
+            raise RuntimeError(
+                f"plasmate returned no valid JSON for {url}: {stdout.decode()[:200]}"
+            )
+        return som
 
     def extract_markdown(self, url: str) -> str:
         """Fetch a URL and return SOM content as markdown.

--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -13,6 +13,58 @@ import threading
 from typing import Any, Optional
 
 
+def _extract_last_json(text: str) -> Any:
+    """Extract the last complete JSON object from text that may contain mixed output.
+
+    Three-phase approach — each phase is progressively more expensive but handles
+    messier input:
+
+    1. **Fast path** — ``json.loads`` on the stripped text directly.  Handles
+       clean output from the MCP stdio transport (the common case).
+    2. **Line scan** — try each non-empty line from the end.  Handles output
+       where a progress/info line precedes the JSON on a separate line.
+    3. **Brace walk** — scan for every ``{`` position right-to-left and call
+       ``raw_decode`` at each.  Handles JSON embedded within a longer string
+       (e.g. a log message that includes the serialised response).
+
+    Returns the parsed value (usually a ``dict``), or ``None`` if no valid JSON
+    object is found.  Malformed or absent JSON silently returns ``None`` rather
+    than raising, so callers can decide whether to fall back or surface an error.
+    """
+    if not text:
+        return None
+
+    stripped = text.strip()
+
+    # Phase 1: clean output — try the whole string first
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Phase 2: JSON on its own line (common when Plasmate emits a status line
+    # such as "Fetching …" before outputting the SOM)
+    for line in reversed(stripped.splitlines()):
+        line = line.strip()
+        if line.startswith(("{", "[")):
+            try:
+                return json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+    # Phase 3: JSON embedded inside a longer string — try raw_decode from each
+    # '{' position, rightmost first, so we return the *last* complete object
+    decoder = json.JSONDecoder()
+    for pos in reversed([i for i, ch in enumerate(stripped) if ch == "{"]):
+        try:
+            value, _ = decoder.raw_decode(stripped, pos)
+            return value
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    return None
+
+
 class Plasmate:
     """
     Synchronous Plasmate client.
@@ -140,10 +192,7 @@ class Plasmate:
         if not text:
             return None
 
-        try:
-            return json.loads(text)
-        except (json.JSONDecodeError, ValueError):
-            return text
+        return _extract_last_json(text)
 
     # ---- Stateless Tools ----
 
@@ -362,10 +411,7 @@ class AsyncPlasmate:
         if not text:
             return None
 
-        try:
-            return json.loads(text)
-        except (json.JSONDecodeError, ValueError):
-            return text
+        return _extract_last_json(text)
 
     async def fetch_page(self, url: str, *, budget: Optional[int] = None, javascript: bool = True) -> dict:
         """Fetch a page and return its Semantic Object Model."""

--- a/sdk/python/tests/test_json_extract.py
+++ b/sdk/python/tests/test_json_extract.py
@@ -1,0 +1,71 @@
+"""Tests for _extract_last_json hardened parser."""
+
+import pytest
+
+from plasmate.client import _extract_last_json
+
+
+class TestExtractLastJson:
+    """Ensure the three-phase parser handles real-world malformed output."""
+
+    def test_clean_object(self):
+        assert _extract_last_json('{"title": "Example"}') == {"title": "Example"}
+
+    def test_clean_array(self):
+        assert _extract_last_json('[1, 2, 3]') == [1, 2, 3]
+
+    def test_whitespace_padding(self):
+        assert _extract_last_json('  \n{"a": 1}\n  ') == {"a": 1}
+
+    def test_progress_line_before_json(self):
+        """Plasmate may emit a status line before the JSON payload."""
+        text = 'Fetching https://example.com...\n{"title": "Example", "url": "https://example.com"}'
+        result = _extract_last_json(text)
+        assert result == {"title": "Example", "url": "https://example.com"}
+
+    def test_multiple_progress_lines(self):
+        text = "Starting...\nConnecting...\nRendering JS...\n{\"ok\": true}"
+        assert _extract_last_json(text) == {"ok": True}
+
+    def test_json_embedded_in_log_line(self):
+        """JSON embedded within a log message (no clean line break)."""
+        text = 'INFO: result = {"status": "done", "count": 42} [finished]'
+        result = _extract_last_json(text)
+        assert result == {"status": "done", "count": 42}
+
+    def test_multiple_json_objects_returns_last(self):
+        """When multiple JSON objects exist, return the last complete one."""
+        text = '{"partial": true}\n{"final": true}'
+        result = _extract_last_json(text)
+        assert result == {"final": True}
+
+    def test_nested_braces_in_strings(self):
+        """Braces inside JSON string values must not confuse the parser."""
+        text = '{"code": "if (x) { y }", "valid": true}'
+        result = _extract_last_json(text)
+        assert result == {"code": "if (x) { y }", "valid": True}
+
+    def test_empty_string(self):
+        assert _extract_last_json("") is None
+
+    def test_none_input(self):
+        # Defensive: should not crash even if None somehow gets through
+        assert _extract_last_json(None) is None  # type: ignore[arg-type]
+
+    def test_no_json_at_all(self):
+        assert _extract_last_json("just some plain text") is None
+
+    def test_truncated_json(self):
+        """Incomplete JSON should return None, not crash."""
+        assert _extract_last_json('{"title": "Example", "url":') is None
+
+    def test_deeply_nested(self):
+        text = '{"meta": {"stats": {"html_bytes": 1000, "som_bytes": 50}}}'
+        result = _extract_last_json(text)
+        assert result["meta"]["stats"]["html_bytes"] == 1000
+
+    def test_trailing_garbage(self):
+        """JSON followed by non-JSON text."""
+        text = '{"ok": true}\nDone in 0.3s'
+        result = _extract_last_json(text)
+        assert result == {"ok": True}


### PR DESCRIPTION
Both the Python SDK (`client.py`) and the browser-use extractor (`extractor.py`) call `json.loads()` directly on Plasmate output. If the binary emits any non-JSON content alongside the payload (progress lines, log messages, warnings to stdout), the parse fails and the raw traceback bubbles up to the caller.

## The fix

A three-phase `_extract_last_json()` parser replaces bare `json.loads()` calls:

1. **Fast path** - `json.loads(text.strip())` - handles clean output (the common case, zero overhead)
2. **Line scan** - try each line from the end - handles progress/status lines before the JSON payload
3. **Brace walk** - `raw_decode` from each `{` position right-to-left - handles JSON embedded in log messages or mixed output

Malformed or absent JSON returns `None` instead of throwing, so callers can decide how to handle it.

## What changed

**`sdk/python/src/plasmate/client.py`:**
- Added `_extract_last_json()` module-level helper
- Both sync and async `_call_tool()` now use it instead of `try: json.loads(text) except: return text`

**`integrations/browser-use/plasmate_browser_use/extractor.py`:**
- Added local `_extract_last_json()` (same implementation)
- `extract()` and `extract_async()` now use it, with a clear `RuntimeError` including the first 200 chars of output when no valid JSON is found

**`sdk/python/tests/test_json_extract.py`:**
- 14 unit tests covering: clean input, progress lines before JSON, embedded JSON in log lines, multiple JSON objects (returns last), nested braces in string values, empty/None input, truncated JSON, trailing garbage

All 14 tests pass.