### PR TITLE
feat: add ES module support for V8 JavaScript runtime

### DIFF
--- a/src/js/extract.rs
+++ b/src/js/extract.rs
@@ -15,14 +15,19 @@ pub struct ScriptBlock {
     pub is_inline: bool,
     /// The script's position in document order.
     pub index: usize,
+    /// Whether this is an ES module (`type="module"`).
+    pub is_module: bool,
 }
 
 /// Extract all executable script blocks from HTML.
 ///
+/// Includes:
+/// - Classic scripts (no type or type="text/javascript")
+/// - ES modules (type="module")
+///
 /// Skips:
-/// - Scripts with type="module" (would need import resolution)
 /// - Scripts with type="application/json" or type="application/ld+json"
-/// - Scripts with src="" (external; would need fetch, handled separately)
+/// - Scripts with src="" (external; handled separately by script_fetch)
 /// - Empty scripts
 pub fn extract_scripts(html: &str) -> Vec<ScriptBlock> {
     let dom = parse_document(RcDom::default(), Default::default())
@@ -48,9 +53,12 @@ fn visit_scripts(node: &Handle, scripts: &mut Vec<ScriptBlock>, index: &mut usiz
                 .iter()
                 .any(|a| a.name.local.as_ref() == "src");
 
-            // Skip non-executable types
+            // Check if this is an ES module
+            let is_module = matches!(script_type.as_deref(), Some("module"));
+
+            // Skip non-executable types (but NOT modules)
             let skip = match script_type.as_deref() {
-                Some("module") => true,
+                Some("module") => false, // Include modules
                 Some("application/json") | Some("application/ld+json") => true,
                 Some("text/html") | Some("text/template") => true,
                 Some(t) if t != "text/javascript" && t != "application/javascript" && t != "" => {
@@ -71,6 +79,7 @@ fn visit_scripts(node: &Handle, scripts: &mut Vec<ScriptBlock>, index: &mut usiz
                         label: format!("inline-{}", *index),
                         is_inline: true,
                         index: *index,
+                        is_module,
                     });
                     *index += 1;
                 }
@@ -87,6 +96,7 @@ fn visit_scripts(node: &Handle, scripts: &mut Vec<ScriptBlock>, index: &mut usiz
                     label: src,
                     is_inline: false,
                     index: *index,
+                    is_module,
                 });
                 *index += 1;
             }
@@ -139,12 +149,22 @@ mod tests {
     }
 
     #[test]
-    fn test_skip_module() {
+    fn test_module_detected() {
         let html =
             r#"<html><head><script type="module">import x from './x';</script></head></html>"#;
         let scripts = extract_scripts(html);
         let inline: Vec<_> = scripts.iter().filter(|s| s.is_inline).collect();
-        assert_eq!(inline.len(), 0);
+        assert_eq!(inline.len(), 1, "Module scripts should be extracted");
+        assert!(inline[0].is_module, "Should be marked as module");
+        assert_eq!(inline[0].source, "import x from './x';");
+    }
+
+    #[test]
+    fn test_classic_script_not_module() {
+        let html = r#"<html><head><script>var x = 1;</script></head></html>"#;
+        let scripts = extract_scripts(html);
+        assert_eq!(scripts.len(), 1);
+        assert!(!scripts[0].is_module, "Classic script should not be marked as module");
     }
 
     #[test]
@@ -181,13 +201,12 @@ mod tests {
     }
 
     #[test]
-    fn test_skip_external_module() {
-        let html = r#"<html><head><script type="module" src="/app.js"></script></head></html>"#;
+    fn test_external_module_detected() {
+        let html = r#"<html><head><script type="module" src="/app.mjs"></script></head></html>"#;
         let scripts = extract_scripts(html);
-        assert_eq!(
-            scripts.len(),
-            0,
-            "External module scripts should be skipped"
-        );
+        assert_eq!(scripts.len(), 1, "External module scripts should be extracted");
+        assert!(scripts[0].is_module, "Should be marked as module");
+        assert!(!scripts[0].is_inline, "External scripts are not inline");
+        assert_eq!(scripts[0].label, "/app.mjs");
     }
 }

--- a/src/js/pipeline.rs
+++ b/src/js/pipeline.rs
@@ -236,14 +236,15 @@ pub async fn process_page_async(
                     source: s.source.clone(),
                     label: s.label.clone(),
                     index: s.index,
+                    is_module: s.is_module,
                 })
                 .collect()
         };
 
-        let exec_scripts: Vec<(String, String)> = resolved
+        let exec_scripts: Vec<(String, String, bool)> = resolved
             .iter()
             .filter(|s| !s.source.is_empty())
-            .map(|s| (s.source.clone(), s.label.clone()))
+            .map(|s| (s.source.clone(), s.label.clone(), s.is_module))
             .collect();
 
         // Always create runtime to bootstrap DOM, even if no scripts
@@ -260,7 +261,7 @@ pub async fn process_page_async(
         wire_dom_bridge(&mut runtime, html);
 
         if !exec_scripts.is_empty() {
-            // Execute page scripts
+            // Execute page scripts (classic and ES modules)
             let report = runtime.execute_page_scripts(&exec_scripts);
 
             // Pump microtasks after script execution (resolves Promise.then chains)
@@ -369,10 +370,10 @@ pub fn process_page_with_client(
         let scripts = extract::extract_scripts(html);
         extract_us = t0.elapsed().as_micros();
 
-        let inline_scripts: Vec<(String, String)> = scripts
+        let inline_scripts: Vec<(String, String, bool)> = scripts
             .iter()
             .filter(|s| s.is_inline)
-            .map(|s| (s.source.clone(), s.label.clone()))
+            .map(|s| (s.source.clone(), s.label.clone(), s.is_module))
             .collect();
 
         // Phase 2: Bootstrap DOM and execute JS
@@ -492,14 +493,15 @@ pub async fn process_page_async_with_plugins(
                     source: s.source.clone(),
                     label: s.label.clone(),
                     index: s.index,
+                    is_module: s.is_module,
                 })
                 .collect()
         };
 
-        let exec_scripts: Vec<(String, String)> = resolved
+        let exec_scripts: Vec<(String, String, bool)> = resolved
             .iter()
             .filter(|s| !s.source.is_empty())
-            .map(|s| (s.source.clone(), s.label.clone()))
+            .map(|s| (s.source.clone(), s.label.clone(), s.is_module))
             .collect();
 
         let mut runtime = JsRuntime::new(config.js_config.clone());
@@ -589,10 +591,10 @@ pub fn process_page_with_plugins(
         let scripts = extract::extract_scripts(html);
         extract_us = t0.elapsed().as_micros();
 
-        let inline_scripts: Vec<(String, String)> = scripts
+        let inline_scripts: Vec<(String, String, bool)> = scripts
             .iter()
             .filter(|s| s.is_inline)
-            .map(|s| (s.source.clone(), s.label.clone()))
+            .map(|s| (s.source.clone(), s.label.clone(), s.is_module))
             .collect();
 
         let t1 = Instant::now();

--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -3181,8 +3181,104 @@ impl JsRuntime {
         }
     }
 
+    /// Execute an ES module in the persistent page context.
+    ///
+    /// ES modules have their own scope and support `import`/`export` syntax.
+    /// Note: Import resolution is limited - imports from other URLs are not fetched.
+    pub fn execute_module(&mut self, source: &str, filename: &str) -> Result<String, JsError> {
+        let context = self
+            .context
+            .as_ref()
+            .ok_or_else(|| JsError::Runtime("No context available".into()))?;
+
+        let scope = &mut v8::HandleScope::new(&mut self.isolate);
+        let context = v8::Local::new(scope, context);
+        let scope = &mut v8::ContextScope::new(scope, context);
+
+        let source_str = v8::String::new(scope, source)
+            .ok_or_else(|| JsError::Runtime("Failed to create source string".into()))?;
+
+        let name = v8::String::new(scope, filename).unwrap();
+        // ScriptOrigin with is_module=true (8th parameter)
+        let origin = v8::ScriptOrigin::new(
+            scope,
+            name.into(),
+            0,     // line offset
+            0,     // column offset
+            false, // is_shared_cross_origin
+            0,     // script_id
+            None,  // source_map_url
+            false, // is_opaque
+            false, // is_wasm
+            true,  // is_module <-- This enables ES module parsing
+            None,  // host_defined_options
+        );
+
+        let tc = &mut v8::TryCatch::new(scope);
+
+        // Create a Source with the origin for module compilation
+        let mut source = v8::script_compiler::Source::new(source_str, Some(&origin));
+
+        // Compile as module
+        let module = match v8::script_compiler::compile_module(tc, &mut source) {
+            Some(m) => m,
+            None => {
+                let msg = tc
+                    .exception()
+                    .map(|e| e.to_rust_string_lossy(tc))
+                    .unwrap_or_else(|| "Unknown module compile error".into());
+                return Err(JsError::Compile(msg));
+            }
+        };
+
+        // Simple resolver that fails on dynamic imports (for now)
+        // In the future, this could resolve and fetch imported modules
+        fn resolve_callback<'a>(
+            context: v8::Local<'a, v8::Context>,
+            specifier: v8::Local<'a, v8::String>,
+            _import_assertions: v8::Local<'a, v8::FixedArray>,
+            _referrer: v8::Local<'a, v8::Module>,
+        ) -> Option<v8::Local<'a, v8::Module>> {
+            let scope = unsafe { &mut v8::CallbackScope::new(context) };
+            let spec = specifier.to_rust_string_lossy(scope);
+            debug!(specifier = %spec, "Module import not resolved (imports not yet supported)");
+            None
+        }
+
+        // Instantiate the module
+        if module.instantiate_module(tc, resolve_callback).is_none() {
+            let msg = tc
+                .exception()
+                .map(|e| e.to_rust_string_lossy(tc))
+                .unwrap_or_else(|| "Module instantiation failed".into());
+            return Err(JsError::Runtime(format!("Module instantiation failed: {}", msg)));
+        }
+
+        // Evaluate the module
+        match module.evaluate(tc) {
+            Some(result) => {
+                self.scripts_executed += 1;
+                // Module evaluation returns a Promise for top-level await
+                // For now, we just return the immediate result
+                let result_str = result
+                    .to_string(tc)
+                    .map(|s| s.to_rust_string_lossy(tc))
+                    .unwrap_or_default();
+                Ok(result_str)
+            }
+            None => {
+                let msg = tc
+                    .exception()
+                    .map(|e| e.to_rust_string_lossy(tc))
+                    .unwrap_or_else(|| "Module evaluation failed".into());
+                Err(JsError::Runtime(msg))
+            }
+        }
+    }
+
     /// Execute multiple script blocks in order (state accumulates).
-    pub fn execute_page_scripts(&mut self, scripts: &[(String, String)]) -> JsExecutionReport {
+    /// Handles both classic scripts and ES modules.
+    pub fn execute_page_scripts(&mut self, scripts: &[(String, String, bool)]) -> JsExecutionReport {
         let mut report = JsExecutionReport {
             total: scripts.len(),
             succeeded: 0,
@@ -3190,11 +3286,16 @@ impl JsRuntime {
             errors: Vec::new(),
         };
 
-        for (source, filename) in scripts {
+        for (source, filename, is_module) in scripts {
             if source.trim().is_empty() {
                 continue;
             }
-            match self.execute_in_context(source, filename) {
+            let result = if *is_module {
+                self.execute_module(source, filename)
+            } else {
+                self.execute_in_context(source, filename)
+            };
+            match result {
                 Ok(_) => report.succeeded += 1,
                 Err(e) => {
                     report.failed += 1;
@@ -4370,15 +4471,48 @@ mod tests {
     fn test_page_scripts_execution() {
         let mut rt = JsRuntime::new(RuntimeConfig::default());
         let scripts = vec![
-            ("var counter = 0;".to_string(), "init.js".to_string()),
-            ("counter += 10;".to_string(), "add.js".to_string()),
-            ("counter += 5;".to_string(), "add2.js".to_string()),
+            ("var counter = 0;".to_string(), "init.js".to_string(), false),
+            ("counter += 10;".to_string(), "add.js".to_string(), false),
+            ("counter += 5;".to_string(), "add2.js".to_string(), false),
         ];
         let report = rt.execute_page_scripts(&scripts);
         assert_eq!(report.succeeded, 3);
         assert_eq!(report.failed, 0);
         let val = rt.execute_in_context("counter", "check.js").unwrap();
         assert_eq!(val, "15");
+    }
+
+    #[test]
+    fn test_execute_module_basic() {
+        let mut rt = JsRuntime::new(RuntimeConfig::default());
+        // ES modules can use const/let at top level without issues
+        let result = rt.execute_module("const x = 42; x;", "test.mjs");
+        assert!(result.is_ok(), "Module should compile and run: {:?}", result);
+    }
+
+    #[test]
+    fn test_execute_module_export_syntax() {
+        let mut rt = JsRuntime::new(RuntimeConfig::default());
+        // Module with export declaration (valid ES module syntax)
+        let result = rt.execute_module("export const value = 123;", "exports.mjs");
+        assert!(result.is_ok(), "Module with exports should compile: {:?}", result);
+    }
+
+    #[test]
+    fn test_page_scripts_with_modules() {
+        let mut rt = JsRuntime::new(RuntimeConfig::default());
+        let scripts = vec![
+            // Classic script
+            ("var globalVal = 100;".to_string(), "classic.js".to_string(), false),
+            // ES module (modules have separate scope but can still run)
+            ("const moduleVal = 200;".to_string(), "module.mjs".to_string(), true),
+        ];
+        let report = rt.execute_page_scripts(&scripts);
+        assert_eq!(report.succeeded, 2, "Both classic and module should succeed");
+        assert_eq!(report.failed, 0);
+        // Classic script's var should be accessible
+        let val = rt.execute_in_context("globalVal", "check.js").unwrap();
+        assert_eq!(val, "100");
     }
 
     #[test]

--- a/src/js/script_fetch.rs
+++ b/src/js/script_fetch.rs
@@ -16,6 +16,8 @@ pub struct ResolvedScript {
     pub source: String,
     pub label: String,
     pub index: usize,
+    /// Whether this is an ES module.
+    pub is_module: bool,
 }
 
 /// Limits for external script fetching.
@@ -55,8 +57,8 @@ pub async fn resolve_scripts(
     let mut resolved = Vec::new();
     let mut fetch_count = 0;
 
-    // Collect external scripts that need fetching
-    let mut to_fetch: Vec<(usize, String)> = Vec::new();
+    // Collect external scripts that need fetching: (index, url, is_module)
+    let mut to_fetch: Vec<(usize, String, bool)> = Vec::new();
 
     for script in scripts {
         if script.is_inline {
@@ -64,6 +66,7 @@ pub async fn resolve_scripts(
                 source: script.source.clone(),
                 label: script.label.clone(),
                 index: script.index,
+                is_module: script.is_module,
             });
         } else if fetch_count < limits.max_external {
             // Resolve URL
@@ -82,24 +85,25 @@ pub async fn resolve_scripts(
                 continue;
             }
 
-            // Skip module scripts, TypeScript, etc.
+            // Skip TypeScript files (need transpilation)
             let lower = url.to_lowercase();
-            if lower.contains(".mjs") || lower.contains(".tsx") || lower.contains(".ts?") {
-                debug!(url, "Skipping non-JS script");
+            if lower.contains(".tsx") || lower.contains(".ts?") || lower.ends_with(".ts") {
+                debug!(url, "Skipping TypeScript file");
                 continue;
             }
 
-            to_fetch.push((script.index, url));
+            to_fetch.push((script.index, url, script.is_module));
             fetch_count += 1;
         }
     }
 
     // Fetch external scripts concurrently
     if !to_fetch.is_empty() {
-        let fetches = to_fetch.iter().map(|(idx, url)| {
+        let fetches = to_fetch.iter().map(|(idx, url, is_module)| {
             let client = client.clone();
             let url = url.clone();
             let idx = *idx;
+            let is_module = *is_module;
             async move {
                 let result = tokio::time::timeout(
                     Duration::from_millis(limits.timeout_ms),
@@ -113,11 +117,12 @@ pub async fn resolve_scripts(
                 match result {
                     Ok(Ok(resp)) if resp.status().is_success() => match resp.text().await {
                         Ok(text) if text.len() <= limits.max_script_bytes => {
-                            debug!(url, bytes = text.len(), "Fetched external script");
+                            debug!(url, bytes = text.len(), is_module, "Fetched external script");
                             Some(ResolvedScript {
                                 source: text,
                                 label: url,
                                 index: idx,
+                                is_module,
                             })
                         }
                         Ok(text) => {
@@ -184,12 +189,14 @@ mod tests {
                 label: "inline-0".to_string(),
                 is_inline: true,
                 index: 0,
+                is_module: false,
             },
             ScriptBlock {
                 source: "var y = 2;".to_string(),
                 label: "inline-1".to_string(),
                 is_inline: true,
                 index: 1,
+                is_module: false,
             },
         ];
 
@@ -216,18 +223,21 @@ mod tests {
                 label: "inline-0".to_string(),
                 is_inline: true,
                 index: 0,
+                is_module: false,
             },
             ScriptBlock {
                 source: String::new(),
                 label: "https://httpbin.org/html".to_string(), // Will fail but that's OK
                 is_inline: false,
                 index: 1,
+                is_module: false,
             },
             ScriptBlock {
                 source: "third();".to_string(),
                 label: "inline-2".to_string(),
                 is_inline: true,
                 index: 2,
+                is_module: false,
             },
         ];
 


### PR DESCRIPTION
## Summary
- Detect `type="module"` scripts during HTML extraction (previously skipped)
- Add `is_module` flag to `ScriptBlock` and `ResolvedScript` types
- Implement `execute_module()` using V8's module compilation API with proper `ScriptOrigin`
- Update `execute_page_scripts()` to route modules through the module compiler

## Why
Many modern sites ship ES modules (React, Vue, Vite-built apps). Without this, Plasmate's JS execution would fail to parse `import`/`export` syntax, causing silent script failures on module-heavy pages.

## Test plan
- [x] `test_execute_module_basic` - verifies basic module compilation
- [x] `test_execute_module_export_syntax` - verifies export declarations compile
- [x] `test_page_scripts_with_modules` - verifies mixed classic + module execution
- [x] `cargo test js::` - all 96 JS tests pass
- [x] `cargo test` - full suite passes

## Notes
- Import resolution currently returns `None` (dynamic imports not yet supported)
- Self-contained modules work correctly
- Classic script `var` bindings remain accessible across scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)