### PR TITLE
fix(mcp): report inspection containment truthfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ Use `inspect_page` when an agent may need pixels. Its default `auto` mode
 always returns a bounded compact SOM and only attaches a screenshot for named
 signals such as near-empty structure, canvas-heavy content, or image-map/image
 controls. `never` recommends without capture; `always` is an explicit capture
-request. Page JavaScript is off by default; `javascript=true` explicitly opts
-into the existing in-process V8 crash boundary before screenshot isolation.
+request. Page JavaScript is off by default; `javascript=true` runs untrusted
+page code through the supervised JavaScript worker before the separately
+isolated screenshot process.
 Rendering uses a sandboxed/CSP-constrained document with JavaScript
 disabled, no unsafe file-access or browser-sandbox switches, a dead network
 proxy, and process-tree cleanup. Plasmate does not interpret the image with a vision model. See

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,9 +94,13 @@ weakening production defaults.
 
 ## Residual risks
 
-V8 executes untrusted page JavaScript inside the Plasmate process. Resource
-limits reduce exposure but are not a process or OS sandbox. Run Plasmate with
-least privilege, do not expose control protocols to other users, and use an OS
-sandbox for adversarial workloads. Auth-profile encryption protects files at
-rest; it does not protect against another process already running as the same
-OS user.
+Ordinary untrusted page JavaScript executes in a supervised child process with
+bounded input/output, a hard deadline, an empty inherited environment, and
+process-tree cleanup. This containment prevents fatal V8 failures from ending
+the CLI, daemon, MCP, AWP, or CDP coordinator, but it is not a complete OS
+sandbox. Direct `JsRuntime` construction and the explicit
+`PipelineConfig::isolate_js = false` escape hatch remain in-process surfaces for
+trusted tests or an already-supervised worker. Run Plasmate with least
+privilege, do not expose control protocols to other users, and use an OS sandbox
+for adversarial workloads. Auth-profile encryption protects files at rest; it
+does not protect against another process already running as the same OS user.

--- a/docs/STRUCTURED-VISUAL-FALLBACK.md
+++ b/docs/STRUCTURED-VISUAL-FALLBACK.md
@@ -33,11 +33,13 @@ interactive counts, region identity, stable element IDs, roles, bounded
 text/labels, actions, and explicit omission counters.
 
 Page JavaScript is disabled by default. Setting `javascript=true` explicitly
-opts into Plasmate's existing in-process V8 pipeline before the screenshot
-subprocess is started. That pipeline can improve dynamic-page structure, but it
-still carries the documented residual risk that a fatal V8 failure can end the
-long-lived MCP server. Chrome process containment does not isolate this earlier
-pipeline execution.
+opts into Plasmate's supervised `plasmate.js-worker.v1` pipeline before the
+screenshot subprocess is started. That pipeline can improve dynamic-page
+structure while keeping fatal V8 failures, hangs, oversized output, and worker
+protocol failures outside the long-lived MCP server. A containment failure
+returns bounded source-HTML structure with typed execution diagnostics; it does
+not silently retry JavaScript in-process. The later Chrome screenshot remains a
+separate, independently supervised process tree.
 
 `visual_mode` has exactly three values:
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -764,7 +764,7 @@ pub async fn handle_crawl_policy(arguments: &Value) -> Value {
 pub fn inspect_page_definition() -> ToolDefinition {
     ToolDefinition {
         name: "inspect_page".to_string(),
-        description: "Inspect a page through a bounded compact SOM first, then optionally attach a hardened offline-rendered screenshot. JavaScript is off by default; javascript=true explicitly opts into the existing in-process V8 execution risk before screenshot isolation. visual_mode='auto' captures only for named structural insufficiency signals; 'never' only recommends; 'always' explicitly requests pixels. Plasmate does not perform vision-model interpretation, and visual failure never discards the SOM.".to_string(),
+        description: "Inspect a page through a bounded compact SOM first, then optionally attach a hardened offline-rendered screenshot. JavaScript is off by default; javascript=true executes it in a supervised worker with bounded source-HTML fallback on containment failure. visual_mode='auto' captures only for named structural insufficiency signals; 'never' only recommends; 'always' explicitly requests pixels. Plasmate does not perform vision-model interpretation, and visual failure never discards the SOM.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -772,7 +772,7 @@ pub fn inspect_page_definition() -> ToolDefinition {
                 "javascript": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Opt in to executing untrusted page JavaScript in Plasmate's current in-process V8 pipeline before inspection. False avoids that residual process-crash boundary."
+                    "description": "Opt in to executing untrusted page JavaScript in Plasmate's supervised worker before inspection. Worker crashes, timeouts, and protocol failures fall back to bounded source-HTML structure instead of terminating the MCP server."
                 },
                 "selector": {
                     "type": "string",
@@ -3724,10 +3724,18 @@ mod tests {
         );
         let inspect = inspect_page_definition();
         assert_eq!(inspect.input_schema["additionalProperties"], false);
+        assert!(inspect.description.contains("supervised worker"));
+        assert!(!inspect.description.contains("in-process V8"));
         assert_eq!(
             inspect.input_schema["properties"]["javascript"]["default"],
             false
         );
+        let javascript_description = inspect.input_schema["properties"]["javascript"]
+            ["description"]
+            .as_str()
+            .unwrap();
+        assert!(javascript_description.contains("supervised worker"));
+        assert!(!javascript_description.contains("in-process V8"));
         assert_eq!(
             inspect.input_schema["properties"]["visual_mode"]["enum"],
             json!(["never", "auto", "always"])


### PR DESCRIPTION
## What changed

- describe inspect_page JavaScript execution as supervised worker execution
- document source-HTML fallback and coordinator survival on containment failure
- update README and security residual-risk guidance
- add regression assertions preventing the MCP tool descriptions from reverting to the obsolete in-process claim

## Why

PR #50 moved ordinary page JavaScript, including inspect_page, behind plasmate.js-worker.v1. The public MCP description and security documentation still described the pre-isolation crash boundary, which could cause models and operators to make incorrect safety decisions.

## Validation

- cargo fmt --all -- --check
- cargo test --locked --all-features mcp::tools::tests::crawl_and_inspection_schemas_are_strict_and_versioned_modes_are_exact
- cargo clippy --locked --all-targets --all-features -- -D warnings
- git diff --check