### PR TITLE
docs: remove stale MCP tool count

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ const { text } = await generateText({
 await mcp.close()
 ```
 
-This wires all 24 Plasmate tools directly into any Vercel AI SDK agent. See [Vercel AI SDK MCP docs](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#mcp-tools) for details.
+This wires the full Plasmate MCP tool set directly into any Vercel AI SDK agent. See [Vercel AI SDK MCP docs](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#mcp-tools) for details.
 
 ### LLM context
 


### PR DESCRIPTION
## Finding

The P0 completion definition requires coherent package metadata. The README accurately enumerates 26 MCP tools, but a later Vercel AI paragraph still claimed 24 even though that adapter dynamically imports the complete MCP catalog.

## Fix

Replace the redundant numeric claim with “the full Plasmate MCP tool set.” The authoritative enumerated list remains at 26, while the adapter sentence can no longer drift whenever tools are added.

## Verification

- enumerated README count matches its 26 listed tool names
- Vercel adapter confirmed to use `client.tools()` dynamically
- Rust 1.88 `release-validate` passes: 9 artifacts and 20/20 sources valid
- `git diff --check` passes

This is intentionally merged before the first countable soak date; the candidate SHA and freeze record will be restarted after protected checks pass.