### PR TITLE
fix(p1): propagate containment and pin module corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,9 @@ jobs:
       - name: V8 compatibility contract
         run: python3 scripts/check-v8-compatibility.py
 
+      - name: Focused WPT module corpus contract
+        run: python3 scripts/check-wpt-module-corpus.py
+
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/scripts/action-manifest-conformance.sh
+++ b/scripts/action-manifest-conformance.sh
@@ -61,6 +61,10 @@ run_in() {
   )
 }
 
+run_in "." \
+  "Focused WPT module corpus contract" \
+  "$PYTHON" scripts/check-wpt-module-corpus.py
+
 if [ "$MODE" = "--quick" ]; then
   run_in "packages/som-parser-python" \
     "Python parser action manifest" \

--- a/scripts/check-wpt-module-corpus.py
+++ b/scripts/check-wpt-module-corpus.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Validate the pinned, reduced WPT module corpus without network access."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+
+SCHEMA = "plasmate.wpt-module-corpus.v1"
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+GIT_SHA = re.compile(r"[0-9a-f]{40}\Z")
+WPT_PREFIX = "html/semantics/scripting-1/the-script-element/module/"
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def validate(root: Path, manifest_path: Path, upstream_root: Path | None) -> list[str]:
+    errors: list[str] = []
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return [f"cannot read manifest {manifest_path}: {error}"]
+
+    if manifest.get("schema") != SCHEMA:
+        fail(errors, f"schema must be {SCHEMA!r}")
+    upstream = manifest.get("upstream", {})
+    commit = upstream.get("commit", "")
+    if not GIT_SHA.fullmatch(commit):
+        fail(errors, "upstream.commit must be a full lowercase 40-character Git SHA")
+    if upstream.get("repository") != "https://github.com/web-platform-tests/wpt":
+        fail(errors, "upstream.repository must name the canonical WPT repository")
+
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or len(cases) < 6:
+        fail(errors, "cases must contain at least six focused module behaviors")
+        cases = []
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+    for index, case in enumerate(cases):
+        label = f"cases[{index}]"
+        case_id = case.get("id", "")
+        if not case_id or case_id in seen_ids:
+            fail(errors, f"{label}.id must be non-empty and unique")
+        seen_ids.add(case_id)
+        upstream_path = case.get("upstream_path", "")
+        if not upstream_path.startswith(WPT_PREFIX) or ".." in Path(upstream_path).parts:
+            fail(errors, f"{label}.upstream_path must stay inside the WPT module corpus")
+        if upstream_path in seen_paths:
+            fail(errors, f"{label}.upstream_path is duplicated")
+        seen_paths.add(upstream_path)
+        expected_upstream = case.get("upstream_sha256", "")
+        if not SHA256.fullmatch(expected_upstream):
+            fail(errors, f"{label}.upstream_sha256 must be a lowercase SHA-256")
+        if upstream_root is not None:
+            source = upstream_root / upstream_path
+            if not source.is_file():
+                fail(errors, f"{label} upstream source is missing: {source}")
+            elif digest(source) != expected_upstream:
+                fail(errors, f"{label} upstream source hash drifted at pinned commit {commit}")
+        relationship = case.get("relationship")
+        if relationship not in {"reduced_behavior", "documented_scope_boundary"}:
+            fail(errors, f"{label}.relationship is not recognized")
+        assertions = case.get("local_assertions")
+        if not isinstance(assertions, list) or not assertions:
+            fail(errors, f"{label}.local_assertions must be non-empty")
+            continue
+        for assertion in assertions:
+            if not isinstance(assertion, str) or "::" not in assertion:
+                fail(errors, f"{label} has malformed local assertion {assertion!r}")
+                continue
+            relative, test_name = assertion.rsplit("::", 1)
+            local_file = root / relative
+            if not local_file.is_file():
+                fail(errors, f"{label} local assertion file is missing: {relative}")
+                continue
+            marker = re.compile(rf"\bfn\s+{re.escape(test_name)}\s*\(")
+            if not marker.search(local_file.read_text(encoding="utf-8")):
+                fail(errors, f"{label} local assertion drifted: {assertion}")
+
+    fixtures = manifest.get("local_fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        fail(errors, "local_fixtures must be non-empty")
+        fixtures = []
+    for index, fixture in enumerate(fixtures):
+        relative = fixture.get("path", "")
+        expected = fixture.get("sha256", "")
+        path = root / relative
+        if not path.is_file():
+            fail(errors, f"local_fixtures[{index}] is missing: {relative}")
+        elif not SHA256.fullmatch(expected):
+            fail(errors, f"local_fixtures[{index}].sha256 is malformed")
+        elif digest(path) != expected:
+            fail(errors, f"local fixture hash drifted without manifest review: {relative}")
+
+    provenance = root / "tests/fixtures/js-modules/PROVENANCE.md"
+    if not provenance.is_file():
+        fail(errors, "module corpus provenance document is missing")
+    else:
+        text = provenance.read_text(encoding="utf-8")
+        if commit and commit not in text:
+            fail(errors, "provenance document does not name the pinned WPT commit")
+        if "wpt-corpus.json" not in text:
+            fail(errors, "provenance document does not name the machine-readable manifest")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--manifest", default="tests/fixtures/js-modules/wpt-corpus.json"
+    )
+    parser.add_argument(
+        "--upstream-root",
+        help="optional WPT checkout at the manifest commit; verifies upstream hashes",
+    )
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    manifest_path = root / args.manifest
+    upstream_root = Path(args.upstream_root).resolve() if args.upstream_root else None
+    errors = validate(root, manifest_path, upstream_root)
+    if errors:
+        for error in errors:
+            print(f"WPT module corpus error: {error}", file=sys.stderr)
+        return 1
+    print(f"WPT module corpus is pinned and internally consistent: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/awp/handler.rs
+++ b/src/awp/handler.rs
@@ -335,11 +335,16 @@ async fn handle_page_navigate(
             });
 
             if let Some(js) = &result.js_report {
-                response["js"] = json!({
+                let mut js_summary = json!({
                     "scripts_total": js.total,
                     "scripts_ok": js.succeeded,
                     "scripts_err": js.failed,
                 });
+                if let Some(failure) = &js.containment_failure {
+                    js_summary["containment_failure"] = json!(failure);
+                    js_summary["source_som_fallback"] = json!(true);
+                }
+                response["js"] = js_summary;
             }
 
             Response::success(id, response)

--- a/src/awp/session.rs
+++ b/src/awp/session.rs
@@ -234,6 +234,7 @@ impl Session {
             total: r.total,
             succeeded: r.succeeded,
             failed: r.failed,
+            containment_failure: r.containment_failure.clone(),
         });
 
         // Update session state - rotate previous SOM before updating current
@@ -313,6 +314,7 @@ impl Session {
             total: r.total,
             succeeded: r.succeeded,
             failed: r.failed,
+            containment_failure: r.containment_failure.clone(),
         });
 
         self.current_url = Some(final_url.clone());
@@ -379,4 +381,5 @@ pub struct JsReportSummary {
     pub total: usize,
     pub succeeded: usize,
     pub failed: usize,
+    pub containment_failure: Option<crate::js::worker::JsContainmentFailure>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Parser, Subcommand};
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 mod mcp;
@@ -1521,6 +1521,15 @@ async fn cmd_fetch(
             err = report.failed,
             "JS execution"
         );
+        if let Some(failure) = &report.containment_failure {
+            warn!(
+                kind = ?failure.kind,
+                code = %failure.code,
+                message = %failure.message,
+                source_som_fallback = true,
+                "JavaScript worker was contained; returning the source SOM fallback"
+            );
+        }
     }
 
     info!(

--- a/src/mcp/sessions.rs
+++ b/src/mcp/sessions.rs
@@ -14,6 +14,7 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::cdp::session::CdpTarget;
+use crate::js::worker::JsWorkerOptions;
 use crate::mcp::trace::{
     self, PendingTraceEvent, ReplayRequest, TraceAttempt, TraceExport, TraceLog, TraceStatus,
 };
@@ -84,6 +85,7 @@ impl SessionState {
 /// Thread-safe with interior mutability via RwLock.
 pub struct SessionManager {
     sessions: Arc<RwLock<HashMap<String, SessionState>>>,
+    js_worker_options: Arc<JsWorkerOptions>,
 }
 
 impl Default for SessionManager {
@@ -95,9 +97,23 @@ impl Default for SessionManager {
 impl SessionManager {
     /// Create a new session manager.
     pub fn new() -> Self {
+        Self::with_worker_options(JsWorkerOptions::default())
+    }
+
+    /// Construct a manager with an explicit stateful-evaluation worker policy.
+    ///
+    /// Production callers use [`Self::new`]. The explicit constructor keeps
+    /// crash, timeout, and output-limit behavior directly testable without
+    /// process-global environment overrides.
+    pub fn with_worker_options(js_worker_options: JsWorkerOptions) -> Self {
         SessionManager {
             sessions: Arc::new(RwLock::new(HashMap::new())),
+            js_worker_options: Arc::new(js_worker_options),
         }
+    }
+
+    pub(crate) fn js_worker_options(&self) -> JsWorkerOptions {
+        self.js_worker_options.as_ref().clone()
     }
 
     /// Generate a new unique session ID.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -22,7 +22,7 @@ use crate::cache::store::{CacheLookup, SomCache};
 use crate::cdp::cookies::{cookie_from_cdp_params, Cookie};
 use crate::js::pipeline::{self, PipelineConfig};
 use crate::js::runtime::RuntimeConfig;
-use crate::js::worker::{self, EvaluationRequest, EvaluationResponse, JsWorkerOptions};
+use crate::js::worker::{self, EvaluationRequest, EvaluationResponse, JsWorkerError};
 use crate::network::fetch;
 use crate::som::types::Som;
 
@@ -258,11 +258,12 @@ fn store_page_state_in_session(
 }
 
 async fn run_session_javascript(
+    sessions: &SessionManager,
     effective_html: String,
     url: String,
     expression: String,
     return_effective_html: bool,
-) -> Result<EvaluationResponse, String> {
+) -> Result<EvaluationResponse, JsWorkerError> {
     worker::evaluate(
         EvaluationRequest {
             protocol_version: worker::WORKER_PROTOCOL_VERSION.to_string(),
@@ -276,20 +277,43 @@ async fn run_session_javascript(
                 ..Default::default()
             },
         },
-        JsWorkerOptions::default(),
+        sessions.js_worker_options(),
     )
     .await
-    .map_err(|error| format!("JavaScript containment error [{}]: {error}", error.code()))
 }
 
-fn mutation_output(response: EvaluationResponse) -> Result<(String, String), String> {
+fn mutation_output(response: EvaluationResponse) -> Result<(String, String), JsWorkerError> {
     response
         .effective_html
         .map(|html| (response.result, html))
         .ok_or_else(|| {
-            "JavaScript containment error [js_worker_protocol]: mutating worker response omitted effective HTML"
-                .to_string()
+            JsWorkerError::Protocol("mutating worker response omitted effective HTML".to_string())
         })
+}
+
+fn containment_error_response(context: &str, error: &JsWorkerError) -> Value {
+    let failure = error.containment_failure();
+    error_response(
+        &json!({
+            "error": format!("{context}: {error}"),
+            "containment_failure": failure,
+            "state_preserved": true,
+        })
+        .to_string(),
+    )
+}
+
+fn js_report_summary(report: &crate::js::runtime::JsExecutionReport) -> Value {
+    let mut summary = json!({
+        "scripts_total": report.total,
+        "scripts_ok": report.succeeded,
+        "scripts_err": report.failed,
+    });
+    if let Some(failure) = &report.containment_failure {
+        summary["containment_failure"] = json!(failure);
+        summary["source_som_fallback"] = Value::Bool(true);
+    }
+    summary
 }
 
 async fn load_session_page_for_mcp(
@@ -1675,19 +1699,26 @@ pub async fn handle_open_page(
         }
     };
 
-    // Return session ID + SOM
+    let mut payload = json!({
+        "session_id": session_id,
+        "title": page_result.som.title,
+        "url": final_url,
+        "cache_restored": cache_restored,
+        "regions": som_json.get("regions"),
+        "webmcp": page_result.webmcp
+    });
+    if let Some(report) = &page_result.js_report {
+        payload["js"] = js_report_summary(report);
+    }
+
+    // Return session ID + SOM. A contained page-worker failure is successful
+    // structured fallback, so expose it in the JS summary instead of turning
+    // the whole tool call into an error.
     json!({
         "content": [
             {
                 "type": "text",
-                "text": json!({
-                    "session_id": session_id,
-                    "title": page_result.som.title,
-                    "url": final_url,
-                    "cache_restored": cache_restored,
-                    "regions": som_json.get("regions"),
-                    "webmcp": page_result.webmcp
-                }).to_string()
+                "text": payload.to_string()
             }
         ]
     })
@@ -1732,7 +1763,8 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
         "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
         expression
     );
-    let eval_result = run_session_javascript(effective_html, url, wrapped_expr, false).await;
+    let eval_result =
+        run_session_javascript(sessions, effective_html, url, wrapped_expr, false).await;
 
     match eval_result {
         Ok(response) => {
@@ -1757,7 +1789,7 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
                 ]
             })
         }
-        Err(error) => error_response(&error),
+        Err(error) => containment_error_response("Evaluate failed", &error),
     }
 }
 
@@ -1865,15 +1897,14 @@ pub async fn handle_click(
             .replace('\n', " ")
     );
 
-    let click_result = run_session_javascript(effective_html, url.clone(), click_js, true).await;
+    let click_result =
+        run_session_javascript(sessions, effective_html, url.clone(), click_js, true).await;
     let (click_result_json, updated_html) = match click_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Click failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Click failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Click failed", &error),
     };
 
     // Parse click result to check for navigation
@@ -2334,15 +2365,14 @@ pub async fn handle_type_text(
         text,
         if append { "true" } else { "false" },
     );
-    let type_result = run_session_javascript(effective_html, url.clone(), type_js, true).await;
+    let type_result =
+        run_session_javascript(sessions, effective_html, url.clone(), type_js, true).await;
     let (result_json, updated_html) = match type_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Type failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Type failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Type failed", &error),
     };
 
     // Check for errors from JS
@@ -2461,15 +2491,14 @@ pub async fn handle_select_option(
             "#,
         element_id, escaped_value, escaped_value, escaped_value
     );
-    let select_result = run_session_javascript(effective_html, url.clone(), select_js, true).await;
+    let select_result =
+        run_session_javascript(sessions, effective_html, url.clone(), select_js, true).await;
     let (result_json, updated_html) = match select_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Select failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Select failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Select failed", &error),
     };
 
     // Check for errors from JS
@@ -2591,15 +2620,14 @@ pub async fn handle_scroll(
             scroll_action
         )
     };
-    let scroll_result = run_session_javascript(effective_html, url.clone(), scroll_js, true).await;
+    let scroll_result =
+        run_session_javascript(sessions, effective_html, url.clone(), scroll_js, true).await;
     let (result_json, updated_html) = match scroll_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Scroll failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Scroll failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Scroll failed", &error),
     };
 
     // Check for errors from JS
@@ -2719,15 +2747,14 @@ pub async fn handle_toggle(
             "#,
         element_id
     );
-    let toggle_result = run_session_javascript(effective_html, url.clone(), toggle_js, true).await;
+    let toggle_result =
+        run_session_javascript(sessions, effective_html, url.clone(), toggle_js, true).await;
     let (result_json, updated_html) = match toggle_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Toggle failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Toggle failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Toggle failed", &error),
     };
 
     // Check for errors from JS
@@ -2833,15 +2860,14 @@ pub async fn handle_clear(
             "#,
         element_id
     );
-    let clear_result = run_session_javascript(effective_html, url.clone(), clear_js, true).await;
+    let clear_result =
+        run_session_javascript(sessions, effective_html, url.clone(), clear_js, true).await;
     let (result_json, updated_html) = match clear_result {
         Ok(response) => match mutation_output(response) {
             Ok(output) => output,
-            Err(error) => return error_response(&error),
+            Err(error) => return containment_error_response("Clear failed", &error),
         },
-        Err(error) => {
-            return error_response(&format!("Clear failed: {error}"));
-        }
+        Err(error) => return containment_error_response("Clear failed", &error),
     };
 
     // Check for errors from JS
@@ -3238,12 +3264,184 @@ fn cookie_to_json(cookie: &Cookie) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::sync::OnceLock;
+    use std::time::{Duration, Instant};
+
     use super::*;
     use crate::cache::store::CacheConfig;
     use crate::cdp::session::CdpTarget;
     use crate::js::pipeline::{PageResult, PipelineTiming};
     use crate::som::metadata::StructuredData;
     use crate::som::types::{Element, ElementRole, Region, RegionRole, ShadowRoot, SomMeta};
+
+    fn stateful_worker_fixture() -> PathBuf {
+        static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+        FIXTURE
+            .get_or_init(|| {
+                let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests/fixtures/js_worker_fixture.rs");
+                let mut output = std::env::temp_dir().join(format!(
+                    "plasmate-stateful-mcp-worker-fixture-{}",
+                    std::process::id()
+                ));
+                if cfg!(windows) {
+                    output.set_extension("exe");
+                }
+                let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+                let compilation = std::process::Command::new(rustc)
+                    .args([
+                        "--edition=2021",
+                        "--crate-name",
+                        "stateful_mcp_worker_fixture",
+                    ])
+                    .arg(&source)
+                    .arg("-o")
+                    .arg(&output)
+                    .output()
+                    .expect("failed to launch rustc for stateful MCP worker fixture");
+                assert!(
+                    compilation.status.success(),
+                    "fixture compilation failed: {}",
+                    String::from_utf8_lossy(&compilation.stderr)
+                );
+                output
+            })
+            .clone()
+    }
+
+    fn stateful_worker_options(timeout: Duration) -> worker::JsWorkerOptions {
+        worker::JsWorkerOptions {
+            executable: Some(stateful_worker_fixture()),
+            timeout,
+            max_stdout_bytes: 4096,
+            max_stderr_bytes: 4096,
+            memory_limit_bytes: 0,
+        }
+    }
+
+    async fn seeded_stateful_session(
+        options: worker::JsWorkerOptions,
+    ) -> (Arc<SessionManager>, String) {
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        sessions
+            .with_session(&session_id, |session| {
+                let html = "<html><head><title>Last good</title></head><body><main id='state'>safe</main></body></html>";
+                session.target.current_url = Some("https://example.test/state".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/state").unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        (sessions, session_id)
+    }
+
+    fn tool_payload(response: &Value) -> Value {
+        serde_json::from_str(response["content"][0]["text"].as_str().unwrap()).unwrap()
+    }
+
+    async fn state_fingerprint(sessions: &SessionManager, session_id: &str) -> String {
+        sessions
+            .with_session(session_id, |session| {
+                let mut nodes: Vec<_> = session
+                    .target
+                    .node_map
+                    .iter()
+                    .map(|(id, node)| {
+                        (
+                            *id,
+                            node.backend_node_id,
+                            node.som_element_id.clone(),
+                            node.node_type,
+                            node.node_name.clone(),
+                            node.node_value.clone(),
+                            node.children_ids.clone(),
+                        )
+                    })
+                    .collect();
+                nodes.sort_by_key(|node| node.0);
+                serde_json::to_string(&json!({
+                    "url": session.target.current_url,
+                    "html": session.target.current_html,
+                    "effective_html": session.target.effective_html,
+                    "som": session.target.current_som,
+                    "nodes": nodes,
+                }))
+                .unwrap()
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn stateful_mcp_worker_crash_preserves_last_good_state_and_coordinator() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let (sessions, session_id) = seeded_stateful_session(options).await;
+        let before = state_fingerprint(&sessions, &session_id).await;
+
+        let failed = handle_evaluate(
+            &json!({"session_id": session_id, "expression": "'__fixture_abort__'"}),
+            &sessions,
+        )
+        .await;
+        assert_eq!(failed["isError"], true);
+        let failure = tool_payload(&failed);
+        assert!(matches!(
+            failure["containment_failure"]["kind"].as_str(),
+            Some("crash" | "exit")
+        ));
+        assert_eq!(failure["state_preserved"], true);
+        assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+
+        let survived = handle_evaluate(
+            &json!({"session_id": session_id, "expression": "1 + 1"}),
+            &sessions,
+        )
+        .await;
+        assert!(survived.get("isError").is_none(), "{survived}");
+        assert_eq!(tool_payload(&survived)["result"], "ok");
+        assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn stateful_mcp_worker_timeout_preserves_last_good_state_and_coordinator() {
+        // Leave enough startup margin for saturated CI hosts while still
+        // proving that the 60-second fixture hang is coordinator-bounded.
+        let options = stateful_worker_options(Duration::from_millis(750));
+        let (sessions, session_id) = seeded_stateful_session(options).await;
+        let before = state_fingerprint(&sessions, &session_id).await;
+        let started = Instant::now();
+
+        let failed = handle_evaluate(
+            &json!({"session_id": session_id, "expression": "'__fixture_hang__'"}),
+            &sessions,
+        )
+        .await;
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert_eq!(failed["isError"], true);
+        let failure = tool_payload(&failed);
+        assert_eq!(failure["containment_failure"]["kind"], "timeout");
+        assert_eq!(failure["containment_failure"]["code"], "js_worker_timeout");
+        assert_eq!(failure["state_preserved"], true);
+        assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+
+        let survived = handle_evaluate(
+            &json!({"session_id": session_id, "expression": "1 + 1"}),
+            &sessions,
+        )
+        .await;
+        assert!(survived.get("isError").is_none(), "{survived}");
+        assert_eq!(tool_payload(&survived)["result"], "ok");
+        assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+    }
 
     #[test]
     fn ard_discover_schema_and_runtime_reject_unknown_arguments() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -112,6 +112,7 @@ pub struct JsReportSummary {
     pub total: usize,
     pub succeeded: usize,
     pub failed: usize,
+    pub containment_failure: Option<crate::js::worker::JsContainmentFailure>,
 }
 
 #[derive(Debug, Clone)]
@@ -253,6 +254,7 @@ impl Session {
             total: r.total,
             succeeded: r.succeeded,
             failed: r.failed,
+            containment_failure: r.containment_failure.clone(),
         });
 
         self.url = Some(final_url.clone());
@@ -519,6 +521,8 @@ pub struct JsReportInfo {
     pub total: usize,
     pub succeeded: usize,
     pub failed: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containment_failure: Option<crate::js::worker::JsContainmentFailure>,
 }
 
 async fn fetch_single(
@@ -565,6 +569,7 @@ async fn fetch_single(
             total: r.total,
             succeeded: r.succeeded,
             failed: r.failed,
+            containment_failure: r.containment_failure.clone(),
         }),
     })
 }

--- a/tests/fixtures/js-modules/PROVENANCE.md
+++ b/tests/fixtures/js-modules/PROVENANCE.md
@@ -1,13 +1,23 @@
 # Module conformance fixture provenance
 
 These fixtures are original, minimal Plasmate fixtures whose behavioral
-assertions are derived from the Web Platform Tests module-script coverage:
+assertions are derived from the Web Platform Tests module-script coverage.
+The source snapshot is pinned to WPT commit
+`ff372ea4a4b10d75830d4bad6445b2904d00a537` (checked 2026-07-20); this avoids
+quietly moving conformance evidence when WPT `master` changes.
 
 - `html/semantics/scripting-1/the-script-element/module/`
 - `html/semantics/scripting-1/the-script-element/moving-between-documents/`
 - `html/webappapis/dynamic-markup-insertion/opening-the-input-stream/`
 
-Upstream: <https://github.com/web-platform-tests/wpt/tree/master/html/semantics/scripting-1/the-script-element/module>
+The machine-readable case-to-test map, upstream source hashes, and local
+fixture hashes are in [`wpt-corpus.json`](wpt-corpus.json). CI runs
+`python3 scripts/check-wpt-module-corpus.py` to fail if a mapped assertion is
+renamed, a local fixture changes without review, or provenance becomes
+unpinned. Maintainers can additionally supply a checkout of that exact WPT
+commit with `--upstream-root` to verify the recorded upstream hashes.
+
+Upstream: <https://github.com/web-platform-tests/wpt/tree/ff372ea4a4b10d75830d4bad6445b2904d00a537/html/semantics/scripting-1/the-script-element/module>
 
 Standards references:
 

--- a/tests/fixtures/js-modules/wpt-corpus.json
+++ b/tests/fixtures/js-modules/wpt-corpus.json
@@ -1,0 +1,81 @@
+{
+  "schema": "plasmate.wpt-module-corpus.v1",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "commit": "ff372ea4a4b10d75830d4bad6445b2904d00a537",
+    "checked_at": "2026-07-20"
+  },
+  "scope": "A reduced, deterministic module-script behavior corpus for Plasmate's documented ES-module subset; it is not a claim of full WPT conformance.",
+  "cases": [
+    {
+      "id": "module-classic-order",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/module-vs-script-1.html",
+      "upstream_sha256": "cfb64e54d3b33bfe09d29532f42555e9eb049d3b0971adf770ff04417ae5dc8d",
+      "local_assertions": ["src/js/pipeline.rs::classic_scripts_run_before_deferred_modules_in_document_order"]
+    },
+    {
+      "id": "module-execution-order",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/execorder.html",
+      "upstream_sha256": "c917500fad786dfdc42fdf8efd80dc9a74ccee335d3a808ec28ef794306c8177",
+      "local_assertions": ["src/js/pipeline.rs::classic_scripts_run_before_deferred_modules_in_document_order"]
+    },
+    {
+      "id": "module-cycle-live-bindings",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/imports-cycle.js",
+      "upstream_sha256": "00a6dbb2040448d2f0144c307e7d7726cf4989805bb530ec0b13828139d1b623",
+      "local_assertions": ["src/js/runtime.rs::native_modules_preserve_bindings_cycles_strictness_and_import_meta"]
+    },
+    {
+      "id": "module-single-evaluation",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/duplicated-imports-1.html",
+      "upstream_sha256": "3a75e120c728ee5fad19493d7248f4427e519b183cf2cda5f8355891ac466306",
+      "local_assertions": ["src/js/runtime.rs::native_module_dependency_and_duplicate_root_evaluate_once"]
+    },
+    {
+      "id": "import-meta-url",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-url.html",
+      "upstream_sha256": "319810513b89bb1f0a9f276be8a1e368eb1bea8ce68f77e22f0929a554d80910",
+      "local_assertions": ["src/js/runtime.rs::native_modules_preserve_bindings_cycles_strictness_and_import_meta"]
+    },
+    {
+      "id": "module-mime-enforcement",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/errorhandling-wrongMimetype.js",
+      "upstream_sha256": "bf2db138b3074e7532a2920799f83226872384d2eff8a699f79ae0ddda72ee40",
+      "local_assertions": ["src/js/modules.rs::javascript_module_content_type_uses_exact_whatwg_essence_list"]
+    },
+    {
+      "id": "module-evaluation-errors",
+      "relationship": "reduced_behavior",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html",
+      "upstream_sha256": "e302fac0aef6be441ff87aa3c77e4bc1d47cbbb53616cc1246b0c347402709fb",
+      "local_assertions": ["src/js/runtime.rs::native_module_syntax_runtime_and_top_level_await_errors_are_explicit"]
+    },
+    {
+      "id": "dynamic-import-scope-boundary",
+      "relationship": "documented_scope_boundary",
+      "upstream_path": "html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports.html",
+      "upstream_sha256": "46813dc891f8d6f698564e3219207f7670d7979103ee565dd671f379905f60c1",
+      "local_assertions": ["src/js/runtime.rs::native_dynamic_import_is_rejected_and_reported"]
+    }
+  ],
+  "local_fixtures": [
+    {
+      "path": "tests/fixtures/js-modules/live-dependency.js",
+      "sha256": "366ab888dc7fc241d52174f84b97517f769951e2e05cfbb7ebba3731647a86db"
+    },
+    {
+      "path": "tests/fixtures/js-modules/live-main.js",
+      "sha256": "cf738841b6d61e524d4e164220492d105dcf6c152407f1929c42c273ca4e1047"
+    },
+    {
+      "path": "tests/fixtures/js-modules/ordering.html",
+      "sha256": "a0273b99a5694679335b909440711eb2eace13fbbb1da2cb565a6c9e3c69b90c"
+    }
+  ]
+}


### PR DESCRIPTION
## Outcome

Closes the remaining P1 containment-observability and module-conformance evidence gaps.

- propagates typed JavaScript containment failures through CLI, session, AWP, and MCP surfaces
- reports source-SOM fallback instead of silently returning degraded output
- returns state_preserved=true for contained stateful evaluate/mutation failures
- directly proves MCP worker crash and timeout preserve the complete last-good state and coordinator survival
- pins an eight-case focused WPT module corpus to an exact upstream commit, source hashes, local fixture hashes, and concrete Rust assertions
- runs offline corpus drift validation in CI and action-manifest conformance

V8 remains deliberately staged at the compatible v139/ICU74 boundary; this PR does not pretend a dependency-only upgrade is safe. The locked MCP 2026-07-28 release candidate is implemented separately and will be rechecked against the final publication without delaying this work.

## Verification

- cargo +1.88.0 test --workspace --locked --all-features
- focused stateful MCP crash/timeout tests after rebasing onto master
- cargo +1.88.0 check --workspace --locked --all-features
- exact upstream WPT hash verification plus offline validator
- cargo fmt --all --check
- diff check
- clippy with all non-pre-existing warnings denied