### PR TITLE
feat: add @plasmate/ai — Vercel AI SDK integration

### DIFF
--- a/integrations/vercel-ai/.gitignore
+++ b/integrations/vercel-ai/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.env
+.env.local
+.DS_Store

--- a/integrations/vercel-ai/LICENSE
+++ b/integrations/vercel-ai/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Plasmate Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/vercel-ai/README.md
+++ b/integrations/vercel-ai/README.md
@@ -1,0 +1,161 @@
+# @plasmate/ai
+
+**Plasmate browser tools for the [Vercel AI SDK](https://sdk.vercel.ai)**
+
+Plasmate is a headless browser MCP server that gives AI models structured access to the web via a [Set of Marks (SOM)](https://plasmate.dev/docs/som) representation. This package is a thin wrapper that connects Plasmate to the Vercel AI SDK in one function call.
+
+## Install
+
+```bash
+npm install @plasmate/ai ai
+```
+
+You also need [Plasmate](https://plasmate.dev/docs/install) installed locally:
+
+```bash
+npm install -g plasmate
+# or
+brew install plasmate-labs/tap/plasmate
+```
+
+## Quick Start
+
+```ts
+import { createPlasmateTools } from '@plasmate/ai'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+const { tools, close } = await createPlasmateTools()
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  maxSteps: 5,
+  prompt: 'Summarize the top 3 stories on news.ycombinator.com',
+})
+
+console.log(text)
+
+await close()
+```
+
+## API
+
+### `createPlasmateTools(options?)`
+
+Spawns `plasmate mcp` as a stdio MCP server and returns tools ready for use with `generateText`, `streamText`, etc.
+
+**Options:**
+
+| Option    | Type     | Default       | Description                              |
+|-----------|----------|---------------|------------------------------------------|
+| `binary`  | `string` | `'plasmate'`  | Path to the plasmate binary (if not in PATH) |
+
+**Returns:** `Promise<{ tools, close }>`
+
+- `tools` — `Record<string, CoreTool>` ready to pass directly to `generateText` / `streamText`
+- `close()` — Call this when done to terminate the MCP subprocess
+
+## Available Tools
+
+| Tool            | Description                                                      |
+|-----------------|------------------------------------------------------------------|
+| `fetch_page`    | Fetch a URL and return a structured SOM representation           |
+| `extract_text`  | Extract readable text content from the current page              |
+| `extract_links` | Extract all links from the current page                          |
+| `open_page`     | Open a URL in a headless browser session                         |
+| `click`         | Click an element identified by its SOM marker                    |
+| `type_text`     | Type text into a focused input element                           |
+| `navigate_to`   | Navigate to a URL within an existing browser session             |
+| `evaluate`      | Evaluate JavaScript in the context of the current page           |
+
+## Usage Examples
+
+### Basic web research
+
+```ts
+import { createPlasmateTools } from '@plasmate/ai'
+import { generateText } from 'ai'
+import { anthropic } from '@ai-sdk/anthropic'
+
+const { tools, close } = await createPlasmateTools()
+
+const { text } = await generateText({
+  model: anthropic('claude-3-5-sonnet-20241022'),
+  tools,
+  maxSteps: 10,
+  prompt: 'What are the latest AI news headlines on techcrunch.com?',
+})
+
+await close()
+console.log(text)
+```
+
+### Custom binary path
+
+```ts
+const { tools, close } = await createPlasmateTools({
+  binary: '/usr/local/bin/plasmate',
+})
+```
+
+### Next.js App Router route
+
+```ts
+// app/api/browse/route.ts
+import { createPlasmateTools } from '@plasmate/ai'
+import { streamText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json()
+
+  const { tools, close } = await createPlasmateTools()
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    tools,
+    maxSteps: 5,
+    prompt,
+    onFinish: async () => {
+      await close()
+    },
+  })
+
+  return result.toDataStreamResponse()
+}
+```
+
+### Error handling
+
+```ts
+import { createPlasmateTools } from '@plasmate/ai'
+
+try {
+  const { tools, close } = await createPlasmateTools()
+  // ... use tools
+  await close()
+} catch (err) {
+  // createPlasmateTools throws if plasmate binary is not found
+  // or the MCP server fails to start
+  console.error('Plasmate error:', err)
+}
+```
+
+## How It Works
+
+`createPlasmateTools` uses the Vercel AI SDK's `experimental_createMCPClient` with a stdio transport to spawn `plasmate mcp` as a child process. Plasmate speaks the [Model Context Protocol (MCP)](https://modelcontextprotocol.io) over stdin/stdout, and the AI SDK converts the MCP tool definitions into `CoreTool` objects that models can call natively.
+
+```
+generateText ──► CoreTool ──► MCP Client ──► plasmate mcp (stdio) ──► headless browser
+```
+
+## Requirements
+
+- Node.js 18+
+- `plasmate` CLI installed and in PATH (or specify via `binary` option)
+- `ai` >= 4.0.0 (peer dependency)
+
+## License
+
+MIT

--- a/integrations/vercel-ai/package.json
+++ b/integrations/vercel-ai/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@plasmate/ai",
+  "version": "0.1.0",
+  "description": "Plasmate tools for the Vercel AI SDK",
+  "keywords": [
+    "plasmate",
+    "vercel-ai-sdk",
+    "mcp",
+    "browser",
+    "web-scraping",
+    "som"
+  ],
+  "homepage": "https://github.com/plasmate-labs/plasmate/tree/master/integrations/vercel-ai#readme",
+  "bugs": {
+    "url": "https://github.com/plasmate-labs/plasmate/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/plasmate-labs/plasmate.git",
+    "directory": "integrations/vercel-ai"
+  },
+  "license": "Apache-2.0",
+  "author": "Plasmate Labs",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "@ai-sdk/mcp": ">=0.0.1",
+    "ai": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@ai-sdk/mcp": "^0.0.1",
+    "@types/node": "^20.0.0",
+    "ai": "^4.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/integrations/vercel-ai/src/index.ts
+++ b/integrations/vercel-ai/src/index.ts
@@ -1,0 +1,88 @@
+import { experimental_createMCPClient } from 'ai'
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
+
+/**
+ * Options for createPlasmateTools
+ */
+export interface CreatePlasmateToolsOptions {
+  /**
+   * Path to the plasmate binary.
+   * Defaults to 'plasmate' (resolved from PATH).
+   */
+  binary?: string
+}
+
+/**
+ * The result returned by createPlasmateTools.
+ * tools: ready-to-use tools for generateText / streamText
+ * close: call this when done to shut down the MCP subprocess
+ */
+export interface PlasmateTools {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools: Record<string, any>
+  close: () => Promise<void>
+}
+
+/**
+ * Create Plasmate browser tools for use with the Vercel AI SDK.
+ *
+ * Spawns `plasmate mcp` as a stdio MCP server and returns the tool set
+ * ready for use with `generateText`, `streamText`, etc.
+ *
+ * @example
+ * ```ts
+ * import { createPlasmateTools } from '@plasmate/ai'
+ * import { generateText } from 'ai'
+ * import { openai } from '@ai-sdk/openai'
+ *
+ * const { tools, close } = await createPlasmateTools()
+ *
+ * const { text } = await generateText({
+ *   model: openai('gpt-4o'),
+ *   tools,
+ *   maxSteps: 5,
+ *   prompt: 'Summarize the top 3 stories on news.ycombinator.com',
+ * })
+ *
+ * await close()
+ * ```
+ */
+export async function createPlasmateTools(
+  options: CreatePlasmateToolsOptions = {}
+): Promise<PlasmateTools> {
+  const binary = options.binary ?? 'plasmate'
+
+  let transport: Experimental_StdioMCPTransport
+
+  try {
+    transport = new Experimental_StdioMCPTransport({
+      command: binary,
+      args: ['mcp'],
+    })
+  } catch (err) {
+    throw new Error(
+      `Failed to create Plasmate MCP transport (binary: "${binary}").\n` +
+        `Make sure plasmate is installed: https://plasmate.dev/docs/install\n` +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+
+  let client: Awaited<ReturnType<typeof experimental_createMCPClient>>
+
+  try {
+    client = await experimental_createMCPClient({ transport })
+  } catch (err) {
+    throw new Error(
+      `Failed to start Plasmate MCP server (binary: "${binary}").\n` +
+        `Make sure plasmate is installed: https://plasmate.dev/docs/install\n` +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+
+  const tools = await client.tools()
+
+  return {
+    tools,
+    close: () => client.close(),
+  }
+}

--- a/integrations/vercel-ai/tsconfig.json
+++ b/integrations/vercel-ai/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `integrations/vercel-ai/` — a new `@plasmate/ai` package that makes Plasmate's browser tools available as first-class tools in the [Vercel AI SDK](https://sdk.vercel.ai).

## What it does

`createPlasmateTools()` spawns `plasmate mcp` as a stdio subprocess, connects via the AI SDK's `experimental_createMCPClient` + `Experimental_StdioMCPTransport`, and returns `CoreTool` objects ready for `generateText` / `streamText`.

```ts
import { createPlasmateTools } from '@plasmate/ai'
import { generateText } from 'ai'
import { openai } from '@ai-sdk/openai'

const { tools, close } = await createPlasmateTools()

const { text } = await generateText({
  model: openai('gpt-4o'),
  tools,
  maxSteps: 5,
  prompt: 'Summarize the top stories on news.ycombinator.com',
})

await close()
```

## Package details

- **Name:** `@plasmate/ai`
- **Version:** 0.1.0
- **License:** Apache-2.0
- **Peer deps:** `ai >= 4.0.0`, `@ai-sdk/mcp >= 0.0.1`
- **Build:** dual ESM + CJS via `tsup`, full TypeScript types

## Follows existing patterns

Structured like `integrations/browser-use` and `integrations/langchain` — lives under `integrations/` alongside the other framework adapters.

## Why this matters

The Vercel AI SDK is the most widely adopted TypeScript AI framework. This gives every Next.js / Node.js developer using the AI SDK a one-liner to drop Plasmate's browser capabilities into their agents — no manual MCP wiring required.