### PR TITLE
Fix V8 ICU initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deno_core_icudata"
+version = "0.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4dccb6147bb3f3ba0c7a48e993bfeb999d2c2e47a81badee80e2b370c8d695"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1659,7 @@ dependencies = [
  "base64",
  "brotli",
  "clap",
+ "deno_core_icudata",
  "flate2",
  "futures-util",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ clap = { version = "4", features = ["derive"] }
 
 # V8 JavaScript engine (Chrome's JS runtime, Rust bindings)
 v8 = "=139.0.0"
+# ICU 74 common data matching the ICU ABI embedded by v8 139.0.0. Keep this
+# exact pin in lockstep with the V8 compatibility contract.
+deno_core_icudata = "=0.74.0"
 
 # Wasm plugin runtime (optional — enable with `--features plugins`)
 wasmtime = { version = "36.0.7", optional = true, default-features = false, features = ["cranelift", "runtime", "std"] }

--- a/compatibility/v8.json
+++ b/compatibility/v8.json
@@ -17,6 +17,12 @@
     "crate_edition": "2024",
     "default_archive_source": "https://github.com/denoland/rusty_v8/releases"
   },
+  "icu_data": {
+    "crate": "deno_core_icudata",
+    "selected": "0.74.0",
+    "icu_major": 74,
+    "registration_api": "set_common_data_74"
+  },
   "supported_targets": [
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
@@ -57,6 +63,7 @@
   "sources": [
     "https://docs.rs/crate/v8/139.0.0",
     "https://docs.rs/crate/v8/150.2.0",
+    "https://github.com/denoland/deno_core_icudata",
     "https://github.com/denoland/rusty_v8",
     "https://chromium.googlesource.com/v8/v8.git/"
   ]

--- a/docs/v8-compatibility.md
+++ b/docs/v8-compatibility.md
@@ -35,6 +35,19 @@ curl, and a C++ toolchain; Linux also needs glib development headers, macOS need
 Xcode command-line tools, and Windows is 64-bit only. The supported archive
 matrix is macOS x86_64/aarch64, Linux x86_64/aarch64, and Windows x86_64.
 
+Every binary embeds `deno_core_icudata` `0.74.0`, the ICU 74 common-data
+package matching the ABI exposed by `v8` `139.0.0`. V8 must receive that data
+before platform initialization; starting without it can make ordinary
+`Intl.DateTimeFormat` construction terminate the process with a misleading
+fatal out-of-memory diagnostic. `PLASMATE_ICU_DATA` and `icudt74l.dat` or
+`icudtl.dat` beside the executable remain supported as operator overrides. ICU
+searches packages in registration order: a valid external package is registered
+first and the embedded package second, giving the override precedence with a
+complete fallback for missing resources. Missing, unreadable, or rejected
+external packages are skipped and their temporary allocation is reclaimed.
+Keep both exact dependency pins and the `Intl.DateTimeFormat` regression test
+in lockstep during the next V8/ICU upgrade.
+
 Run the deterministic drift check whenever Cargo or the V8 pin changes:
 
 ```bash

--- a/scripts/check-v8-compatibility.py
+++ b/scripts/check-v8-compatibility.py
@@ -26,12 +26,36 @@ def main() -> None:
         fail("binding.selected must be an exact semantic version")
     if binding.get("highest_api_compatible") != selected:
         fail("selected and highest_api_compatible differ")
+    icu_data = data.get("icu_data", {})
+    icu_crate = icu_data.get("crate")
+    icu_selected = icu_data.get("selected")
+    if icu_crate != "deno_core_icudata":
+        fail("icu_data.crate must be deno_core_icudata")
+    if not isinstance(icu_selected, str) or not re.fullmatch(
+        r"\d+\.\d+\.\d+", icu_selected
+    ):
+        fail("icu_data.selected must be an exact semantic version")
+    if icu_data.get("icu_major") != 74:
+        fail("v8 139.0.0 requires ICU 74 common data")
+    if icu_data.get("registration_api") != "set_common_data_74":
+        fail("v8 139.0.0 must use set_common_data_74")
 
     cargo = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
     expected_requirement = f"={selected}"
     requirement = re.search(r'^v8\s*=\s*"([^"]+)"', cargo, re.MULTILINE)
     if requirement is None or requirement.group(1) != expected_requirement:
         fail(f"Cargo.toml v8 must be pinned to {expected_requirement}")
+    icu_requirement = re.search(
+        rf'^{re.escape(icu_crate)}\s*=\s*"([^"]+)"', cargo, re.MULTILINE
+    )
+    expected_icu_requirement = f"={icu_selected}"
+    if (
+        icu_requirement is None
+        or icu_requirement.group(1) != expected_icu_requirement
+    ):
+        fail(
+            f"Cargo.toml {icu_crate} must be pinned to {expected_icu_requirement}"
+        )
     minimum_rust = data.get("project", {}).get("minimum_rust", "").removesuffix(".0")
     rust_version = re.search(r'^rust-version\s*=\s*"([^"]+)"', cargo, re.MULTILINE)
     if rust_version is None or rust_version.group(1) != minimum_rust:
@@ -43,6 +67,15 @@ def main() -> None:
     )
     if locked != [selected]:
         fail(f"Cargo.lock contains v8 versions {locked!r}, expected [{selected!r}]")
+    locked_icu = re.findall(
+        rf'\[\[package\]\]\nname = "{re.escape(icu_crate)}"\nversion = "([^"]+)"',
+        lock,
+    )
+    if locked_icu != [icu_selected]:
+        fail(
+            f"Cargo.lock contains {icu_crate} versions {locked_icu!r}, "
+            f"expected [{icu_selected!r}]"
+        )
 
     if not data.get("supported_targets") or not data.get("verification", {}).get("commands"):
         fail("target matrix and verification commands must be non-empty")
@@ -50,7 +83,10 @@ def main() -> None:
         fail("upgrade gap must name the blocking change")
     if data.get("upgrade_gap", {}).get("severity") != "critical":
         fail("the V8 upgrade gap must remain classified as critical")
-    print(f"v8 compatibility manifest matches Cargo metadata ({selected})")
+    print(
+        "v8 compatibility manifest matches Cargo metadata "
+        f"(v8 {selected}, ICU data {icu_selected})"
+    )
 
 
 if __name__ == "__main__":

--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -4,7 +4,7 @@
 //! Scripts share state within a page (as in a real browser).
 //! A minimal DOM shim lets common JS patterns work without a full DOM.
 
-use std::alloc::{alloc, Layout};
+use std::alloc::{alloc, dealloc, Layout};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -50,16 +50,12 @@ fn icu_data_path() -> Option<PathBuf> {
     None
 }
 
-/// Load ICU data into memory and register it with the ICU library.
-/// Must be called BEFORE `v8::V8::initialize()` so V8 uses our data
-/// instead of its built-in minimal ICU data.
-fn load_icu_data() {
-    let Some(path) = icu_data_path() else {
-        warn!("ICU data file not found; Intl APIs may misbehave. Set PLASMATE_ICU_DATA=/path/to/icudt74l.dat");
-        return;
-    };
-
-    let bytes = match std::fs::read(&path) {
+/// Load optional operator-supplied ICU data into aligned memory and register it.
+///
+/// The allocation intentionally lives for the process lifetime: ICU retains the
+/// supplied pointer after registration.
+fn load_external_icu_data(path: &std::path::Path) {
+    let bytes = match std::fs::read(path) {
         Ok(b) => b,
         Err(err) => {
             warn!(path = %path.display(), %err, "Failed to read ICU data file");
@@ -71,25 +67,52 @@ fn load_icu_data() {
     let layout = match Layout::from_size_align(bytes.len(), 16) {
         Ok(l) => l,
         Err(_) => {
-            warn!("Invalid ICU data size: {}", bytes.len());
+            warn!(path = %path.display(), bytes = bytes.len(), "Invalid ICU data size");
             return;
         }
     };
     let ptr = unsafe { alloc(layout) };
     if ptr.is_null() {
-        warn!("Out of memory allocating ICU data");
+        warn!(path = %path.display(), "Out of memory allocating ICU data");
         return;
     }
     unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len()) };
     let data = unsafe { std::slice::from_raw_parts(ptr, bytes.len()) };
 
-    // Register the data with ICU before V8 initializes.
     match v8::icu::set_common_data_74(data) {
         Ok(()) => {
-            info!(path = %path.display(), bytes = data.len(), "ICU data loaded ({} MB)", data.len() / 1_048_576)
+            info!(path = %path.display(), bytes = data.len(), "External ICU data loaded");
         }
-        Err(code) => warn!(path = %path.display(), code, "ICU data load returned error code"),
+        Err(code) => {
+            // ICU only retains the caller-owned buffer after successful
+            // registration. Reclaim rejected data instead of leaking a
+            // potentially large operator-supplied file.
+            unsafe { dealloc(ptr, layout) };
+            warn!(path = %path.display(), code, "External ICU data was rejected");
+        }
     }
+}
+
+/// Register ICU data before `v8::V8::initialize()`.
+///
+/// A version-matched data package is compiled into every Plasmate binary. An
+/// explicit `PLASMATE_ICU_DATA` file (or a legacy sidecar beside the executable)
+/// is registered first and therefore has deterministic lookup precedence. ICU
+/// searches common-data packages in registration order, so the bundled package
+/// is then registered as the complete fallback for resources absent from a
+/// valid filtered override. Missing, unreadable, or rejected external data is
+/// never registered. V8 treats some missing ICU resources as fatal
+/// out-of-memory errors.
+fn load_icu_data() {
+    if let Some(path) = icu_data_path() {
+        load_external_icu_data(&path);
+    }
+
+    let data = deno_core_icudata::ICU_DATA;
+    if let Err(code) = v8::icu::set_common_data_74(data) {
+        panic!("bundled ICU 74 data could not be registered (ICU error {code})");
+    }
+    info!(bytes = data.len(), "Bundled ICU 74 data loaded");
 }
 
 /// Initialize V8 platform (must be called once).
@@ -4791,6 +4814,18 @@ mod tests {
         let mut rt = JsRuntime::new(RuntimeConfig::default());
         let result = rt.execute_in_context("1 + 2", "test.js").unwrap();
         assert_eq!(result, "3");
+    }
+
+    #[test]
+    fn intl_date_time_format_uses_bundled_icu_data() {
+        let mut runtime = JsRuntime::new(RuntimeConfig::default());
+        let result = runtime
+            .execute_in_context(
+                "new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', year: 'numeric' }).format(new Date('2020-01-01T00:00:00Z'))",
+                "intl-date-time-format.js",
+            )
+            .unwrap();
+        assert_eq!(result, "2020");
     }
 
     #[test]

--- a/tests/v8_compatibility.rs
+++ b/tests/v8_compatibility.rs
@@ -26,6 +26,22 @@ fn v8_compatibility_manifest_cannot_drift_from_locked_build() {
         cargo["dependencies"]["v8"].as_str(),
         Some(expected_requirement.as_str())
     );
+    let icu_crate = manifest["icu_data"]["crate"]
+        .as_str()
+        .expect("ICU data crate");
+    let icu_selected = manifest["icu_data"]["selected"]
+        .as_str()
+        .expect("selected ICU data version");
+    assert_eq!(manifest["icu_data"]["icu_major"], 74);
+    assert_eq!(
+        manifest["icu_data"]["registration_api"],
+        "set_common_data_74"
+    );
+    let expected_icu_requirement = format!("={icu_selected}");
+    assert_eq!(
+        cargo["dependencies"][icu_crate].as_str(),
+        Some(expected_icu_requirement.as_str())
+    );
     let project_rust = manifest["project"]["minimum_rust"]
         .as_str()
         .expect("project MSRV")
@@ -47,6 +63,14 @@ fn v8_compatibility_manifest_cannot_drift_from_locked_build() {
         .filter_map(|package| package["version"].as_str())
         .collect();
     assert_eq!(locked, vec![selected]);
+    let locked_icu: Vec<_> = lock["package"]
+        .as_array()
+        .expect("Cargo.lock package list")
+        .iter()
+        .filter(|package| package["name"].as_str() == Some(icu_crate))
+        .filter_map(|package| package["version"].as_str())
+        .collect();
+    assert_eq!(locked_icu, vec![icu_selected]);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Exact-pin and embed ICU 74 common data matching v8 139.0.0.
- Register valid operator ICU data first, with bundled complete per-resource fallback.
- Add an Intl.DateTimeFormat regression and V8/ICU drift enforcement.
- Document the compatibility and upgrade contract.

## Why

The live P0 JS scorecard reproduced a fatal V8 abort on whitehouse.gov: DateTimePatternGeneratorCache::CreateGenerator reported an out-of-memory failure even with a 512 MiB heap. A/B testing proved the real cause was starting V8 without the matching ICU 74 common-data package.

## Impact

Plasmate no longer depends on host-installed ICU data for ordinary Intl APIs. Worker limits and process isolation are unchanged. External data remains a deterministic first-precedence override and rejected allocations are reclaimed.

## Verification

- Exact live A/B reproduction: master without ICU crashed; ICU74 and patched builds completed 1/1 with zero crashes.
- Rust 1.88 locked check.
- Strict all-target Clippy.
- Runtime suite 47/47.
- V8 compatibility 2/2.
- Independent root verification of the focused Intl regression, compatibility tests, lockfile, formatting, and MIT dependency license.