### PR TITLE
fix(p0): complete containment and security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,29 @@ jobs:
         env:
           PLASMATE_UNSAFE_ALLOW_PRIVATE_NETWORK: '1'
         run: |
+          server_pid=""
+          cleanup() {
+            if [[ -n "$server_pid" ]]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
           cargo build --release
           ./target/release/plasmate serve --protocol cdp --host 127.0.0.1 --port 9222 2>/dev/null &
-          PID=$!
-          sleep 1
-          node smoke/puppeteer-smoke.mjs
-          kill $PID
+          server_pid=$!
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:9222/json/version >/dev/null; then
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "CDP server exited before becoming ready" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          curl --fail --silent --show-error http://127.0.0.1:9222/json/version >/dev/null
+          timeout 60s node smoke/puppeteer-smoke.mjs
 
       - name: MCP smoke test
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -154,10 +171,28 @@ jobs:
         env:
           PLASMATE_UNSAFE_ALLOW_PRIVATE_NETWORK: '1'
         run: |
+          server_pid=""
+          cleanup() {
+            if [[ -n "$server_pid" ]]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
           python3 bench/local_server.py 8765 &
-          sleep 1
-          ./target/release/plasmate throughput-bench 2>&1 | tee bench-results.txt
-          kill $(lsof -ti:8765) 2>/dev/null || true
+          server_pid=$!
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:8765/ >/dev/null; then
+              break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "benchmark fixture server exited before becoming ready" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          curl --fail --silent --show-error http://127.0.0.1:8765/ >/dev/null
+          timeout 5m ./target/release/plasmate throughput-bench 2>&1 | tee bench-results.txt
 
           # Extract sequential ms/page and fail if regression > 2x baseline
           MS_PER_PAGE=$(grep "Sequential:" bench-results.txt | grep -oP '[\d.]+ms/page' | grep -oP '[\d.]+')

--- a/src/coverage/runner.rs
+++ b/src/coverage/runner.rs
@@ -96,6 +96,7 @@ pub enum FailureKind {
     NonHtml,
     PipelineError,
     WorkerCrash,
+    WorkerResourceExhaustion,
     WorkerExit,
     WorkerProtocolError,
     WorkerSpawnError,
@@ -125,8 +126,41 @@ pub struct CoverageResult {
     pub js_succeeded: Option<usize>,
     pub js_failed: Option<usize>,
 
+    /// Parent-observed evidence for an isolated JS coverage worker. This is
+    /// absent for non-JS/in-process coverage and populated for every attempted
+    /// supervised worker, including launch and protocol failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker: Option<CoverageWorkerEvidence>,
+
     pub failure_kind: Option<FailureKind>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageWorkerOutcome {
+    Success,
+    Blocked,
+    PageError,
+    Timeout,
+    Signaled,
+    Exited,
+    ResourceExhaustion,
+    OutputLimit,
+    MalformedOutput,
+    LaunchFailure,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoverageWorkerEvidence {
+    pub outcome: CoverageWorkerOutcome,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic_excerpt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,6 +182,8 @@ pub struct CoverageSummary {
     pub timed_out: usize,
     #[serde(default)]
     pub worker_crashes: usize,
+    #[serde(default)]
+    pub worker_resource_exhaustions: usize,
     #[serde(default)]
     pub worker_exits: usize,
     /// Coordinator setup or worker-protocol errors, excluding page crashes.
@@ -176,6 +212,8 @@ pub struct CoverageOutcomes {
     pub blocked: usize,
     pub failed: usize,
     pub crash: usize,
+    #[serde(default)]
+    pub resource_exhaustion: usize,
     pub timeout: usize,
 }
 
@@ -433,6 +471,9 @@ fn classify_outcomes(results: &[CoverageResult]) -> CoverageOutcomes {
             (CoverageStatus::Ok, _) => outcomes.success += 1,
             (CoverageStatus::Blocked, _) => outcomes.blocked += 1,
             (CoverageStatus::Failed, Some(FailureKind::WorkerCrash)) => outcomes.crash += 1,
+            (CoverageStatus::Failed, Some(FailureKind::WorkerResourceExhaustion)) => {
+                outcomes.resource_exhaustion += 1
+            }
             (CoverageStatus::Failed, Some(FailureKind::Timeout)) => outcomes.timeout += 1,
             (CoverageStatus::Failed, _) => outcomes.failed += 1,
         }
@@ -519,6 +560,7 @@ pub fn validate_evidence(report: &CoverageReport) -> Result<(), String> {
         + report.summary.outcomes.blocked
         + report.summary.outcomes.failed
         + report.summary.outcomes.crash
+        + report.summary.outcomes.resource_exhaustion
         + report.summary.outcomes.timeout;
     if classified != report.summary.outcomes.inputs_total {
         return Err("coverage outcome buckets do not partition inputs_total".to_string());
@@ -532,9 +574,16 @@ pub fn validate_evidence(report: &CoverageReport) -> Result<(), String> {
         || report.summary.failed
             != report.summary.outcomes.failed
                 + report.summary.outcomes.crash
+                + report.summary.outcomes.resource_exhaustion
                 + report.summary.outcomes.timeout
     {
         return Err("legacy coverage aggregates disagree with outcome buckets".to_string());
+    }
+    if report.summary.timed_out != report.summary.outcomes.timeout
+        || report.summary.worker_crashes != report.summary.outcomes.crash
+        || report.summary.worker_resource_exhaustions != report.summary.outcomes.resource_exhaustion
+    {
+        return Err("worker outcome aggregates disagree with outcome buckets".to_string());
     }
     if report.measurement.cache.collected
         || report.measurement.cache.repetitions_per_input != 1
@@ -625,6 +674,7 @@ pub async fn run(urls: &[String], opts: &CoverageOptions) -> CoverageReport {
                         js_total_scripts: None,
                         js_succeeded: None,
                         js_failed: None,
+                        worker: None,
                         failure_kind: Some(FailureKind::Timeout),
                         error: Some(format!("Overall timeout after {}ms", opts.timeout_ms)),
                     },
@@ -656,6 +706,7 @@ pub async fn run(urls: &[String], opts: &CoverageOptions) -> CoverageReport {
     let mut failed = 0usize;
     let mut timed_out = 0usize;
     let mut worker_crashes = 0usize;
+    let mut worker_resource_exhaustions = 0usize;
     let mut worker_exits = 0usize;
     let mut worker_errors = 0usize;
     let mut ratios: Vec<f64> = Vec::new();
@@ -678,6 +729,7 @@ pub async fn run(urls: &[String], opts: &CoverageOptions) -> CoverageReport {
         match &r.failure_kind {
             Some(FailureKind::Timeout) => timed_out += 1,
             Some(FailureKind::WorkerCrash) => worker_crashes += 1,
+            Some(FailureKind::WorkerResourceExhaustion) => worker_resource_exhaustions += 1,
             Some(FailureKind::WorkerExit) => worker_exits += 1,
             Some(FailureKind::WorkerProtocolError | FailureKind::WorkerSpawnError) => {
                 worker_errors += 1
@@ -780,6 +832,7 @@ pub async fn run(urls: &[String], opts: &CoverageOptions) -> CoverageReport {
             success_percent,
             timed_out,
             worker_crashes,
+            worker_resource_exhaustions,
             worker_exits,
             worker_errors,
             infrastructure_failures: worker_errors,
@@ -813,6 +866,7 @@ fn failed_result(input_url: String, kind: FailureKind, error: String) -> Coverag
         js_total_scripts: None,
         js_succeeded: None,
         js_failed: None,
+        worker: None,
         failure_kind: Some(kind),
         error: Some(error),
     }
@@ -830,16 +884,64 @@ fn bounded_diagnostic(stderr: &[u8], truncated: bool) -> String {
     diagnostic
 }
 
+fn diagnostic_is_resource_exhaustion(diagnostic: &str) -> bool {
+    let normalized = diagnostic.to_ascii_lowercase();
+    [
+        "heap out of memory",
+        "out of memory",
+        "memory allocation of",
+        "allocation failed",
+        "failed to reserve address space",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn worker_evidence(
+    outcome: CoverageWorkerOutcome,
+    duration_ms: u64,
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    diagnostic: &str,
+) -> CoverageWorkerEvidence {
+    CoverageWorkerEvidence {
+        outcome,
+        duration_ms,
+        exit_code,
+        signal,
+        diagnostic_excerpt: (!diagnostic.is_empty()).then(|| diagnostic.to_string()),
+    }
+}
+
+fn with_worker_evidence(
+    mut result: CoverageResult,
+    evidence: CoverageWorkerEvidence,
+) -> CoverageResult {
+    result.worker = Some(evidence);
+    result
+}
+
 async fn cover_single_supervised(input_url: &str, opts: &CoverageOptions) -> CoverageResult {
+    let worker_start = Instant::now();
     let executable = match &opts.worker_executable {
         Some(path) => path.clone(),
         None => match std::env::current_exe() {
             Ok(path) => path,
             Err(error) => {
-                return failed_result(
-                    input_url.to_string(),
-                    FailureKind::WorkerSpawnError,
-                    format!("Cannot resolve coverage worker executable: {error}"),
+                let message = format!("Cannot resolve coverage worker executable: {error}");
+                return with_worker_evidence(
+                    failed_result(
+                        input_url.to_string(),
+                        FailureKind::WorkerSpawnError,
+                        message.clone(),
+                    ),
+                    worker_evidence(
+                        CoverageWorkerOutcome::LaunchFailure,
+                        worker_start.elapsed().as_millis() as u64,
+                        None,
+                        None,
+                        &message,
+                    ),
                 );
             }
         },
@@ -878,74 +980,177 @@ async fn cover_single_supervised(input_url: &str, opts: &CoverageOptions) -> Cov
     let output = match output {
         Ok(output) => output,
         Err(error) => {
-            return failed_result(
-                input_url.to_string(),
-                FailureKind::WorkerSpawnError,
-                error.to_string(),
+            let message = error.to_string();
+            return with_worker_evidence(
+                failed_result(
+                    input_url.to_string(),
+                    FailureKind::WorkerSpawnError,
+                    message.clone(),
+                ),
+                worker_evidence(
+                    CoverageWorkerOutcome::LaunchFailure,
+                    worker_start.elapsed().as_millis() as u64,
+                    None,
+                    None,
+                    &message,
+                ),
             );
         }
     };
-    classify_worker_output(input_url, opts.timeout_ms, output)
+    classify_worker_output(
+        input_url,
+        opts.timeout_ms,
+        worker_start.elapsed().as_millis() as u64,
+        output,
+    )
 }
 
 fn classify_worker_output(
     input_url: &str,
     timeout_ms: u64,
+    duration_ms: u64,
     output: ProcessOutput,
 ) -> CoverageResult {
     let diagnostic = bounded_diagnostic(&output.stderr, output.stderr_truncated);
+    if diagnostic_is_resource_exhaustion(&diagnostic)
+        && !matches!(output.outcome, ProcessOutcome::Exited { code: 0 })
+    {
+        let (exit_code, signal) = match output.outcome {
+            ProcessOutcome::Exited { code } => (Some(code), None),
+            ProcessOutcome::Signaled { signal } => (None, Some(signal)),
+            ProcessOutcome::TimedOut => (None, None),
+        };
+        return with_worker_evidence(
+            failed_result(
+                input_url.to_string(),
+                FailureKind::WorkerResourceExhaustion,
+                format!("Supervised JS worker exhausted resources: {diagnostic}"),
+            ),
+            worker_evidence(
+                CoverageWorkerOutcome::ResourceExhaustion,
+                duration_ms,
+                exit_code,
+                signal,
+                &diagnostic,
+            ),
+        );
+    }
 
     match output.outcome {
-        ProcessOutcome::TimedOut => failed_result(
-            input_url.to_string(),
-            FailureKind::Timeout,
-            format!(
-                "Supervised JS worker exceeded {}ms{}",
-                timeout_ms,
-                if diagnostic.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {diagnostic}")
-                }
+        ProcessOutcome::TimedOut => with_worker_evidence(
+            failed_result(
+                input_url.to_string(),
+                FailureKind::Timeout,
+                format!(
+                    "Supervised JS worker exceeded {}ms{}",
+                    timeout_ms,
+                    if diagnostic.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {diagnostic}")
+                    }
+                ),
+            ),
+            worker_evidence(
+                CoverageWorkerOutcome::Timeout,
+                duration_ms,
+                None,
+                None,
+                &diagnostic,
             ),
         ),
-        ProcessOutcome::Signaled { signal } => failed_result(
-            input_url.to_string(),
-            FailureKind::WorkerCrash,
-            format!(
-                "Supervised JS worker terminated by signal {signal}{}",
-                if diagnostic.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {diagnostic}")
-                }
+        ProcessOutcome::Signaled { signal } => with_worker_evidence(
+            failed_result(
+                input_url.to_string(),
+                FailureKind::WorkerCrash,
+                format!(
+                    "Supervised JS worker terminated by signal {signal}{}",
+                    if diagnostic.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {diagnostic}")
+                    }
+                ),
+            ),
+            worker_evidence(
+                CoverageWorkerOutcome::Signaled,
+                duration_ms,
+                None,
+                Some(signal),
+                &diagnostic,
             ),
         ),
-        ProcessOutcome::Exited { code } if code != 0 => failed_result(
-            input_url.to_string(),
-            FailureKind::WorkerExit,
-            format!(
-                "Supervised JS worker exited with code {code}{}",
-                if diagnostic.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {diagnostic}")
-                }
+        ProcessOutcome::Exited { code } if code != 0 => with_worker_evidence(
+            failed_result(
+                input_url.to_string(),
+                FailureKind::WorkerExit,
+                format!(
+                    "Supervised JS worker exited with code {code}{}",
+                    if diagnostic.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {diagnostic}")
+                    }
+                ),
+            ),
+            worker_evidence(
+                CoverageWorkerOutcome::Exited,
+                duration_ms,
+                Some(code),
+                None,
+                &diagnostic,
             ),
         ),
-        ProcessOutcome::Exited { .. } if output.stdout_truncated => failed_result(
-            input_url.to_string(),
-            FailureKind::WorkerProtocolError,
-            "Supervised JS worker response exceeded the output limit".to_string(),
-        ),
-        ProcessOutcome::Exited { .. } => match serde_json::from_slice(&output.stdout) {
-            Ok(result) => result,
-            Err(error) => failed_result(
+        ProcessOutcome::Exited { code } if output.stdout_truncated => with_worker_evidence(
+            failed_result(
                 input_url.to_string(),
                 FailureKind::WorkerProtocolError,
-                format!("Invalid coverage worker response: {error}"),
+                "Supervised JS worker response exceeded the output limit".to_string(),
             ),
-        },
+            worker_evidence(
+                CoverageWorkerOutcome::OutputLimit,
+                duration_ms,
+                Some(code),
+                None,
+                &diagnostic,
+            ),
+        ),
+        ProcessOutcome::Exited { code } => {
+            match serde_json::from_slice::<CoverageResult>(&output.stdout) {
+                Ok(result) => {
+                    let outcome = match &result.status {
+                        CoverageStatus::Ok => CoverageWorkerOutcome::Success,
+                        CoverageStatus::Blocked => CoverageWorkerOutcome::Blocked,
+                        CoverageStatus::Failed => CoverageWorkerOutcome::PageError,
+                    };
+                    with_worker_evidence(
+                        result,
+                        worker_evidence(outcome, duration_ms, Some(code), None, &diagnostic),
+                    )
+                }
+                Err(error) => {
+                    let message = format!("Invalid coverage worker response: {error}");
+                    with_worker_evidence(
+                        failed_result(
+                            input_url.to_string(),
+                            FailureKind::WorkerProtocolError,
+                            message.clone(),
+                        ),
+                        worker_evidence(
+                            CoverageWorkerOutcome::MalformedOutput,
+                            duration_ms,
+                            Some(code),
+                            None,
+                            if diagnostic.is_empty() {
+                                &message
+                            } else {
+                                &diagnostic
+                            },
+                        ),
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -996,6 +1201,7 @@ async fn cover_single(
                         js_total_scripts: None,
                         js_succeeded: None,
                         js_failed: None,
+                        worker: None,
                         failure_kind: None,
                         error: Some(format!("HTTP {status} — site blocked request")),
                     };
@@ -1019,6 +1225,7 @@ async fn cover_single(
                 js_total_scripts: None,
                 js_succeeded: None,
                 js_failed: None,
+                worker: None,
                 failure_kind: Some(kind),
                 error: Some(msg),
             };
@@ -1050,6 +1257,7 @@ async fn cover_single(
             js_total_scripts: None,
             js_succeeded: None,
             js_failed: None,
+            worker: None,
             failure_kind: Some(FailureKind::NonHtml),
             error: Some("Non-HTML content-type".into()),
         };
@@ -1107,6 +1315,7 @@ async fn cover_single(
                     js_total_scripts: None,
                     js_succeeded: None,
                     js_failed: None,
+                    worker: None,
                     failure_kind: Some(FailureKind::PipelineError),
                     error: Some(format!("{e:?}")),
                 };
@@ -1164,6 +1373,7 @@ async fn cover_single(
         js_total_scripts: js_total,
         js_succeeded,
         js_failed,
+        worker: None,
         failure_kind: None,
         error: None,
     }
@@ -1188,10 +1398,12 @@ mod tests {
         let result = classify_worker_output(
             "https://example.test",
             123,
+            17,
             worker_output(ProcessOutcome::TimedOut),
         );
         assert!(matches!(result.failure_kind, Some(FailureKind::Timeout)));
         assert!(result.error.unwrap().contains("123ms"));
+        assert_eq!(result.worker.unwrap().duration_ms, 17);
     }
 
     #[test]
@@ -1199,12 +1411,14 @@ mod tests {
         let result = classify_worker_output(
             "https://example.test",
             123,
+            18,
             worker_output(ProcessOutcome::Signaled { signal: 9 }),
         );
         assert!(matches!(
             result.failure_kind,
             Some(FailureKind::WorkerCrash)
         ));
+        assert_eq!(result.worker.unwrap().signal, Some(9));
     }
 
     #[test]
@@ -1212,16 +1426,35 @@ mod tests {
         let result = classify_worker_output(
             "https://example.test",
             123,
+            19,
             worker_output(ProcessOutcome::Exited { code: 17 }),
         );
         assert!(matches!(result.failure_kind, Some(FailureKind::WorkerExit)));
+        assert_eq!(result.worker.unwrap().exit_code, Some(17));
+    }
+
+    #[test]
+    fn worker_oom_diagnostic_is_distinct_resource_exhaustion() {
+        let mut output = worker_output(ProcessOutcome::Signaled { signal: 6 });
+        output.stderr =
+            b"FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"
+                .to_vec();
+        let result = classify_worker_output("https://example.test", 123, 20, output);
+        assert!(matches!(
+            result.failure_kind,
+            Some(FailureKind::WorkerResourceExhaustion)
+        ));
+        let evidence = result.worker.unwrap();
+        assert_eq!(evidence.outcome, CoverageWorkerOutcome::ResourceExhaustion);
+        assert_eq!(evidence.signal, Some(6));
+        assert_eq!(evidence.duration_ms, 20);
     }
 
     #[test]
     fn malformed_worker_response_is_an_infrastructure_error() {
         let mut output = worker_output(ProcessOutcome::Exited { code: 0 });
         output.stdout = b"not-json".to_vec();
-        let result = classify_worker_output("https://example.test", 123, output);
+        let result = classify_worker_output("https://example.test", 123, 21, output);
         assert!(matches!(
             result.failure_kind,
             Some(FailureKind::WorkerProtocolError)
@@ -1265,16 +1498,22 @@ mod tests {
             },
             failed_result("failed".to_string(), FailureKind::HttpError, String::new()),
             failed_result("crash".to_string(), FailureKind::WorkerCrash, String::new()),
+            failed_result(
+                "resource".to_string(),
+                FailureKind::WorkerResourceExhaustion,
+                String::new(),
+            ),
             failed_result("timeout".to_string(), FailureKind::Timeout, String::new()),
         ];
         assert_eq!(
             classify_outcomes(&results),
             CoverageOutcomes {
-                inputs_total: 5,
+                inputs_total: 6,
                 success: 1,
                 blocked: 1,
                 failed: 1,
                 crash: 1,
+                resource_exhaustion: 1,
                 timeout: 1,
             }
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1817,7 +1817,7 @@ async fn cmd_coverage(
         report.summary.ok as f64 / report.summary.urls_total as f64 * 100.0
     };
     println!(
-        "Coverage: overall {} / {} ({:.1}%); parseable-site {} / {} ({:.1}%, excludes blocked); blocked {}; failed {}; worker crashes {}; worker exits {}; infrastructure failures {}; median compression {:.1}x",
+        "Coverage: overall {} / {} ({:.1}%); parseable-site {} / {} ({:.1}%, excludes blocked); blocked {}; failed {}; worker crashes {}; worker resource exhaustions {}; worker exits {}; infrastructure failures {}; median compression {:.1}x",
         report.summary.ok,
         report.summary.urls_total,
         overall_percent,
@@ -1827,6 +1827,7 @@ async fn cmd_coverage(
         report.summary.blocked,
         report.summary.failed,
         report.summary.worker_crashes,
+        report.summary.worker_resource_exhaustions,
         report.summary.worker_exits,
         report.summary.infrastructure_failures,
         report.summary.median_ratio

--- a/src/network/fetch.rs
+++ b/src/network/fetch.rs
@@ -467,18 +467,14 @@ async fn fetch_url_inner_with_policy(
                         "redirect response missing a valid Location".into(),
                     )
                 })?;
-            let next = current.join(location).map_err(|e| {
-                FetchError::NavigationFailed(format!("invalid redirect Location: {e}"))
-            })?;
-            if same_origin_only && origin_key(&next) != initial_origin {
-                return Err(FetchError::UrlBlocked(
-                    "cross-origin redirect is not allowed for this operation".to_string(),
-                ));
-            }
-            current = policy
-                .validate_url(next.as_str())
-                .await
-                .map_err(FetchError::UrlBlocked)?;
+            current = validated_redirect_target(
+                &current,
+                location,
+                &initial_origin,
+                same_origin_only,
+                policy,
+            )
+            .await?;
             continue;
         }
 
@@ -491,6 +487,27 @@ async fn fetch_url_inner_with_policy(
     }
 
     Err(FetchError::TooManyRedirects(limits.max_redirects))
+}
+
+async fn validated_redirect_target(
+    current: &Url,
+    location: &str,
+    initial_origin: &(String, String, Option<u16>),
+    same_origin_only: bool,
+    policy: OutboundUrlPolicy,
+) -> Result<Url, FetchError> {
+    let next = current
+        .join(location)
+        .map_err(|e| FetchError::NavigationFailed(format!("invalid redirect Location: {e}")))?;
+    if same_origin_only && origin_key(&next) != *initial_origin {
+        return Err(FetchError::UrlBlocked(
+            "cross-origin redirect is not allowed for this operation".to_string(),
+        ));
+    }
+    policy
+        .validate_url(next.as_str())
+        .await
+        .map_err(FetchError::UrlBlocked)
 }
 
 fn document_request(client: &Client, url: &str) -> reqwest::RequestBuilder {
@@ -697,6 +714,25 @@ mod security_tests {
         format!("http://{address}/")
     }
 
+    async fn redirect_loop_fixture_server(requests: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            for _ in 0..requests {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = [0u8; 1024];
+                let _ = stream.read(&mut request).await;
+                stream
+                    .write_all(
+                        b"HTTP/1.1 302 Found\r\nLocation: /loop\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            }
+        });
+        format!("http://{address}/loop")
+    }
+
     fn fixture_client() -> Client {
         Client::builder()
             .redirect(reqwest::redirect::Policy::none())
@@ -760,6 +796,42 @@ mod security_tests {
         )
         .await;
         assert!(matches!(result, Err(FetchError::UrlBlocked(_))));
+    }
+
+    #[tokio::test]
+    async fn public_redirect_to_private_destination_is_blocked_before_request() {
+        let current = Url::parse("https://public.example/start").unwrap();
+        let initial_origin = origin_key(&current);
+        let result = validated_redirect_target(
+            &current,
+            "http://127.0.0.1/private",
+            &initial_origin,
+            false,
+            OutboundUrlPolicy::deny_private_network(),
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::UrlBlocked(_))));
+    }
+
+    #[tokio::test]
+    async fn redirect_loop_stops_at_configured_count() {
+        let limits = FetchLimits {
+            max_compressed_bytes: 100,
+            max_body_bytes: 100,
+            max_redirects: 2,
+        };
+        let url = redirect_loop_fixture_server(limits.max_redirects + 1).await;
+        let result = fetch_url_inner_with_policy(
+            &fixture_client(),
+            &url,
+            1_000,
+            None,
+            limits,
+            OutboundUrlPolicy::for_test_fixtures(),
+            false,
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::TooManyRedirects(2))));
     }
 
     #[tokio::test]
@@ -831,6 +903,29 @@ mod security_tests {
         )
         .await;
         assert!(matches!(result, Err(FetchError::BodyTooLarge { limit: 4 })));
+    }
+
+    #[tokio::test]
+    async fn oversized_chunked_wire_body_stops_at_hard_limit() {
+        let url = fixture_server(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n4\r\n0123\r\n4\r\n4567\r\n0\r\n\r\n",
+        )
+        .await;
+        let result = fetch_url_inner_with_policy(
+            &fixture_client(),
+            &url,
+            1_000,
+            None,
+            FetchLimits {
+                max_compressed_bytes: 6,
+                max_body_bytes: 100,
+                max_redirects: 1,
+            },
+            OutboundUrlPolicy::for_test_fixtures(),
+            false,
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::BodyTooLarge { limit: 6 })));
     }
 
     #[test]

--- a/src/network/security.rs
+++ b/src/network/security.rs
@@ -256,8 +256,35 @@ mod tests {
         assert!(policy.validate_url_syntax("file:///etc/passwd").is_err());
         assert!(policy.validate_url_syntax("ftp://example.com/a").is_err());
         assert!(policy
+            .validate_url_syntax("data:text/plain,secret")
+            .is_err());
+        assert!(policy
+            .validate_url_syntax("unix:///var/run/docker.sock")
+            .is_err());
+        assert!(policy
+            .validate_url_syntax("http+unix://%2Fvar%2Frun%2Fdocker.sock/info")
+            .is_err());
+        assert!(policy.validate_url_syntax("not a URL").is_err());
+        assert!(policy.validate_url_syntax("http://[::1").is_err());
+        assert!(policy
             .validate_url_syntax("https://user:pass@example.com")
             .is_err());
+    }
+
+    #[test]
+    fn rejects_whatwg_numeric_ipv4_forms_that_normalize_to_loopback() {
+        let policy = OutboundUrlPolicy::deny_private_network();
+        for value in [
+            "http://2130706433/",
+            "http://0x7f000001/",
+            "http://017700000001/",
+            "http://127.1/",
+        ] {
+            assert!(
+                policy.validate_url_syntax(value).is_err(),
+                "allowed numeric loopback form {value}"
+            );
+        }
     }
 
     #[test]

--- a/tests/coverage_containment_test.rs
+++ b/tests/coverage_containment_test.rs
@@ -1,0 +1,137 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use plasmate::coverage::runner::{
+    self, CoverageOptions, CoverageStatus, CoverageWorkerOutcome, FailureKind,
+};
+
+fn fixture_path() -> PathBuf {
+    static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+    FIXTURE
+        .get_or_init(|| {
+            let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/coverage_worker_fixture.rs");
+            // Independent cargo invocations can run this test concurrently in
+            // the same worktree. A process-unique path prevents one rustc from
+            // replacing the fixture while another test process is executing it.
+            let mut output = PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+                .join(format!("coverage-worker-fixture-{}", std::process::id()));
+            if cfg!(windows) {
+                output.set_extension("exe");
+            }
+            let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+            let compilation = Command::new(rustc)
+                .args(["--edition=2021", "--crate-name", "coverage_worker_fixture"])
+                .arg(&source)
+                .arg("-o")
+                .arg(&output)
+                .output()
+                .expect("failed to launch rustc for coverage worker fixture");
+            assert!(
+                compilation.status.success(),
+                "fixture compilation failed: {}",
+                String::from_utf8_lossy(&compilation.stderr)
+            );
+            output
+        })
+        .clone()
+}
+
+#[tokio::test]
+async fn coordinator_continues_after_every_worker_failure_class() {
+    let urls: Vec<String> = [
+        "exit",
+        "abort",
+        "hang",
+        "output",
+        "malformed",
+        "resource",
+        "page_error",
+        "blocked",
+        "success",
+    ]
+    .into_iter()
+    .map(|mode| format!("https://fixture.invalid/__fixture_{mode}__"))
+    .collect();
+    let options = CoverageOptions {
+        concurrency: 1,
+        timeout_ms: 1_000,
+        worker_output_bytes: 4096,
+        worker_executable: Some(fixture_path()),
+        max_urls: None,
+        ..CoverageOptions::default()
+    };
+
+    let report = tokio::time::timeout(Duration::from_secs(15), runner::run(&urls, &options))
+        .await
+        .expect("coverage coordinator exceeded its bounded deadline");
+    assert_eq!(report.results.len(), urls.len());
+
+    let result = |mode: &str| {
+        report
+            .results
+            .iter()
+            .find(|result| result.input_url.contains(&format!("__fixture_{mode}__")))
+            .unwrap_or_else(|| panic!("missing result for {mode}"))
+    };
+
+    assert!(
+        matches!(
+            result("exit").failure_kind.as_ref(),
+            Some(FailureKind::WorkerExit)
+        ),
+        "{:#?}",
+        report.results
+    );
+    assert_eq!(result("exit").worker.as_ref().unwrap().exit_code, Some(23));
+    assert!(matches!(
+        result("abort").failure_kind.as_ref(),
+        Some(FailureKind::WorkerCrash)
+    ));
+    assert!(result("abort").worker.as_ref().unwrap().signal.is_some() || cfg!(windows));
+    assert!(matches!(
+        result("hang").failure_kind.as_ref(),
+        Some(FailureKind::Timeout)
+    ));
+    assert_eq!(
+        result("output").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::OutputLimit
+    );
+    assert_eq!(
+        result("malformed").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::MalformedOutput
+    );
+    assert!(matches!(
+        result("resource").failure_kind.as_ref(),
+        Some(FailureKind::WorkerResourceExhaustion)
+    ));
+    assert_eq!(
+        result("resource").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::ResourceExhaustion
+    );
+    assert!(matches!(
+        &result("page_error").status,
+        CoverageStatus::Failed
+    ));
+    assert_eq!(
+        result("page_error").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::PageError
+    );
+    assert!(matches!(&result("blocked").status, CoverageStatus::Blocked));
+    assert_eq!(
+        result("blocked").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::Blocked
+    );
+    assert!(matches!(&result("success").status, CoverageStatus::Ok));
+    assert_eq!(
+        result("success").worker.as_ref().unwrap().outcome,
+        CoverageWorkerOutcome::Success
+    );
+    assert!(report.results.iter().all(|result| result
+        .worker
+        .as_ref()
+        .is_some_and(|worker| worker.duration_ms < 10_000)));
+}

--- a/tests/fixtures/coverage_worker_fixture.rs
+++ b/tests/fixtures/coverage_worker_fixture.rs
@@ -1,0 +1,60 @@
+use std::io::{Read, Write};
+use std::time::Duration;
+
+fn input_url(request: &str) -> String {
+    let marker = "\"input_url\":\"";
+    let start = request.find(marker).expect("input_url") + marker.len();
+    let remainder = &request[start..];
+    let end = remainder.find('"').expect("input_url terminator");
+    remainder[..end].to_string()
+}
+
+fn valid_result(url: &str, status: &str) -> String {
+    let (failure_kind, error) = match status {
+        "ok" | "blocked" => ("null", "null"),
+        "failed" => ("\"http_error\"", "\"ordinary page error\""),
+        _ => panic!("unsupported fixture status"),
+    };
+    format!(
+        "{{\"input_url\":\"{url}\",\"final_url\":null,\"status\":\"{status}\",\"http_status\":null,\"content_type\":null,\"title\":null,\"html_bytes\":null,\"som_bytes\":null,\"compression_ratio\":null,\"element_count\":null,\"interactive_count\":null,\"fetch_ms\":null,\"pipeline_ms\":null,\"js_total_scripts\":null,\"js_succeeded\":null,\"js_failed\":null,\"failure_kind\":{failure_kind},\"error\":{error}}}"
+    )
+}
+
+fn main() {
+    let mut request = String::new();
+    std::io::stdin().read_to_string(&mut request).unwrap();
+    let url = input_url(&request);
+
+    if url.contains("__fixture_exit__") {
+        std::process::exit(23);
+    }
+    if url.contains("__fixture_abort__") {
+        std::process::abort();
+    }
+    if url.contains("__fixture_hang__") {
+        std::thread::sleep(Duration::from_secs(60));
+        return;
+    }
+    if url.contains("__fixture_output__") {
+        std::io::stdout().write_all(&vec![b'x'; 1024 * 1024]).unwrap();
+        return;
+    }
+    if url.contains("__fixture_malformed__") {
+        println!("not-json");
+        return;
+    }
+    if url.contains("__fixture_resource__") {
+        eprintln!("FATAL ERROR: Allocation failed - JavaScript heap out of memory");
+        std::process::abort();
+    }
+    if url.contains("__fixture_page_error__") {
+        println!("{}", valid_result(&url, "failed"));
+        return;
+    }
+    if url.contains("__fixture_blocked__") {
+        println!("{}", valid_result(&url, "blocked"));
+        return;
+    }
+
+    println!("{}", valid_result(&url, "ok"));
+}


### PR DESCRIPTION
## Outcome

Closes the remaining in-repository P0 containment and security-test gaps without adding any calendar freeze. This is the identical reviewed SHA from #52, reissued from the organization branch because Vercel rejected fork authorization despite all 13 protected checks passing.

- bounds CI fixture servers with readiness, liveness, timeouts, and EXIT cleanup
- adds missing SSRF, redirect-loop, malformed URL, numeric-host, and oversized chunked-body regressions
- records supervised coverage worker exit/signal/duration/diagnostic evidence
- separates blocked, crash, timeout, and resource-exhaustion outcomes
- proves the coordinator continues through every worker failure class

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --locked
- cargo test --workspace --locked --all-features
- targeted network/security suites
- coverage containment integration test, three consecutive passes
- workflow action pin validation (47 pins)

External release-secret placement and final exact-SHA evidence remain operational follow-ups; they are not hidden by this PR.