### PR TITLE
P1: isolate ordinary untrusted JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Post-v0.5.1 work remains unreleased and is being brought back behind required formatting, all-feature lint, test, conformance, and smoke gates.
 - Current development includes expanded SOM action metadata, cache/session observability, proxy and cookie surfaces, iframe and Shadow DOM extraction, and broader SDK/adapter conformance.
+- Moved ordinary page JavaScript plus MCP/CDP stateful evaluation and mutation
+  into a shared process-group-supervised worker with hard wall, request, heap,
+  and output bounds. Fatal V8 exits and infinite scripts can no longer terminate
+  or hang the owning process. Page-worker failures return a typed containment
+  record while preserving a source-HTML SOM; session failures preserve the last
+  good structured state.
 - Added opt-in, bounded, memory-only `plasmate.trace.v1` session action traces plus four MCP tools for status, privacy-safe export, clearing, and exact validation-before-replay. Replay is validation-only and never executes an action in this release.
 - Added the reproducible `plasmate.agent-task-benchmark.v1` release gate. Six compiled, loopback-only scenarios exercise real supervised MCP navigation, approved actions, trace export, validation-only replay refusal, and expected/unexpected failure containment with complete outcome and step denominators, fixture/executable provenance, an independent validator, and no model judgment or public-network dependency.
 - Added bounded, static Agentic Resource Discovery v0.9 draft inspection through `plasmate ard-discover` and the read-only `ard_discover` MCP tool. The implementation checks the well-known, HTML link, and robots.txt signals; rejects unsafe or cross-origin catalog fetches; validates catalog envelopes; and labels all discovered data and trust claims as untrusted and unverified. Registry search, DNS discovery, nested crawling, endpoint fetching, invocation, and trust/signature verification are not included.
@@ -28,7 +34,7 @@
   installing Plasmate no longer pulls an upstream graph pinned to vulnerable
   `pypdf` releases.
 - Added the versioned `plasmate.crawl-policy.v1` RFC 9309 evaluator through `plasmate crawl-policy` and the read-only `crawl_policy` MCP tool. It uses a public-only, same-origin robots request; combines exact product-token groups with wildcard fallback; implements longest-rule selection, wildcard/end anchoring, percent-encoding semantics, and conservative unavailable/unreachable handling; and leaves ordinary fetch behavior unchanged.
-- Added the read-only `inspect_page` MCP tool. It returns a bounded compact SOM first and uses deterministic `never`/`auto`/`always` visual fallback. Page JavaScript is off by default; explicit opt-in retains the documented in-process V8 risk before screenshot isolation. Screenshots render only already-fetched HTML in a JavaScript-disabled, sandboxed/CSP-constrained Chrome document with restrictive file defaults, a dead network proxy, process-tree cleanup, and hard dimensions/time/image/envelope bounds. Typed visual failure never discards structure, and Plasmate does not perform vision-model interpretation.
+- Added the read-only `inspect_page` MCP tool. It returns a bounded compact SOM first and uses deterministic `never`/`auto`/`always` visual fallback. Page JavaScript is off by default; explicit opt-in uses the supervised V8 worker. Screenshots render only already-fetched HTML in a JavaScript-disabled, sandboxed/CSP-constrained Chrome document with restrictive file defaults, a dead network proxy, process-tree cleanup, and hard dimensions/time/image/envelope bounds. Typed visual failure never discards structure, and Plasmate does not perform vision-model interpretation.
 
 ## v0.5.1 (2026-04-05)
 

--- a/docs/WEBMCP.md
+++ b/docs/WEBMCP.md
@@ -23,6 +23,9 @@ the existing SOM `regions` member is unchanged.
   and duplicate removal, excess tools are omitted from the end with an explicit
   warning. The same ceiling is enforced before a catalog enters page-state
   cache storage.
+- Imperative registration metadata crosses the JavaScript process boundary as
+  bounded JSON only. V8 handles and page callbacks never leave the supervised
+  worker; a worker failure falls back to declarative discovery over source HTML.
 - Secure HTTPS top-level origins. Cross-origin iframe documents are not fetched
   or exposed, even when their iframe declares `allow="tools"`.
 - Disabling both API shapes when page code assigns `document.domain`.

--- a/docs/runtime-containment.md
+++ b/docs/runtime-containment.md
@@ -1,20 +1,82 @@
 # Runtime containment
 
-JavaScript coverage pages run in one supervised child process per URL. This is
-required because fatal V8 failures abort the process and cannot be recovered by
-Rust error handling.
+Fatal V8 failures abort the process and cannot be recovered by Rust error
+handling. Ordinary page JavaScript and one-shot stateful evaluations therefore
+run in a supervised Plasmate child rather than the CLI, MCP, daemon, AWP, CDP,
+or embedding process that owns the request.
 
-The coverage coordinator enforces these boundaries:
+## Ordinary page and session execution
 
-- `--timeout` is a hard wall timeout for each worker.
-- `--js-heap-mb` sets the V8 heap budget inside the worker.
-- `--worker-output-kb` bounds captured stdout and stderr while continuing to
-  drain both pipes.
-- `--worker-memory-mb` optionally applies a Linux address-space limit. It is
-  disabled by default because V8 reserves substantial virtual address space;
-  deployments should validate a non-zero value against their V8 build.
-- Worker process groups and descendants are terminated on timeout, completion,
-  or coordinator cancellation.
+The page pipeline resolves bounded external classic scripts and native module
+graphs before entering V8, then sends the source HTML and prepared graph to
+`__js-worker` over the versioned `plasmate.js-worker.v1` JSON protocol. This
+boundary covers:
+
+- synchronous and asynchronous public page-pipeline helpers;
+- `plasmate fetch` and daemon fetches;
+- stateless and stateful MCP page loads;
+- AWP/CDP navigation and `Page.setContent`;
+- MCP evaluate, click, type, select, scroll, toggle, and clear operations; and
+- CDP `Runtime.evaluate` and `Runtime.callFunctionOn`.
+
+The default worker has a 15-second hard wall deadline, a 16 MiB stdout bound,
+a 256 KiB stderr bound, the runtime's 64 MiB V8 heap limit, and no operating-
+system address-space limit. V8 reserves substantial virtual address space, so a
+non-zero Linux address-space ceiling must be validated against the pinned V8
+build. Requests are bounded at 32 MiB. Output pipes continue to drain after a
+bound is reached, preventing a noisy child from deadlocking its parent.
+
+Every child gets a dedicated process group. The group and any descendants are
+terminated on timeout, caller cancellation, normal completion, and coordinator
+shutdown. A child signal, non-zero exit, timeout, spawn failure, output
+violation, or protocol violation becomes a typed `JsWorkerError` with a stable
+code such as `js_worker_timeout` or `js_worker_crash`.
+
+The worker starts with an empty environment. Only `PLASMATE_ICU_DATA` and the
+explicit `PLASMATE_UNSAFE_ALLOW_PRIVATE_NETWORK` development opt-in are copied
+when present. Auth tokens, cloud credentials, proxy credentials, and unrelated
+application secrets are not ambiently exposed to page-controlled code.
+
+Page rendering does not discard all useful output when V8 fails. The parent
+compiles the original HTML to SOM and adds a typed `containment_failure` to the
+otherwise compatible `JsExecutionReport`. Imperative WebMCP capture is absent
+in that fallback, while bounded declarative discovery still runs over the
+source HTML. Stateful mutation/evaluation failures leave the session's last
+good SOM, effective HTML, and WebMCP catalog unchanged.
+
+The worker returns only serializable state: effective HTML, execution
+diagnostics, and bounded WebMCP registration metadata. Function callbacks and
+V8 handles never cross the boundary. Wasm post-parse and post-SOM plugin hooks
+remain in the parent and run on either the worker result or the source-HTML
+fallback.
+
+External classic scripts and native module graphs are still acquired in the
+parent with the caller-provided asynchronous client. Page-originated `fetch`
+and `XMLHttpRequest` retain the pre-existing restricted bridge behavior: they
+use a fresh, public-network-checked blocking client and do not inherit caller
+cookies, proxy settings, custom TLS configuration, or default headers.
+Authenticated page-side XHR through caller client state is therefore not
+supported; worker isolation does not newly remove that capability.
+
+An embedding executable that is not named `plasmate` must install a sibling
+`plasmate` binary or set `PLASMATE_JS_WORKER_EXECUTABLE` to an exact compatible
+binary. If no worker can be resolved, the typed spawn failure follows the same
+source-HTML fallback rather than executing untrusted JavaScript in-process.
+Direct `JsRuntime` construction and the explicit `PipelineConfig {
+isolate_js: false, .. }` escape hatch remain in-process and are only for an
+already-supervised worker or trusted tests.
+
+## Coverage execution
+
+Coverage retains one supervised child process per URL. The coverage child
+performs fetch, V8 execution, and SOM compilation as one unit and therefore
+disables a redundant nested JS worker. Its coordinator enforces:
+
+- `--timeout` as the hard wall timeout for each URL worker;
+- `--js-heap-mb` as the V8 heap budget inside the worker;
+- `--worker-output-kb` as bounded stdout and stderr capture;
+- `--worker-memory-mb` as an optional Linux address-space limit; and
+- process-group cleanup for completion, timeout, and cancellation.
 
 Worker timeouts, signals, and non-zero exits are recorded as per-URL failures,
 and the remaining URLs continue. Coordinator launch and worker-protocol errors
@@ -22,8 +84,3 @@ are recorded in `summary.infrastructure_failures`; the report is written before
 the CLI exits non-zero for those systemic failures. `summary.success_percent`
 uses all input URLs, while `parsed_percent` retains the historical metric that
 excludes blocked sites.
-
-This boundary currently protects the batch coverage path only. MCP, AWP, CDP,
-daemon, and ordinary `fetch` JavaScript execution still occur in their owning
-processes. Those paths should adopt the reusable `process_supervisor` primitive
-before Plasmate claims process isolation for interactive or long-lived sessions.

--- a/docs/v8-compatibility.md
+++ b/docs/v8-compatibility.md
@@ -27,6 +27,13 @@ runtime/module and supervisor containment suites pass, and its embedded-V8
 security delta is reviewed. Do not relax the exact version requirement to a
 broad major range.
 
+Public synchronous and asynchronous page pipelines plus CLI, daemon, MCP, AWP,
+and CDP paths execute V8 through the process-isolated
+`plasmate.js-worker.v1` boundary described in
+[`runtime-containment.md`](runtime-containment.md). Direct `JsRuntime`
+construction and the explicit `isolate_js: false` worker escape hatch remain
+in-process and are not an untrusted-code surface.
+
 ## Build and target assumptions
 
 Default builds download a prebuilt static archive from rusty_v8's GitHub

--- a/src/benchmark/v1.rs
+++ b/src/benchmark/v1.rs
@@ -634,6 +634,9 @@ async fn run_sample(
             let config = PipelineConfig {
                 execute_js: js_enabled,
                 fetch_external_scripts: false,
+                // JavaScript benchmark tasks already run in the supervised
+                // `__benchmark-worker` process.
+                isolate_js: false,
                 ..Default::default()
             };
             let compiled = if js_enabled {

--- a/src/cdp/session.rs
+++ b/src/cdp/session.rs
@@ -10,7 +10,8 @@ use tokio::sync::Mutex;
 
 use crate::cdp::cookies::CookieJar;
 use crate::js::pipeline::PipelineConfig;
-use crate::js::runtime::{JsRuntime, RuntimeConfig};
+use crate::js::runtime::RuntimeConfig;
+use crate::js::worker::{self, EvaluationRequest, JsWorkerOptions};
 use crate::network::fetch;
 use crate::network::intercept::{
     InterceptAction, NetworkInterceptor, ResourceType as InterceptResourceType,
@@ -588,8 +589,8 @@ impl CdpTarget {
 
     /// Evaluate JavaScript expression against the post-navigation DOM.
     ///
-    /// This creates a temporary JsRuntime, bootstraps the DOM from effective_html
-    /// (without re-executing scripts), and evaluates the expression.
+    /// This bootstraps the DOM in a supervised child (without re-executing page
+    /// scripts), so a fatal V8 error or loop cannot terminate the CDP server.
     ///
     /// Returns the result as a serde_json::Value, or an error string.
     pub fn evaluate_js(&self, expression: &str) -> Result<serde_json::Value, String> {
@@ -599,47 +600,12 @@ impl CdpTarget {
             .ok_or_else(|| "No page loaded".to_string())?;
         let url = self.current_url.as_deref().unwrap_or("about:blank");
 
-        // Create a temporary runtime for this evaluation
-        // We use spawn_blocking because V8 is !Send and we're in an async context
-        let html_clone = html.clone();
-        let url_clone = url.to_string();
-        let expression_clone = expression.to_string();
-
-        // Create the runtime and evaluate synchronously
-        // This is safe because we're creating a new isolate just for this evaluation
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false, // Don't re-execute scripts
-            ..Default::default()
-        });
-
-        // Bootstrap DOM from effective HTML (scripts won't re-execute because
-        // the DOM shim's bootstrap just parses HTML into the DOM tree)
-        runtime.bootstrap_dom(&html_clone, &url_clone);
-
         // Wrap expression to properly serialize objects/arrays
         let wrapped_expr = format!(
             "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
-            expression_clone
+            expression
         );
-
-        // Evaluate the expression
-        match runtime.eval(&wrapped_expr) {
-            Ok(result) => {
-                // Handle undefined
-                if result == "undefined" || result.is_empty() {
-                    return Ok(serde_json::Value::Null);
-                }
-                // Try to parse as JSON first (for objects/arrays)
-                if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(&result) {
-                    Ok(json_val)
-                } else {
-                    // Return as string value
-                    Ok(serde_json::Value::String(result))
-                }
-            }
-            Err(e) => Err(e.to_string()),
-        }
+        self.evaluate_in_worker(html, url, wrapped_expr)
     }
 
     /// Execute a function call against the post-navigation DOM.
@@ -656,17 +622,6 @@ impl CdpTarget {
             .as_ref()
             .ok_or_else(|| "No page loaded".to_string())?;
         let url = self.current_url.as_deref().unwrap_or("about:blank");
-
-        let html_clone = html.clone();
-        let url_clone = url.to_string();
-
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&html_clone, &url_clone);
 
         // Build the call expression: (function).call(null, arg1, arg2, ...)
         // We wrap the result in JSON.stringify to properly serialize objects/arrays
@@ -686,21 +641,43 @@ impl CdpTarget {
             )
         };
 
-        match runtime.eval(&call_expr) {
-            Ok(result) => {
-                // Handle undefined
-                if result == "undefined" || result.is_empty() {
-                    return Ok(serde_json::Value::Null);
-                }
-                // Try to parse as JSON first (for objects/arrays)
-                if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(&result) {
-                    Ok(json_val)
-                } else {
-                    // Return as string value
-                    Ok(serde_json::Value::String(result))
-                }
-            }
-            Err(e) => Err(e.to_string()),
+        self.evaluate_in_worker(html, url, call_expr)
+    }
+
+    fn evaluate_in_worker(
+        &self,
+        html: &str,
+        url: &str,
+        expression: String,
+    ) -> Result<serde_json::Value, String> {
+        let options = JsWorkerOptions {
+            timeout: std::time::Duration::from_millis(
+                self.timeout_ms.min(worker::DEFAULT_WORKER_TIMEOUT_MS),
+            ),
+            ..Default::default()
+        };
+        let response = worker::evaluate_sync(
+            EvaluationRequest {
+                protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+                html: html.to_string(),
+                url: url.to_string(),
+                expression,
+                return_effective_html: false,
+                runtime_config: RuntimeConfig {
+                    inject_dom_shim: true,
+                    execute_inline_scripts: false,
+                    ..Default::default()
+                },
+            },
+            options,
+        )
+        .map_err(|error| format!("JavaScript containment error [{}]: {error}", error.code()))?;
+        if response.result == "undefined" || response.result.is_empty() {
+            Ok(serde_json::Value::Null)
+        } else if let Ok(value) = serde_json::from_str(&response.result) {
+            Ok(value)
+        } else {
+            Ok(serde_json::Value::String(response.result))
         }
     }
 }

--- a/src/coverage/runner.rs
+++ b/src/coverage/runner.rs
@@ -1070,6 +1070,9 @@ async fn cover_single(
         execute_js: opts.execute_js,
         fetch_external_scripts: opts.fetch_external_scripts,
         timer_drain_ms: opts.timer_drain_ms,
+        // `run_worker` is already the one-URL process boundary supervised by
+        // the coverage coordinator; do not create a redundant nested worker.
+        isolate_js: false,
         ..Default::default()
     };
 

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -14,3 +14,4 @@ pub mod modules;
 pub mod pipeline;
 pub mod runtime;
 pub mod script_fetch;
+pub mod worker;

--- a/src/js/modules.rs
+++ b/src/js/modules.rs
@@ -20,7 +20,7 @@ use crate::network::security::OutboundUrlPolicy;
 pub const MODULE_DIAGNOSTICS_VERSION: &str = "plasmate.js-modules.v1";
 pub(crate) const MAX_MODULE_DIAGNOSTICS: usize = 128;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleLimits {
     pub max_modules: usize,
     pub max_depth: usize,
@@ -45,7 +45,7 @@ impl Default for ModuleLimits {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleSource {
     /// Canonical cache identity. Inline roots use a synthetic fragment so
     /// multiple elements remain distinct module records.
@@ -58,7 +58,7 @@ pub struct ModuleSource {
     pub imports: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModuleGraph {
     /// Number of module script elements encountered, including invalid roots.
     pub root_count: usize,

--- a/src/js/pipeline.rs
+++ b/src/js/pipeline.rs
@@ -14,6 +14,7 @@ use super::extract::ScriptKind;
 use super::modules;
 use super::runtime::{JsExecutionReport, JsRuntime, RuntimeConfig};
 use super::script_fetch;
+use super::worker::{self, JsWorkerOptions, PreparedPageRequest, PreparedPageResponse};
 use crate::plugin::PluginManager;
 use crate::som::compiler;
 use crate::som::types::Som;
@@ -65,6 +66,19 @@ pub struct PipelineConfig {
     pub js_config: RuntimeConfig,
     /// Max timer drain threshold in ms (execute short setTimeout callbacks).
     pub timer_drain_ms: u64,
+    /// Put V8 in a supervised child process. Public async CLI/server paths must
+    /// leave this enabled; isolated workers set it false to avoid nesting.
+    pub isolate_js: bool,
+    /// Hard wall deadline for the complete V8 child operation.
+    pub js_worker_timeout_ms: u64,
+    /// Maximum worker stdout bytes. The serialized DOM and runtime discovery
+    /// catalog must fit inside this bound.
+    pub js_worker_output_bytes: usize,
+    /// Optional Linux address-space ceiling. Zero disables it because V8
+    /// reserves substantial virtual address space.
+    pub js_worker_memory_bytes: u64,
+    /// Test/operator override for the worker executable.
+    pub js_worker_executable: Option<std::path::PathBuf>,
 }
 
 impl Default for PipelineConfig {
@@ -76,7 +90,46 @@ impl Default for PipelineConfig {
             module_limits: modules::ModuleLimits::default(),
             js_config: RuntimeConfig::default(),
             timer_drain_ms: 100,
+            isolate_js: true,
+            js_worker_timeout_ms: worker::DEFAULT_WORKER_TIMEOUT_MS,
+            js_worker_output_bytes: worker::DEFAULT_WORKER_OUTPUT_BYTES,
+            js_worker_memory_bytes: 0,
+            js_worker_executable: None,
         }
+    }
+}
+
+fn worker_options(config: &PipelineConfig) -> JsWorkerOptions {
+    JsWorkerOptions {
+        executable: config.js_worker_executable.clone(),
+        timeout: std::time::Duration::from_millis(config.js_worker_timeout_ms),
+        max_stdout_bytes: config.js_worker_output_bytes,
+        max_stderr_bytes: worker::DEFAULT_WORKER_STDERR_BYTES,
+        memory_limit_bytes: config.js_worker_memory_bytes,
+    }
+}
+
+fn containment_report(
+    classic_scripts: usize,
+    module_graph: &modules::ModuleGraph,
+    error: &worker::JsWorkerError,
+) -> JsExecutionReport {
+    let total = classic_scripts.saturating_add(module_graph.root_count);
+    let module_diagnostics = if module_graph.root_count > 0 || !module_graph.diagnostics.is_empty()
+    {
+        Some(modules::ModuleExecutionDiagnostics::from_graph(
+            module_graph,
+        ))
+    } else {
+        None
+    };
+    JsExecutionReport {
+        total,
+        succeeded: 0,
+        failed: total,
+        errors: vec![("<process-containment>".to_string(), error.to_string())],
+        module_diagnostics,
+        containment_failure: Some(error.containment_failure()),
     }
 }
 
@@ -212,6 +265,97 @@ fn serialize_post_js(runtime: &mut JsRuntime) -> Option<String> {
     None
 }
 
+/// Execute network-prepared scripts inside an already isolated worker.
+///
+/// External classic scripts and native module graphs are acquired in the
+/// parent before this boundary so network deadlines remain independently
+/// enforceable. Page-origin fetch/XHR remains available through the existing
+/// security-checked bridge in the worker.
+pub fn run_prepared_page(
+    request: PreparedPageRequest,
+) -> Result<PreparedPageResponse, PipelineError> {
+    let started = Instant::now();
+    let mut effective_html = request.html.clone();
+    let mut runtime = JsRuntime::new(request.runtime_config);
+    if request.inject_fetch_bridge {
+        runtime.inject_fetch_bridge(reqwest::Client::new());
+    }
+    runtime.bootstrap_dom(&request.html, &request.url);
+    runtime.install_webmcp_discovery();
+    wire_dom_bridge(&mut runtime, &request.html);
+    if request.install_timer_shims {
+        install_timer_shims(&mut runtime);
+    }
+
+    let mut js_report = None;
+    if !request.classic_scripts.is_empty()
+        || !request.module_graph.roots.is_empty()
+        || !request.module_graph.diagnostics.is_empty()
+    {
+        let mut report = runtime.execute_page_scripts(&request.classic_scripts);
+        let module_report = runtime.execute_module_graph(&request.module_graph);
+        report.total += module_report.roots;
+        report.succeeded += module_report.roots_evaluated;
+        report.failed += module_report.roots_failed;
+        if module_report.roots > 0 || !module_report.diagnostics.is_empty() {
+            report.module_diagnostics = Some(module_report);
+        }
+        if request.install_timer_shims {
+            drain_timer_queue(&mut runtime);
+        }
+        runtime.pump_microtasks();
+        runtime.fire_dom_content_loaded();
+        runtime.pump_microtasks();
+        if request.timer_drain_ms > 0 {
+            runtime.drain_timers(request.timer_drain_ms);
+            runtime.pump_microtasks();
+        }
+        runtime.fire_load();
+        runtime.pump_microtasks();
+        js_report = Some(report);
+        if let Some(serialized) = serialize_post_js(&mut runtime) {
+            if !serialized.is_empty() && serialized != "undefined" {
+                effective_html = serialized;
+            }
+        }
+    }
+    let runtime_capture = runtime.collect_webmcp_registrations();
+    Ok(PreparedPageResponse {
+        effective_html,
+        js_report,
+        runtime_capture,
+        execution_us: started.elapsed().as_micros().min(u64::MAX as u128) as u64,
+    })
+}
+
+async fn execute_prepared_page(
+    request: PreparedPageRequest,
+    config: &PipelineConfig,
+) -> Result<PreparedPageResponse, worker::JsWorkerError> {
+    // Unit tests exercise the V8 implementation directly. Production async
+    // paths and integration tests cross the real process boundary.
+    if !config.isolate_js || cfg!(test) {
+        return run_prepared_page(request).map_err(|error| worker::JsWorkerError::Worker {
+            code: "page_execution".to_string(),
+            message: error.to_string(),
+        });
+    }
+    worker::execute_page(request, worker_options(config)).await
+}
+
+fn execute_prepared_page_sync(
+    request: PreparedPageRequest,
+    config: &PipelineConfig,
+) -> Result<PreparedPageResponse, worker::JsWorkerError> {
+    if !config.isolate_js || cfg!(test) {
+        return run_prepared_page(request).map_err(|error| worker::JsWorkerError::Worker {
+            code: "page_execution".to_string(),
+            message: error.to_string(),
+        });
+    }
+    worker::execute_page_sync(request, worker_options(config))
+}
+
 /// Process a page through the full pipeline (async version with external script fetching).
 pub async fn process_page_async(
     html: &str,
@@ -264,77 +408,45 @@ pub async fn process_page_async(
             .map(|s| (s.source.clone(), s.label.clone()))
             .collect();
 
-        // Always create runtime to bootstrap DOM, even if no scripts
-        let mut runtime = JsRuntime::new(config.js_config.clone());
-
-        // Inject the fetch bridge for real HTTP requests from JS
-        runtime.inject_fetch_bridge(client.clone());
-
-        // Bootstrap the DOM tree from source HTML
-        runtime.bootstrap_dom(html, url);
-        runtime.install_webmcp_discovery();
-
-        // Wire the DOM bridge: parse HTML with html5ever, register tree in
-        // NodeRegistry, inject into V8 so JS mutations flow to the rcdom tree.
-        wire_dom_bridge(&mut runtime, html);
-
-        if !exec_scripts.is_empty()
-            || !module_graph.roots.is_empty()
-            || !module_graph.diagnostics.is_empty()
-        {
-            // Execute page scripts
-            let mut report = runtime.execute_page_scripts(&exec_scripts);
-            let module_report = runtime.execute_module_graph(&module_graph);
-            report.total += module_report.roots;
-            report.succeeded += module_report.roots_evaluated;
-            report.failed += module_report.roots_failed;
-            if module_report.roots > 0 || !module_report.diagnostics.is_empty() {
-                report.module_diagnostics = Some(module_report);
+        let request = PreparedPageRequest {
+            protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+            html: html.to_string(),
+            url: url.to_string(),
+            classic_scripts: exec_scripts,
+            module_graph: module_graph.clone(),
+            runtime_config: config.js_config.clone(),
+            timer_drain_ms: config.timer_drain_ms,
+            install_timer_shims: false,
+            inject_fetch_bridge: true,
+        };
+        match execute_prepared_page(request, config).await {
+            Ok(response) => {
+                js_report = response.js_report;
+                effective_html = std::borrow::Cow::Owned(response.effective_html);
+                webmcp_runtime_capture = Some(response.runtime_capture);
+                js_us = t1.elapsed().as_micros();
+                debug!(
+                    external_fetched = resolved
+                        .iter()
+                        .filter(|s| !s.label.starts_with("inline"))
+                        .count(),
+                    js_ms = js_us / 1000,
+                    "isolated JS execution complete"
+                );
             }
-
-            // Pump microtasks after script execution (resolves Promise.then chains)
-            runtime.pump_microtasks();
-
-            // Fire DOMContentLoaded after scripts execute
-            runtime.fire_dom_content_loaded();
-            runtime.pump_microtasks();
-
-            // Drain short timers
-            if config.timer_drain_ms > 0 {
-                runtime.drain_timers(config.timer_drain_ms);
-                runtime.pump_microtasks();
-            }
-
-            // Fire load event
-            runtime.fire_load();
-            runtime.pump_microtasks();
-
-            js_us = t1.elapsed().as_micros();
-
-            debug!(
-                scripts_total = report.total,
-                scripts_ok = report.succeeded,
-                scripts_err = report.failed,
-                external_fetched = resolved
-                    .iter()
-                    .filter(|s| !s.label.starts_with("inline"))
-                    .count(),
-                js_ms = js_us / 1000,
-                "JS execution complete (async)"
-            );
-
-            js_report = Some(report);
-
-            // Try to serialize from the NodeRegistry (captures rcdom mutations),
-            // falling back to V8's JS DOM serialization.
-            let serialized = serialize_post_js(&mut runtime);
-            if let Some(s) = serialized {
-                if !s.is_empty() && s != "undefined" {
-                    effective_html = std::borrow::Cow::Owned(s);
-                }
+            Err(error) => {
+                tracing::warn!(code = error.code(), %error, "isolated JS execution failed; compiling source HTML fallback");
+                js_report = Some(containment_report(
+                    resolved
+                        .iter()
+                        .filter(|script| !script.source.is_empty())
+                        .count(),
+                    &module_graph,
+                    &error,
+                ));
+                js_us = t1.elapsed().as_micros();
             }
         }
-        webmcp_runtime_capture = Some(runtime.collect_webmcp_registrations());
     }
 
     let t2 = Instant::now();
@@ -380,8 +492,9 @@ pub fn process_page(
 
 /// Process a page through the full pipeline with an optional HTTP client.
 ///
-/// When a client is provided, JS fetch() and XMLHttpRequest will make real
-/// HTTP requests. Without a client, they return stub responses.
+/// When a client is provided, the restricted JS fetch()/XMLHttpRequest bridge
+/// is enabled. The bridge intentionally does not copy caller cookies, proxy,
+/// custom TLS, or default headers. Without a client, it returns stub responses.
 pub fn process_page_with_client(
     html: &str,
     url: &str,
@@ -409,75 +522,37 @@ pub fn process_page_with_client(
             .collect();
         let module_graph = modules::inline_module_graph(&scripts, url, &config.module_limits);
 
-        // Phase 2: Bootstrap DOM and execute JS
         let t1 = Instant::now();
-        let mut runtime = JsRuntime::new(config.js_config.clone());
-
-        // Inject the fetch bridge if a client is provided
-        if let Some(c) = client {
-            runtime.inject_fetch_bridge(c.clone());
-        }
-
-        // Bootstrap the DOM tree from source HTML
-        runtime.bootstrap_dom(html, url);
-        runtime.install_webmcp_discovery();
-
-        // Wire the DOM bridge so JS mutations flow to the rcdom tree.
-        wire_dom_bridge(&mut runtime, html);
-
-        if !inline_scripts.is_empty()
-            || !module_graph.roots.is_empty()
-            || !module_graph.diagnostics.is_empty()
-        {
-            // Execute page scripts in the context with the bootstrapped DOM
-            let mut report = runtime.execute_page_scripts(&inline_scripts);
-            let module_report = runtime.execute_module_graph(&module_graph);
-            report.total += module_report.roots;
-            report.succeeded += module_report.roots_evaluated;
-            report.failed += module_report.roots_failed;
-            if module_report.roots > 0 || !module_report.diagnostics.is_empty() {
-                report.module_diagnostics = Some(module_report);
+        let request = PreparedPageRequest {
+            protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+            html: html.to_string(),
+            url: url.to_string(),
+            classic_scripts: inline_scripts,
+            module_graph: module_graph.clone(),
+            runtime_config: config.js_config.clone(),
+            timer_drain_ms: config.timer_drain_ms,
+            install_timer_shims: false,
+            inject_fetch_bridge: client.is_some(),
+        };
+        match execute_prepared_page_sync(request, config) {
+            Ok(response) => {
+                js_report = response.js_report;
+                effective_html = std::borrow::Cow::Owned(response.effective_html);
+                webmcp_runtime_capture = Some(response.runtime_capture);
             }
-
-            // Pump microtasks after script execution (resolves Promise.then chains)
-            runtime.pump_microtasks();
-
-            // Fire DOMContentLoaded after scripts execute
-            runtime.fire_dom_content_loaded();
-            runtime.pump_microtasks();
-
-            // Drain short timers (many pages use setTimeout(fn, 0) for initialization)
-            if config.timer_drain_ms > 0 {
-                runtime.drain_timers(config.timer_drain_ms);
-                runtime.pump_microtasks();
-            }
-
-            // Fire load event
-            runtime.fire_load();
-            runtime.pump_microtasks();
-
-            js_us = t1.elapsed().as_micros();
-
-            debug!(
-                scripts_total = report.total,
-                scripts_ok = report.succeeded,
-                scripts_err = report.failed,
-                js_ms = js_us / 1000,
-                "JS execution complete"
-            );
-
-            js_report = Some(report);
-
-            // Try to serialize from the NodeRegistry (captures rcdom mutations),
-            // falling back to V8's JS DOM serialization.
-            let serialized = serialize_post_js(&mut runtime);
-            if let Some(s) = serialized {
-                if !s.is_empty() && s != "undefined" {
-                    effective_html = std::borrow::Cow::Owned(s);
-                }
+            Err(error) => {
+                tracing::warn!(code = error.code(), %error, "isolated sync JS execution failed; compiling source HTML fallback");
+                js_report = Some(containment_report(
+                    scripts
+                        .iter()
+                        .filter(|script| script.is_inline && script.kind == ScriptKind::Classic)
+                        .count(),
+                    &module_graph,
+                    &error,
+                ));
             }
         }
-        webmcp_runtime_capture = Some(runtime.collect_webmcp_registrations());
+        js_us = t1.elapsed().as_micros();
     }
 
     let t2 = Instant::now();
@@ -560,49 +635,37 @@ pub async fn process_page_async_with_plugins(
             .map(|s| (s.source.clone(), s.label.clone()))
             .collect();
 
-        let mut runtime = JsRuntime::new(config.js_config.clone());
-        runtime.inject_fetch_bridge(client.clone());
-        runtime.bootstrap_dom(html, url);
-        runtime.install_webmcp_discovery();
-
-        // Wire the DOM bridge so JS mutations flow to the rcdom tree.
-        wire_dom_bridge(&mut runtime, html);
-
-        // Install timer/rAF shims so SPA frameworks can queue deferred callbacks.
-        install_timer_shims(&mut runtime);
-
-        if !exec_scripts.is_empty()
-            || !module_graph.roots.is_empty()
-            || !module_graph.diagnostics.is_empty()
-        {
-            let mut report = runtime.execute_page_scripts(&exec_scripts);
-            let module_report = runtime.execute_module_graph(&module_graph);
-            report.total += module_report.roots;
-            report.succeeded += module_report.roots_evaluated;
-            report.failed += module_report.roots_failed;
-            if module_report.roots > 0 || !module_report.diagnostics.is_empty() {
-                report.module_diagnostics = Some(module_report);
+        let request = PreparedPageRequest {
+            protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+            html: html.to_string(),
+            url: url.to_string(),
+            classic_scripts: exec_scripts,
+            module_graph: module_graph.clone(),
+            runtime_config: config.js_config.clone(),
+            timer_drain_ms: config.timer_drain_ms,
+            install_timer_shims: true,
+            inject_fetch_bridge: true,
+        };
+        match execute_prepared_page(request, config).await {
+            Ok(response) => {
+                js_report = response.js_report;
+                effective_html = std::borrow::Cow::Owned(response.effective_html);
+                webmcp_runtime_capture = Some(response.runtime_capture);
+                js_us = t1.elapsed().as_micros();
             }
-            drain_timer_queue(&mut runtime);
-            runtime.pump_microtasks();
-            runtime.fire_dom_content_loaded();
-            runtime.pump_microtasks();
-            if config.timer_drain_ms > 0 {
-                runtime.drain_timers(config.timer_drain_ms);
-                runtime.pump_microtasks();
-            }
-            runtime.fire_load();
-            runtime.pump_microtasks();
-            js_us = t1.elapsed().as_micros();
-            js_report = Some(report);
-            let serialized = serialize_post_js(&mut runtime);
-            if let Some(s) = serialized {
-                if !s.is_empty() && s != "undefined" {
-                    effective_html = std::borrow::Cow::Owned(s);
-                }
+            Err(error) => {
+                tracing::warn!(code = error.code(), %error, "isolated plugin JS execution failed; running plugins on source HTML fallback");
+                js_report = Some(containment_report(
+                    resolved
+                        .iter()
+                        .filter(|script| !script.source.is_empty())
+                        .count(),
+                    &module_graph,
+                    &error,
+                ));
+                js_us = t1.elapsed().as_micros();
             }
         }
-        webmcp_runtime_capture = Some(runtime.collect_webmcp_registrations());
     }
 
     // Plugin hook: post_parse (between JS execution and SOM compilation).
@@ -670,48 +733,36 @@ pub fn process_page_with_plugins(
         let module_graph = modules::inline_module_graph(&scripts, url, &config.module_limits);
 
         let t1 = Instant::now();
-        let mut runtime = JsRuntime::new(config.js_config.clone());
-        runtime.bootstrap_dom(html, url);
-        runtime.install_webmcp_discovery();
-
-        // Wire the DOM bridge so JS mutations flow to the rcdom tree.
-        wire_dom_bridge(&mut runtime, html);
-
-        // Install timer/rAF shims so SPA frameworks can queue deferred callbacks.
-        install_timer_shims(&mut runtime);
-
-        if !inline_scripts.is_empty()
-            || !module_graph.roots.is_empty()
-            || !module_graph.diagnostics.is_empty()
-        {
-            let mut report = runtime.execute_page_scripts(&inline_scripts);
-            let module_report = runtime.execute_module_graph(&module_graph);
-            report.total += module_report.roots;
-            report.succeeded += module_report.roots_evaluated;
-            report.failed += module_report.roots_failed;
-            if module_report.roots > 0 || !module_report.diagnostics.is_empty() {
-                report.module_diagnostics = Some(module_report);
+        let request = PreparedPageRequest {
+            protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+            html: html.to_string(),
+            url: url.to_string(),
+            classic_scripts: inline_scripts,
+            module_graph: module_graph.clone(),
+            runtime_config: config.js_config.clone(),
+            timer_drain_ms: config.timer_drain_ms,
+            install_timer_shims: true,
+            inject_fetch_bridge: false,
+        };
+        match execute_prepared_page_sync(request, config) {
+            Ok(response) => {
+                js_report = response.js_report;
+                effective_html = std::borrow::Cow::Owned(response.effective_html);
+                webmcp_runtime_capture = Some(response.runtime_capture);
             }
-            drain_timer_queue(&mut runtime);
-            runtime.pump_microtasks();
-            runtime.fire_dom_content_loaded();
-            runtime.pump_microtasks();
-            if config.timer_drain_ms > 0 {
-                runtime.drain_timers(config.timer_drain_ms);
-                runtime.pump_microtasks();
-            }
-            runtime.fire_load();
-            runtime.pump_microtasks();
-            js_us = t1.elapsed().as_micros();
-            js_report = Some(report);
-            let serialized = serialize_post_js(&mut runtime);
-            if let Some(s) = serialized {
-                if !s.is_empty() && s != "undefined" {
-                    effective_html = std::borrow::Cow::Owned(s);
-                }
+            Err(error) => {
+                tracing::warn!(code = error.code(), %error, "isolated sync plugin JS execution failed; running plugins on source HTML fallback");
+                js_report = Some(containment_report(
+                    scripts
+                        .iter()
+                        .filter(|script| script.is_inline && script.kind == ScriptKind::Classic)
+                        .count(),
+                    &module_graph,
+                    &error,
+                ));
             }
         }
-        webmcp_runtime_capture = Some(runtime.collect_webmcp_registrations());
+        js_us = t1.elapsed().as_micros();
     }
 
     let effective_html_owned = if plugins.has_hook(crate::plugin::Hook::PostParse) {

--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -128,7 +128,7 @@ pub fn init_platform() {
 }
 
 /// Configuration for a JS runtime instance.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RuntimeConfig {
     /// Max JS execution time per classic script or native module graph in
     /// milliseconds.
@@ -3342,6 +3342,7 @@ impl JsRuntime {
             failed: 0,
             errors: Vec::new(),
             module_diagnostics: None,
+            containment_failure: None,
         };
 
         for (source, filename) in scripts {
@@ -3767,11 +3768,15 @@ impl JsRuntime {
     /// Inject the fetch bridge into the V8 context.
     ///
     /// This registers a native `__plasmate_do_fetch(url, opts_json)` function
-    /// that performs real HTTP requests using reqwest. The JS fetch() and
-    /// XMLHttpRequest in the DOM shim will call this if it exists.
+    /// that performs real HTTP requests using a restricted reqwest blocking
+    /// client. The JS fetch() and XMLHttpRequest in the DOM shim will call
+    /// this if it exists.
     ///
     /// # Arguments
-    /// * `client` - The reqwest Client to use for HTTP requests
+    /// * `client` - Enables the bridge for this runtime. Its cookie store,
+    ///   proxy, custom TLS, and default headers are intentionally not copied
+    ///   into page-originated requests; this preserves the bridge's existing
+    ///   public-network security policy.
     pub fn inject_fetch_bridge(&mut self, client: reqwest::Client) {
         // Store the client in thread-local storage
         FETCH_CLIENT.with(|c| {
@@ -4449,7 +4454,9 @@ fn fetch_bridge_callback(
 
     debug!(url = %url, method = %method, "Fetch bridge performing request");
 
-    // Perform the fetch using the thread-local client.
+    // Perform the fetch when a bridge was explicitly installed. The stored
+    // client is an availability token only: do_fetch_on_thread constructs the
+    // restricted blocking transport used by the bridge.
     //
     // SAFETY: catch_unwind is mandatory here. V8 callbacks run on a C++ call
     // stack that cannot unwind through Rust panics. Any panic that escapes into
@@ -4527,7 +4534,7 @@ fn fetch_bridge_callback(
 /// result back via an `mpsc` channel and block the V8 callback thread on
 /// `recv_timeout`.
 fn perform_blocking_fetch(
-    _client: &reqwest::Client,
+    _bridge_token: &reqwest::Client,
     url: &str,
     method: &str,
     body: Option<&str>,
@@ -4762,6 +4769,11 @@ pub struct JsExecutionReport {
     /// preserving the legacy serialized shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module_diagnostics: Option<ModuleExecutionDiagnostics>,
+    /// A process-containment failure. When present, page JavaScript did not
+    /// complete, but the caller may still return a SOM compiled from the
+    /// original HTML instead of discarding all structured output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub containment_failure: Option<crate::js::worker::JsContainmentFailure>,
 }
 
 /// Heap memory statistics.

--- a/src/js/worker.rs
+++ b/src/js/worker.rs
@@ -1,0 +1,527 @@
+//! Process-isolated JavaScript execution protocol.
+//!
+//! V8 can terminate its host process on fatal errors and ordinary classic
+//! scripts can run forever. Public CLI/server paths therefore send prepared
+//! page work or one-shot stateful evaluations to a supervised Plasmate child.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::modules::ModuleGraph;
+use super::runtime::{JsExecutionReport, JsRuntime, RuntimeConfig};
+use crate::process_supervisor::{
+    self, ProcessOutcome, ProcessOutput, ProcessSpec, SupervisorError,
+};
+
+pub const WORKER_PROTOCOL_VERSION: &str = "plasmate.js-worker.v1";
+pub const DEFAULT_WORKER_TIMEOUT_MS: u64 = 15_000;
+pub const DEFAULT_WORKER_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+pub const DEFAULT_WORKER_STDERR_BYTES: usize = 256 * 1024;
+pub const MAX_WORKER_INPUT_BYTES: usize = 32 * 1024 * 1024;
+
+fn protocol_version() -> String {
+    WORKER_PROTOCOL_VERSION.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreparedPageRequest {
+    #[serde(default = "protocol_version")]
+    pub protocol_version: String,
+    pub html: String,
+    pub url: String,
+    pub classic_scripts: Vec<(String, String)>,
+    pub module_graph: ModuleGraph,
+    pub runtime_config: RuntimeConfig,
+    pub timer_drain_ms: u64,
+    pub install_timer_shims: bool,
+    pub inject_fetch_bridge: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreparedPageResponse {
+    pub effective_html: String,
+    pub js_report: Option<JsExecutionReport>,
+    pub runtime_capture: crate::webmcp::RuntimeCapture,
+    pub execution_us: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationRequest {
+    #[serde(default = "protocol_version")]
+    pub protocol_version: String,
+    pub html: String,
+    pub url: String,
+    /// The complete expression to evaluate. Callers remain responsible for
+    /// any JSON-result wrapper required by their protocol.
+    pub expression: String,
+    pub return_effective_html: bool,
+    pub runtime_config: RuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationResponse {
+    pub result: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_html: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum JsWorkerRequest {
+    Page(PreparedPageRequest),
+    Evaluate(EvaluationRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum JsWorkerResponse {
+    Page { value: PreparedPageResponse },
+    Evaluation { value: EvaluationResponse },
+    Error { code: String, message: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct JsWorkerOptions {
+    pub executable: Option<PathBuf>,
+    pub timeout: Duration,
+    pub max_stdout_bytes: usize,
+    pub max_stderr_bytes: usize,
+    pub memory_limit_bytes: u64,
+}
+
+impl Default for JsWorkerOptions {
+    fn default() -> Self {
+        Self {
+            executable: None,
+            timeout: Duration::from_millis(DEFAULT_WORKER_TIMEOUT_MS),
+            max_stdout_bytes: DEFAULT_WORKER_OUTPUT_BYTES,
+            max_stderr_bytes: DEFAULT_WORKER_STDERR_BYTES,
+            memory_limit_bytes: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JsContainmentFailureKind {
+    Spawn,
+    Timeout,
+    Crash,
+    Exit,
+    OutputLimit,
+    Protocol,
+    WorkerError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsContainmentFailure {
+    pub kind: JsContainmentFailureKind,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JsWorkerError {
+    #[error("could not resolve the Plasmate worker executable: {0}")]
+    Executable(String),
+    #[error("could not encode the JavaScript worker request: {0}")]
+    Encode(String),
+    #[error("JavaScript worker request exceeded {limit} bytes ({actual} bytes)")]
+    InputLimit { limit: usize, actual: usize },
+    #[error("JavaScript worker supervision failed: {0}")]
+    Supervisor(#[from] SupervisorError),
+    #[error("JavaScript worker exceeded its {timeout_ms}ms wall deadline")]
+    Timeout { timeout_ms: u64 },
+    #[error("JavaScript worker was terminated by signal {signal}{diagnostic}")]
+    Crashed { signal: i32, diagnostic: String },
+    #[error("JavaScript worker exited with code {code}{diagnostic}")]
+    Exit { code: i32, diagnostic: String },
+    #[error("JavaScript worker output exceeded its configured bound")]
+    OutputLimit,
+    #[error("JavaScript worker returned invalid protocol output: {0}")]
+    Protocol(String),
+    #[error("JavaScript worker rejected the request ({code}): {message}")]
+    Worker { code: String, message: String },
+}
+
+impl JsWorkerError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Executable(_) | Self::Supervisor(_) => "js_worker_spawn",
+            Self::Encode(_) | Self::InputLimit { .. } => "js_worker_request",
+            Self::Timeout { .. } => "js_worker_timeout",
+            Self::Crashed { .. } => "js_worker_crash",
+            Self::Exit { .. } => "js_worker_exit",
+            Self::OutputLimit => "js_worker_output_limit",
+            Self::Protocol(_) => "js_worker_protocol",
+            Self::Worker { .. } => "js_worker_error",
+        }
+    }
+
+    pub fn containment_failure(&self) -> JsContainmentFailure {
+        let kind = match self {
+            Self::Executable(_) | Self::Supervisor(_) => JsContainmentFailureKind::Spawn,
+            Self::Timeout { .. } => JsContainmentFailureKind::Timeout,
+            Self::Crashed { .. } => JsContainmentFailureKind::Crash,
+            Self::Exit { .. } => JsContainmentFailureKind::Exit,
+            Self::OutputLimit => JsContainmentFailureKind::OutputLimit,
+            Self::Encode(_) | Self::InputLimit { .. } | Self::Protocol(_) => {
+                JsContainmentFailureKind::Protocol
+            }
+            Self::Worker { .. } => JsContainmentFailureKind::WorkerError,
+        };
+        JsContainmentFailure {
+            kind,
+            code: self.code().to_string(),
+            message: self.to_string(),
+        }
+    }
+}
+
+fn diagnostic(stderr: &[u8], truncated: bool) -> String {
+    let mut text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.len() > 2048 {
+        let mut end = 2048;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+        text.push('…');
+    }
+    if truncated {
+        text.push_str(" [stderr truncated]");
+    }
+    if text.is_empty() {
+        String::new()
+    } else {
+        format!(": {text}")
+    }
+}
+
+fn resolve_executable(options: &JsWorkerOptions) -> Result<PathBuf, JsWorkerError> {
+    if let Some(path) = &options.executable {
+        return Ok(path.clone());
+    }
+    if let Some(path) = std::env::var_os("PLASMATE_JS_WORKER_EXECUTABLE") {
+        return Ok(PathBuf::from(path));
+    }
+    let current =
+        std::env::current_exe().map_err(|error| JsWorkerError::Executable(error.to_string()))?;
+    let executable_name = if cfg!(windows) {
+        "plasmate.exe"
+    } else {
+        "plasmate"
+    };
+    if current
+        .file_name()
+        .is_some_and(|name| name == executable_name)
+    {
+        return Ok(current);
+    }
+    if let Some(parent) = current.parent() {
+        let sibling = parent.join(executable_name);
+        if sibling.is_file() {
+            return Ok(sibling);
+        }
+        // Cargo integration-test executables live in target/*/deps while the
+        // Plasmate binary is one directory above.
+        if parent.file_name().is_some_and(|name| name == "deps") {
+            if let Some(profile) = parent.parent() {
+                let sibling = profile.join(executable_name);
+                if sibling.is_file() {
+                    return Ok(sibling);
+                }
+            }
+        }
+    }
+    Err(JsWorkerError::Executable(format!(
+        "{} is not a Plasmate binary and no sibling worker was found; set PLASMATE_JS_WORKER_EXECUTABLE",
+        current.display()
+    )))
+}
+
+fn process_spec(
+    request: &JsWorkerRequest,
+    options: &JsWorkerOptions,
+) -> Result<ProcessSpec, JsWorkerError> {
+    let stdin =
+        serde_json::to_vec(request).map_err(|error| JsWorkerError::Encode(error.to_string()))?;
+    if stdin.len() > MAX_WORKER_INPUT_BYTES {
+        return Err(JsWorkerError::InputLimit {
+            limit: MAX_WORKER_INPUT_BYTES,
+            actual: stdin.len(),
+        });
+    }
+    Ok(ProcessSpec {
+        program: resolve_executable(options)?,
+        args: vec![OsString::from("__js-worker")],
+        env: worker_environment(),
+        stdin,
+        timeout: options.timeout,
+        max_stdout_bytes: options.max_stdout_bytes,
+        max_stderr_bytes: options.max_stderr_bytes,
+        memory_limit_bytes: options.memory_limit_bytes,
+    })
+}
+
+fn worker_environment() -> Vec<(OsString, OsString)> {
+    [
+        "PLASMATE_ICU_DATA",
+        crate::network::security::UNSAFE_PRIVATE_NETWORK_ENV,
+    ]
+    .into_iter()
+    .filter_map(|name| std::env::var_os(name).map(|value| (OsString::from(name), value)))
+    .collect()
+}
+
+fn classify_output(
+    output: ProcessOutput,
+    timeout: Duration,
+) -> Result<JsWorkerResponse, JsWorkerError> {
+    let detail = diagnostic(&output.stderr, output.stderr_truncated);
+    match output.outcome {
+        ProcessOutcome::TimedOut => {
+            return Err(JsWorkerError::Timeout {
+                timeout_ms: timeout.as_millis().min(u64::MAX as u128) as u64,
+            })
+        }
+        ProcessOutcome::Signaled { signal } => {
+            return Err(JsWorkerError::Crashed {
+                signal,
+                diagnostic: detail,
+            })
+        }
+        ProcessOutcome::Exited { code } if code != 0 => {
+            return Err(JsWorkerError::Exit {
+                code,
+                diagnostic: detail,
+            })
+        }
+        ProcessOutcome::Exited { .. } => {}
+    }
+    if output.stdout_truncated {
+        return Err(JsWorkerError::OutputLimit);
+    }
+    serde_json::from_slice(&output.stdout).map_err(|error| {
+        JsWorkerError::Protocol(format!(
+            "{error}{}",
+            if detail.is_empty() {
+                String::new()
+            } else {
+                detail
+            }
+        ))
+    })
+}
+
+async fn exchange(
+    request: JsWorkerRequest,
+    options: JsWorkerOptions,
+) -> Result<JsWorkerResponse, JsWorkerError> {
+    let spec = process_spec(&request, &options)?;
+    let output = process_supervisor::supervise_clean_env(spec).await?;
+    classify_output(output, options.timeout)
+}
+
+fn exchange_sync(
+    request: JsWorkerRequest,
+    options: JsWorkerOptions,
+) -> Result<JsWorkerResponse, JsWorkerError> {
+    let spec = process_spec(&request, &options)?;
+    let output = process_supervisor::supervise_sync_clean_env(spec)?;
+    classify_output(output, options.timeout)
+}
+
+pub async fn execute_page(
+    request: PreparedPageRequest,
+    options: JsWorkerOptions,
+) -> Result<PreparedPageResponse, JsWorkerError> {
+    match exchange(JsWorkerRequest::Page(request), options).await? {
+        JsWorkerResponse::Page { value } => Ok(value),
+        JsWorkerResponse::Error { code, message } => Err(JsWorkerError::Worker { code, message }),
+        JsWorkerResponse::Evaluation { .. } => Err(JsWorkerError::Protocol(
+            "received evaluation response for page request".to_string(),
+        )),
+    }
+}
+
+pub fn execute_page_sync(
+    request: PreparedPageRequest,
+    options: JsWorkerOptions,
+) -> Result<PreparedPageResponse, JsWorkerError> {
+    match exchange_sync(JsWorkerRequest::Page(request), options)? {
+        JsWorkerResponse::Page { value } => Ok(value),
+        JsWorkerResponse::Error { code, message } => Err(JsWorkerError::Worker { code, message }),
+        JsWorkerResponse::Evaluation { .. } => Err(JsWorkerError::Protocol(
+            "received evaluation response for page request".to_string(),
+        )),
+    }
+}
+
+pub async fn evaluate(
+    request: EvaluationRequest,
+    options: JsWorkerOptions,
+) -> Result<EvaluationResponse, JsWorkerError> {
+    decode_evaluation(exchange(JsWorkerRequest::Evaluate(request), options).await?)
+}
+
+pub fn evaluate_sync(
+    request: EvaluationRequest,
+    options: JsWorkerOptions,
+) -> Result<EvaluationResponse, JsWorkerError> {
+    decode_evaluation(exchange_sync(JsWorkerRequest::Evaluate(request), options)?)
+}
+
+fn decode_evaluation(response: JsWorkerResponse) -> Result<EvaluationResponse, JsWorkerError> {
+    match response {
+        JsWorkerResponse::Evaluation { value } => Ok(value),
+        JsWorkerResponse::Error { code, message } => Err(JsWorkerError::Worker { code, message }),
+        JsWorkerResponse::Page { .. } => Err(JsWorkerError::Protocol(
+            "received page response for evaluation request".to_string(),
+        )),
+    }
+}
+
+/// Run one already-isolated request. The binary entry point is responsible for
+/// reading/writing the single JSON envelope and for never writing protocol data
+/// to stderr.
+pub fn run_worker_request(request: JsWorkerRequest) -> JsWorkerResponse {
+    let request_version = match &request {
+        JsWorkerRequest::Page(request) => &request.protocol_version,
+        JsWorkerRequest::Evaluate(request) => &request.protocol_version,
+    };
+    if request_version != WORKER_PROTOCOL_VERSION {
+        return JsWorkerResponse::Error {
+            code: "unsupported_protocol".to_string(),
+            message: format!(
+                "unsupported JavaScript worker protocol {request_version:?}; expected {WORKER_PROTOCOL_VERSION}"
+            ),
+        };
+    }
+    match request {
+        JsWorkerRequest::Page(request) => match super::pipeline::run_prepared_page(request) {
+            Ok(value) => JsWorkerResponse::Page { value },
+            Err(error) => JsWorkerResponse::Error {
+                code: "page_execution".to_string(),
+                message: error.to_string(),
+            },
+        },
+        JsWorkerRequest::Evaluate(request) => run_evaluation(request),
+    }
+}
+
+fn run_evaluation(request: EvaluationRequest) -> JsWorkerResponse {
+    let mut runtime = JsRuntime::new(request.runtime_config);
+    runtime.bootstrap_dom(&request.html, &request.url);
+    let result = match runtime.eval(&request.expression) {
+        Ok(result) => result,
+        Err(error) => {
+            return JsWorkerResponse::Error {
+                code: "javascript_error".to_string(),
+                message: error.to_string(),
+            }
+        }
+    };
+    let effective_html = if request.return_effective_html {
+        match runtime.serialize_dom() {
+            Ok(html) => Some(html),
+            Err(error) => {
+                return JsWorkerResponse::Error {
+                    code: "dom_serialization".to_string(),
+                    message: error.to_string(),
+                }
+            }
+        }
+    } else {
+        None
+    };
+    JsWorkerResponse::Evaluation {
+        value: EvaluationResponse {
+            result,
+            effective_html,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn output(outcome: ProcessOutcome, stdout: &[u8], truncated: bool) -> ProcessOutput {
+        ProcessOutput {
+            outcome,
+            stdout: stdout.to_vec(),
+            stderr: Vec::new(),
+            stdout_truncated: truncated,
+            stderr_truncated: false,
+        }
+    }
+
+    #[test]
+    fn worker_outcomes_are_typed() {
+        assert!(matches!(
+            classify_output(
+                output(ProcessOutcome::TimedOut, b"", false),
+                Duration::from_millis(25)
+            ),
+            Err(JsWorkerError::Timeout { timeout_ms: 25 })
+        ));
+        assert!(matches!(
+            classify_output(
+                output(ProcessOutcome::Signaled { signal: 6 }, b"", false),
+                Duration::from_secs(1)
+            ),
+            Err(JsWorkerError::Crashed { signal: 6, .. })
+        ));
+        assert!(matches!(
+            classify_output(
+                output(ProcessOutcome::Exited { code: 9 }, b"", false),
+                Duration::from_secs(1)
+            ),
+            Err(JsWorkerError::Exit { code: 9, .. })
+        ));
+        assert!(matches!(
+            classify_output(
+                output(ProcessOutcome::Exited { code: 0 }, b"{}", true),
+                Duration::from_secs(1)
+            ),
+            Err(JsWorkerError::OutputLimit)
+        ));
+    }
+
+    #[test]
+    fn normal_evaluation_preserves_dom_when_requested() {
+        let response = run_evaluation(EvaluationRequest {
+            protocol_version: WORKER_PROTOCOL_VERSION.to_string(),
+            html: "<html><body><p id='x'>before</p></body></html>".to_string(),
+            url: "https://example.com/".to_string(),
+            expression: "document.getElementById('x').textContent = 'after'; 'ok'".to_string(),
+            return_effective_html: true,
+            runtime_config: RuntimeConfig::default(),
+        });
+        let JsWorkerResponse::Evaluation { value } = response else {
+            panic!("expected successful evaluation")
+        };
+        assert_eq!(value.result, "ok");
+        assert!(value.effective_html.unwrap().contains("after"));
+    }
+
+    #[test]
+    fn unsupported_protocol_is_rejected_before_execution() {
+        let response = run_worker_request(JsWorkerRequest::Evaluate(EvaluationRequest {
+            protocol_version: "plasmate.js-worker.v0".to_string(),
+            html: "<p>safe</p>".to_string(),
+            url: "https://example.com/".to_string(),
+            expression: "while (true) {}".to_string(),
+            return_effective_html: false,
+            runtime_config: RuntimeConfig::default(),
+        }));
+        assert!(matches!(
+            response,
+            JsWorkerResponse::Error { code, .. } if code == "unsupported_protocol"
+        ));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,9 @@ enum Commands {
     /// Internal single-page coverage worker. Input/output are JSON over stdio.
     #[command(name = "__coverage-worker", hide = true)]
     CoverageWorker,
+    /// Internal process-isolated JavaScript worker. JSON protocol over stdio.
+    #[command(name = "__js-worker", hide = true)]
+    JsWorker,
     /// Throughput benchmark: fetch+compile N pages from a local server.
     /// Matches Lightpanda's benchmark methodology (local server, no external latency).
     ThroughputBench {
@@ -838,6 +841,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let request: coverage::runner::CoverageWorkerRequest = serde_json::from_slice(&input)?;
             let result = coverage::runner::run_worker(request).await;
             println!("{}", serde_json::to_string(&result)?);
+        }
+        Commands::JsWorker => {
+            use std::io::Read;
+            let mut input = Vec::new();
+            std::io::stdin()
+                .take((plasmate::js::worker::MAX_WORKER_INPUT_BYTES as u64).saturating_add(1))
+                .read_to_end(&mut input)?;
+            let response = if input.len() > plasmate::js::worker::MAX_WORKER_INPUT_BYTES {
+                plasmate::js::worker::JsWorkerResponse::Error {
+                    code: "request_too_large".to_string(),
+                    message: "JavaScript worker request exceeded its input bound".to_string(),
+                }
+            } else {
+                match serde_json::from_slice::<plasmate::js::worker::JsWorkerRequest>(&input) {
+                    Ok(request) => plasmate::js::worker::run_worker_request(request),
+                    Err(error) => plasmate::js::worker::JsWorkerResponse::Error {
+                        code: "invalid_request".to_string(),
+                        message: error.to_string(),
+                    },
+                }
+            };
+            println!("{}", serde_json::to_string(&response)?);
         }
         Commands::ThroughputBench {
             base_url,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -21,7 +21,8 @@ use super::trace::ReplayRequest;
 use crate::cache::store::{CacheLookup, SomCache};
 use crate::cdp::cookies::{cookie_from_cdp_params, Cookie};
 use crate::js::pipeline::{self, PipelineConfig};
-use crate::js::runtime::{JsRuntime, RuntimeConfig};
+use crate::js::runtime::RuntimeConfig;
+use crate::js::worker::{self, EvaluationRequest, EvaluationResponse, JsWorkerOptions};
 use crate::network::fetch;
 use crate::som::types::Som;
 
@@ -254,6 +255,41 @@ fn store_page_state_in_session(
     session.target.rebuild_node_map();
 
     serde_json::to_value(&page_result.som).ok()
+}
+
+async fn run_session_javascript(
+    effective_html: String,
+    url: String,
+    expression: String,
+    return_effective_html: bool,
+) -> Result<EvaluationResponse, String> {
+    worker::evaluate(
+        EvaluationRequest {
+            protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+            html: effective_html,
+            url,
+            expression,
+            return_effective_html,
+            runtime_config: RuntimeConfig {
+                inject_dom_shim: true,
+                execute_inline_scripts: false,
+                ..Default::default()
+            },
+        },
+        JsWorkerOptions::default(),
+    )
+    .await
+    .map_err(|error| format!("JavaScript containment error [{}]: {error}", error.code()))
+}
+
+fn mutation_output(response: EvaluationResponse) -> Result<(String, String), String> {
+    response
+        .effective_html
+        .map(|html| (response.result, html))
+        .ok_or_else(|| {
+            "JavaScript containment error [js_worker_protocol]: mutating worker response omitted effective HTML"
+                .to_string()
+        })
 }
 
 async fn load_session_page_for_mcp(
@@ -1659,8 +1695,8 @@ pub async fn handle_open_page(
 
 /// Handle the evaluate tool call.
 ///
-/// Runs JavaScript in the session's page context using V8.
-/// V8's OwnedIsolate is !Send, so we use spawn_blocking.
+/// Runs JavaScript in a supervised child and leaves the session's last good SOM
+/// untouched when the child crashes, times out, or violates an output bound.
 pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) -> Value {
     // Parse arguments
     let params: EvaluateParams = match serde_json::from_value(arguments.clone()) {
@@ -1691,30 +1727,16 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
         }
     };
 
-    // Run JS evaluation in a blocking task (V8 is !Send)
     let expression = params.expression.clone();
-    let eval_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false, // Don't re-execute page scripts
-            ..Default::default()
-        });
-
-        // Bootstrap DOM from effective HTML
-        runtime.bootstrap_dom(&effective_html, &url);
-
-        // Wrap expression to properly serialize objects/arrays
-        let wrapped_expr = format!(
-            "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
-            expression
-        );
-
-        runtime.eval(&wrapped_expr)
-    })
-    .await;
+    let wrapped_expr = format!(
+        "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
+        expression
+    );
+    let eval_result = run_session_javascript(effective_html, url, wrapped_expr, false).await;
 
     match eval_result {
-        Ok(Ok(result)) => {
+        Ok(response) => {
+            let result = response.result;
             // Parse result - try JSON first, then string
             let value = if result == "undefined" || result.is_empty() {
                 Value::Null
@@ -1735,8 +1757,7 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
                 ]
             })
         }
-        Ok(Err(e)) => error_response(&format!("JavaScript error: {}", e)),
-        Err(e) => error_response(&format!("Execution error: {}", e)),
+        Err(error) => error_response(&error),
     }
 }
 
@@ -1844,36 +1865,14 @@ pub async fn handle_click(
             .replace('\n', " ")
     );
 
-    // Execute the click JS
-    let url_clone = url.clone();
-    let effective_html_clone = effective_html.clone();
-    let click_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html_clone, &url_clone);
-
-        let result = runtime.eval(&click_js).map_err(|e| e.to_string())?;
-
-        // Get the updated HTML after click handlers ran
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+    let click_result = run_session_javascript(effective_html, url.clone(), click_js, true).await;
     let (click_result_json, updated_html) = match click_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Click failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Click failed: {error}"));
         }
     };
 
@@ -2295,22 +2294,11 @@ pub async fn handle_type_text(
     let element_id = params.element_id.clone();
     let text = params.text.clone();
     let append = params.append;
-    let url_clone = url.clone();
-    let type_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html, &url_clone);
-
-        let element_id = serde_json::to_string(&element_id).unwrap_or_else(|_| "null".to_string());
-        let html_id = serde_json::to_string(&html_id).unwrap_or_else(|_| "null".to_string());
-        let text = serde_json::to_string(&text).unwrap_or_else(|_| "null".to_string());
-
-        let type_js = format!(
-            r#"
+    let element_id = serde_json::to_string(&element_id).unwrap_or_else(|_| "null".to_string());
+    let html_id = serde_json::to_string(&html_id).unwrap_or_else(|_| "null".to_string());
+    let text = serde_json::to_string(&text).unwrap_or_else(|_| "null".to_string());
+    let type_js = format!(
+        r#"
             (function() {{
                 var somId = {};
                 var htmlId = {};
@@ -2341,28 +2329,19 @@ pub async fn handle_type_text(
                 return JSON.stringify({{ typed: true }});
             }})()
             "#,
-            element_id,
-            html_id,
-            text,
-            if append { "true" } else { "false" },
-        );
-
-        let result = runtime.eval(&type_js).map_err(|e| e.to_string())?;
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+        element_id,
+        html_id,
+        text,
+        if append { "true" } else { "false" },
+    );
+    let type_result = run_session_javascript(effective_html, url.clone(), type_js, true).await;
     let (result_json, updated_html) = match type_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Type failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Type failed: {error}"));
         }
     };
 
@@ -2453,20 +2432,9 @@ pub async fn handle_select_option(
     // Run JS to select option
     let element_id = params.element_id.clone();
     let value = params.value.clone();
-    let url_clone = url.clone();
-    let select_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html, &url_clone);
-
-        let escaped_value = value.replace('\\', "\\\\").replace('\'', "\\'");
-
-        let select_js = format!(
-            r#"
+    let escaped_value = value.replace('\\', "\\\\").replace('\'', "\\'");
+    let select_js = format!(
+        r#"
             (function() {{
                 var el = document.querySelector('[data-plasmate-id="{}"]');
                 if (!el) {{
@@ -2491,25 +2459,16 @@ pub async fn handle_select_option(
                 return JSON.stringify({{ selected: true, value: el.value }});
             }})()
             "#,
-            element_id, escaped_value, escaped_value, escaped_value
-        );
-
-        let result = runtime.eval(&select_js).map_err(|e| e.to_string())?;
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+        element_id, escaped_value, escaped_value, escaped_value
+    );
+    let select_result = run_session_javascript(effective_html, url.clone(), select_js, true).await;
     let (result_json, updated_html) = match select_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Select failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Select failed: {error}"));
         }
     };
 
@@ -2601,19 +2560,9 @@ pub async fn handle_scroll(
     let direction = params.direction.clone();
     let pixels = params.pixels;
     let element_id = params.element_id.clone();
-    let url_clone = url.clone();
-    let scroll_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html, &url_clone);
-
-        let scroll_js = if let Some(ref eid) = element_id {
-            format!(
-                r#"
+    let scroll_js = if let Some(ref eid) = element_id {
+        format!(
+            r#"
                 (function() {{
                     var el = document.querySelector('[data-plasmate-id="{}"]');
                     if (!el) {{
@@ -2623,42 +2572,33 @@ pub async fn handle_scroll(
                     return JSON.stringify({{ scrolled: true, scrollTop: document.documentElement.scrollTop || 0 }});
                 }})()
                 "#,
-                eid
-            )
-        } else {
-            let scroll_action = match direction.as_str() {
-                "up" => format!("window.scrollBy(0, -{})", pixels),
-                "top" => "window.scrollTo(0, 0)".to_string(),
-                "bottom" => "window.scrollTo(0, document.body.scrollHeight)".to_string(),
-                _ => format!("window.scrollBy(0, {})", pixels), // "down" is default
-            };
-            format!(
-                r#"
+            eid
+        )
+    } else {
+        let scroll_action = match direction.as_str() {
+            "up" => format!("window.scrollBy(0, -{})", pixels),
+            "top" => "window.scrollTo(0, 0)".to_string(),
+            "bottom" => "window.scrollTo(0, document.body.scrollHeight)".to_string(),
+            _ => format!("window.scrollBy(0, {})", pixels), // "down" is default
+        };
+        format!(
+            r#"
                 (function() {{
                     {};
                     return JSON.stringify({{ scrolled: true, scrollTop: document.documentElement.scrollTop || 0 }});
                 }})()
                 "#,
-                scroll_action
-            )
-        };
-
-        let result = runtime.eval(&scroll_js).map_err(|e| e.to_string())?;
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+            scroll_action
+        )
+    };
+    let scroll_result = run_session_javascript(effective_html, url.clone(), scroll_js, true).await;
     let (result_json, updated_html) = match scroll_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Scroll failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Scroll failed: {error}"));
         }
     };
 
@@ -2754,18 +2694,8 @@ pub async fn handle_toggle(
 
     // Run JS to toggle the element
     let element_id = params.element_id.clone();
-    let url_clone = url.clone();
-    let toggle_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html, &url_clone);
-
-        let toggle_js = format!(
-            r#"
+    let toggle_js = format!(
+        r#"
             (function() {{
                 var el = document.querySelector('[data-plasmate-id="{}"]');
                 if (!el) {{
@@ -2787,25 +2717,16 @@ pub async fn handle_toggle(
                 }}
             }})()
             "#,
-            element_id
-        );
-
-        let result = runtime.eval(&toggle_js).map_err(|e| e.to_string())?;
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+        element_id
+    );
+    let toggle_result = run_session_javascript(effective_html, url.clone(), toggle_js, true).await;
     let (result_json, updated_html) = match toggle_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Toggle failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Toggle failed: {error}"));
         }
     };
 
@@ -2895,18 +2816,8 @@ pub async fn handle_clear(
 
     // Run JS to clear the element value
     let element_id = params.element_id.clone();
-    let url_clone = url.clone();
-    let clear_result = tokio::task::spawn_blocking(move || {
-        let mut runtime = JsRuntime::new(RuntimeConfig {
-            inject_dom_shim: true,
-            execute_inline_scripts: false,
-            ..Default::default()
-        });
-
-        runtime.bootstrap_dom(&effective_html, &url_clone);
-
-        let clear_js = format!(
-            r#"
+    let clear_js = format!(
+        r#"
             (function() {{
                 var el = document.querySelector('[data-plasmate-id="{}"]');
                 if (!el) {{
@@ -2920,25 +2831,16 @@ pub async fn handle_clear(
                 return JSON.stringify({{ cleared: true }});
             }})()
             "#,
-            element_id
-        );
-
-        let result = runtime.eval(&clear_js).map_err(|e| e.to_string())?;
-        let updated_html = runtime
-            .eval("document.documentElement.outerHTML")
-            .map_err(|e| e.to_string())?;
-
-        Ok::<(String, String), String>((result, updated_html))
-    })
-    .await;
-
+        element_id
+    );
+    let clear_result = run_session_javascript(effective_html, url.clone(), clear_js, true).await;
     let (result_json, updated_html) = match clear_result {
-        Ok(Ok((result, html))) => (result, html),
-        Ok(Err(e)) => {
-            return error_response(&format!("Clear failed: {}", e));
-        }
-        Err(e) => {
-            return error_response(&format!("Execution error: {}", e));
+        Ok(response) => match mutation_output(response) {
+            Ok(output) => output,
+            Err(error) => return error_response(&error),
+        },
+        Err(error) => {
+            return error_response(&format!("Clear failed: {error}"));
         }
     };
 

--- a/src/process_supervisor.rs
+++ b/src/process_supervisor.rs
@@ -607,8 +607,12 @@ impl Drop for CancellationGuard {
 fn supervise_blocking(
     spec: ProcessSpec,
     cancellation: Arc<CancellationState>,
+    clear_env: bool,
 ) -> Result<ProcessOutput, SupervisorError> {
     let mut command = std::process::Command::new(&spec.program);
+    if clear_env {
+        command.env_clear();
+    }
     command
         .args(&spec.args)
         .envs(spec.env)
@@ -691,18 +695,47 @@ fn supervise_blocking(
     })
 }
 
+/// Synchronous counterpart to [`supervise`]. Long-lived protocol handlers that
+/// are already synchronous (for example CDP Runtime.evaluate) use this rather
+/// than duplicating process-group and bounded-pipe handling.
+pub fn supervise_sync(spec: ProcessSpec) -> Result<ProcessOutput, SupervisorError> {
+    let cancellation = Arc::new(CancellationState::default());
+    supervise_blocking(spec, cancellation, false)
+}
+
+/// Synchronously supervise a child that starts from an empty environment.
+/// Only the variables explicitly listed in [`ProcessSpec::env`] are inherited.
+pub fn supervise_sync_clean_env(spec: ProcessSpec) -> Result<ProcessOutput, SupervisorError> {
+    let cancellation = Arc::new(CancellationState::default());
+    supervise_blocking(spec, cancellation, true)
+}
+
 /// Run a child process with a hard wall timeout and bounded output capture.
 ///
 /// Output beyond each configured limit is drained and discarded so a noisy
 /// worker cannot deadlock on a full pipe or exhaust the parent's memory.
 pub async fn supervise(spec: ProcessSpec) -> Result<ProcessOutput, SupervisorError> {
+    supervise_with_env_policy(spec, false).await
+}
+
+/// Supervise a child that starts from an empty environment. Only the variables
+/// explicitly listed in [`ProcessSpec::env`] are inherited.
+pub async fn supervise_clean_env(spec: ProcessSpec) -> Result<ProcessOutput, SupervisorError> {
+    supervise_with_env_policy(spec, true).await
+}
+
+async fn supervise_with_env_policy(
+    spec: ProcessSpec,
+    clear_env: bool,
+) -> Result<ProcessOutput, SupervisorError> {
     let wall_timeout = spec.timeout;
     let cancellation = Arc::new(CancellationState::default());
     let mut guard = CancellationGuard {
         state: cancellation.clone(),
         armed: true,
     };
-    let task = tokio::task::spawn_blocking(move || supervise_blocking(spec, cancellation));
+    let task =
+        tokio::task::spawn_blocking(move || supervise_blocking(spec, cancellation, clear_env));
     match tokio::time::timeout(wall_timeout, task).await {
         Ok(joined) => {
             let result = joined.map_err(|error| SupervisorError::Task(error.to_string()))?;

--- a/src/webmcp.rs
+++ b/src/webmcp.rs
@@ -187,7 +187,7 @@ impl Default for WebMcpCatalog {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeCapture {
     pub domain_was_set_by_page: bool,
@@ -195,7 +195,7 @@ pub struct RuntimeCapture {
     pub registrations: Vec<ImperativeRegistration>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImperativeRegistration {
     pub name: String,

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -1,0 +1,23 @@
+use std::io::{Read, Write};
+use std::time::Duration;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    if input.contains("__fixture_abort__") {
+        std::process::abort();
+    }
+    if input.contains("__fixture_hang__") {
+        std::thread::sleep(Duration::from_secs(60));
+        return;
+    }
+    if input.contains("__fixture_output__") {
+        std::io::stdout().write_all(&vec![b'x'; 1024 * 1024]).unwrap();
+        return;
+    }
+    if input.contains("__fixture_env__") && std::env::var_os("PLASMATE_TEST_SECRET").is_some() {
+        eprintln!("secret environment leaked into worker");
+        std::process::exit(17);
+    }
+    println!(r#"{{"status":"evaluation","value":{{"result":"ok"}}}}"#);
+}

--- a/tests/js_worker_test.rs
+++ b/tests/js_worker_test.rs
@@ -1,0 +1,285 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use plasmate::js::runtime::RuntimeConfig;
+use plasmate::js::worker::{self, EvaluationRequest, JsWorkerError, JsWorkerOptions};
+use serial_test::serial;
+
+fn fixture_path() -> PathBuf {
+    static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+    FIXTURE
+        .get_or_init(|| {
+            let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/js_worker_fixture.rs");
+            let mut output = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("js-worker-fixture");
+            if cfg!(windows) {
+                output.set_extension("exe");
+            }
+            let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+            let compilation = std::process::Command::new(rustc)
+                .args(["--edition=2021", "--crate-name", "js_worker_fixture"])
+                .arg(&source)
+                .arg("-o")
+                .arg(&output)
+                .output()
+                .expect("failed to launch rustc for JS worker fixture");
+            assert!(
+                compilation.status.success(),
+                "fixture compilation failed: {}",
+                String::from_utf8_lossy(&compilation.stderr)
+            );
+            output
+        })
+        .clone()
+}
+
+fn request(url: &str) -> EvaluationRequest {
+    EvaluationRequest {
+        protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
+        html: "<p>safe fallback</p>".to_string(),
+        url: url.to_string(),
+        expression: "1 + 1".to_string(),
+        return_effective_html: false,
+        runtime_config: RuntimeConfig::default(),
+    }
+}
+
+fn options() -> JsWorkerOptions {
+    JsWorkerOptions {
+        executable: Some(fixture_path()),
+        timeout: Duration::from_secs(5),
+        max_stdout_bytes: 4096,
+        max_stderr_bytes: 4096,
+        memory_limit_bytes: 0,
+    }
+}
+
+fn real_worker_options() -> JsWorkerOptions {
+    JsWorkerOptions {
+        executable: Some(PathBuf::from(env!("CARGO_BIN_EXE_plasmate"))),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn normal_worker_response_round_trips() {
+    let response = worker::evaluate(request("https://fixture.invalid/__fixture_ok__"), options())
+        .await
+        .unwrap();
+    assert_eq!(response.result, "ok");
+}
+
+#[tokio::test]
+#[serial]
+async fn worker_abort_is_contained_and_typed() {
+    let error = worker::evaluate(
+        request("https://fixture.invalid/__fixture_abort__"),
+        options(),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        JsWorkerError::Crashed { .. } | JsWorkerError::Exit { .. }
+    ));
+}
+
+#[tokio::test]
+#[serial]
+async fn worker_hang_hits_hard_wall_deadline() {
+    let mut options = options();
+    options.timeout = Duration::from_millis(100);
+    let started = Instant::now();
+    let error = worker::evaluate(request("https://fixture.invalid/__fixture_hang__"), options)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, JsWorkerError::Timeout { .. }));
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[tokio::test]
+#[serial]
+async fn worker_output_is_drained_but_bounded() {
+    let mut options = options();
+    options.max_stdout_bytes = 128;
+    let error = worker::evaluate(
+        request("https://fixture.invalid/__fixture_output__"),
+        options,
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, JsWorkerError::OutputLimit));
+}
+
+#[tokio::test]
+#[serial]
+async fn unrelated_parent_environment_is_not_inherited() {
+    let previous = std::env::var_os("PLASMATE_TEST_SECRET");
+    std::env::set_var("PLASMATE_TEST_SECRET", "must-not-cross-boundary");
+    let result = worker::evaluate(
+        request("https://fixture.invalid/__fixture_env__"),
+        options(),
+    )
+    .await;
+    match previous {
+        Some(value) => std::env::set_var("PLASMATE_TEST_SECRET", value),
+        None => std::env::remove_var("PLASMATE_TEST_SECRET"),
+    }
+    assert_eq!(result.unwrap().result, "ok");
+}
+
+#[tokio::test]
+#[serial]
+async fn page_pipeline_keeps_static_som_after_worker_crash() {
+    let html = "<html><head><title>Fallback survives</title></head><body><main>Structured fallback</main><script>while (true) {}</script></body></html>";
+    let config = plasmate::js::pipeline::PipelineConfig {
+        fetch_external_scripts: false,
+        js_worker_executable: Some(fixture_path()),
+        ..Default::default()
+    };
+    let result = plasmate::js::pipeline::process_page_async(
+        html,
+        "https://fixture.invalid/__fixture_abort__",
+        &config,
+        &reqwest::Client::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.som.title, "Fallback survives");
+    let failure = result
+        .js_report
+        .and_then(|report| report.containment_failure)
+        .expect("typed containment failure");
+    assert!(matches!(
+        failure.kind,
+        worker::JsContainmentFailureKind::Crash | worker::JsContainmentFailureKind::Exit
+    ));
+}
+
+#[tokio::test]
+#[serial]
+async fn real_worker_executes_javascript_and_returns_mutated_dom() {
+    let mut request = request("https://example.com/");
+    request.html = "<html><body><p id='state'>before</p></body></html>".to_string();
+    request.expression =
+        "document.getElementById('state').textContent = 'after'; 'complete'".to_string();
+    request.return_effective_html = true;
+    let response = worker::evaluate(request, real_worker_options())
+        .await
+        .unwrap();
+    assert_eq!(response.result, "complete");
+    assert!(response.effective_html.unwrap().contains("after"));
+}
+
+#[tokio::test]
+#[serial]
+async fn real_infinite_script_cannot_hang_test_coordinator() {
+    let mut request = request("https://example.com/");
+    request.expression = "while (true) {}".to_string();
+    let mut options = real_worker_options();
+    options.timeout = Duration::from_millis(500);
+    let started = Instant::now();
+    let error = worker::evaluate(request, options).await.unwrap_err();
+    assert!(matches!(error, JsWorkerError::Timeout { .. }));
+    assert!(started.elapsed() < Duration::from_secs(3));
+}
+
+#[tokio::test]
+#[serial]
+async fn real_javascript_result_cannot_overrun_parent_output_bound() {
+    let mut request = request("https://example.com/");
+    request.expression = "'x'.repeat(1024 * 1024)".to_string();
+    let mut options = real_worker_options();
+    options.max_stdout_bytes = 1024;
+    let error = worker::evaluate(request, options).await.unwrap_err();
+    assert!(matches!(error, JsWorkerError::OutputLimit));
+}
+
+#[tokio::test]
+#[serial]
+async fn real_page_worker_applies_page_script_dom_mutation() {
+    let html = "<html><body><main id='app'>before</main><script>document.getElementById('app').textContent = 'after';</script></body></html>";
+    let config = plasmate::js::pipeline::PipelineConfig {
+        fetch_external_scripts: false,
+        js_worker_executable: Some(PathBuf::from(env!("CARGO_BIN_EXE_plasmate"))),
+        ..Default::default()
+    };
+    let result = plasmate::js::pipeline::process_page_async(
+        html,
+        "https://example.com/",
+        &config,
+        &reqwest::Client::new(),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.effective_html.contains("after"));
+    assert!(
+        result
+            .js_report
+            .as_ref()
+            .is_some_and(|report| report.succeeded == 1 && report.containment_failure.is_none()),
+        "report={:#?}; html={}",
+        result.js_report,
+        result.effective_html
+    );
+    assert!(serde_json::to_string(&result.som)
+        .unwrap()
+        .contains("after"));
+}
+
+#[test]
+#[serial]
+fn synchronous_public_pipeline_uses_real_process_boundary() {
+    let html = "<html><body><main id='app'>before</main><script>document.getElementById('app').textContent = 'sync-after';</script></body></html>";
+    let config = plasmate::js::pipeline::PipelineConfig {
+        js_worker_executable: Some(PathBuf::from(env!("CARGO_BIN_EXE_plasmate"))),
+        ..Default::default()
+    };
+    let result =
+        plasmate::js::pipeline::process_page(html, "https://example.com/", &config).unwrap();
+    assert!(result.effective_html.contains("sync-after"));
+    assert!(
+        result
+            .js_report
+            .as_ref()
+            .is_some_and(|report| report.containment_failure.is_none()),
+        "report={:#?}; html={}",
+        result.js_report,
+        result.effective_html
+    );
+}
+
+#[test]
+#[serial]
+fn missing_worker_is_typed_and_preserves_sync_static_som() {
+    let html = "<html><head><title>Still structured</title></head><body><main>fallback</main><script>document.title = 'lost';</script></body></html>";
+    let config = plasmate::js::pipeline::PipelineConfig {
+        js_worker_executable: Some(PathBuf::from("/definitely/not/a/plasmate-worker")),
+        ..Default::default()
+    };
+    let result =
+        plasmate::js::pipeline::process_page(html, "https://example.com/", &config).unwrap();
+    assert_eq!(result.som.title, "Still structured");
+    let failure = result
+        .js_report
+        .and_then(|report| report.containment_failure)
+        .expect("typed missing-worker failure");
+    assert_eq!(failure.kind, worker::JsContainmentFailureKind::Spawn);
+    assert_eq!(failure.code, "js_worker_spawn");
+}
+
+#[test]
+#[serial]
+fn cdp_stateful_evaluation_uses_supervised_worker() {
+    let mut target = plasmate::cdp::session::CdpTarget::new().unwrap();
+    target.current_url = Some("https://example.com/".to_string());
+    target.effective_html =
+        Some("<html><head><title>Worker title</title></head><body></body></html>".to_string());
+    let value = target.evaluate_js("document.title").unwrap();
+    assert_eq!(value, serde_json::Value::String("Worker title".to_string()));
+}


### PR DESCRIPTION
## Summary
- route ordinary page JS and stateful MCP/CDP evaluation/mutation through a supervised one-shot worker
- enforce a 15s hard wall, bounded protocol I/O, process-group cleanup, V8 heap limits, optional Linux address-space limits, and a cleared allowlisted environment
- preserve source-HTML SOM fallback and last-good session state with typed containment failures
- cover synchronous and asynchronous page APIs, CLI, daemon, MCP, AWP, and CDP
- retain P2 SOM-to-HTML type targeting inside the isolated mutation path

## Verification
- Rust 1.88 all-feature suite passed before integration
- 13/13 worker integration tests passed after P0+P2 rebase
- combined six-scenario agent benchmark: 6/6 contracts, 0 crashes, 0 timeouts
- strict all-target/all-feature clippy passed
- formatting and diff checks passed

External classic/module acquisition continues to use the caller client in the parent. Page fetch/XHR retains the existing restricted fresh-client behavior and does not inherit caller cookies/proxy/custom TLS/default headers. No elapsed-time soak or freeze is introduced.