### PR TITLE
test(p2): require real Chrome containment evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,40 @@ jobs:
         working-directory: smoke
         run: npm ci
 
+      - name: Resolve Chrome rendering evidence binary
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        id: chrome-evidence-browser
+        shell: bash
+        run: |
+          chrome_bin=""
+          for candidate in google-chrome-stable google-chrome chromium chromium-browser; do
+            if resolved="$(type -P "$candidate" 2>/dev/null)"; then
+              chrome_bin="$resolved"
+              break
+            fi
+          done
+          if [[ -z "$chrome_bin" ]]; then
+            echo "Chrome rendering evidence requires Chrome or Chromium on the Ubuntu runner" >&2
+            exit 1
+          fi
+          chrome_bin="$(realpath -- "$chrome_bin")"
+          if [[ ! -f "$chrome_bin" || ! -x "$chrome_bin" ]]; then
+            echo "Resolved Chrome rendering evidence binary is not an executable file: $chrome_bin" >&2
+            exit 1
+          fi
+          timeout 15s "$chrome_bin" --version
+          printf 'binary=%s\n' "$chrome_bin" >> "$GITHUB_OUTPUT"
+
+      - name: Chrome rendering containment evidence
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          PLASMATE_CHROME_TEST_BINARY: ${{ steps.chrome-evidence-browser.outputs.binary }}
+          PLASMATE_REQUIRE_CHROME_EVIDENCE: '1'
+        run: >-
+          timeout 2m cargo test --locked --lib
+          screenshot::tests::chromium_boundary_blocks_script_execution_and_cross_file_rendering
+          -- --exact --nocapture
+
       - name: CDP smoke test (Puppeteer)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -97,6 +97,18 @@ pub enum ScreenshotError {
 
 /// Find Chrome/Chromium binary on the system.
 fn find_chrome() -> Option<String> {
+    // The dedicated rendering-evidence test must exercise the exact browser
+    // binary that CI resolved. Keep this override test-only so production
+    // discovery and user-facing behavior cannot be changed by an environment
+    // variable.
+    #[cfg(test)]
+    if let Some(candidate) = std::env::var_os("PLASMATE_CHROME_TEST_BINARY") {
+        let candidate = std::path::PathBuf::from(candidate);
+        return candidate
+            .is_file()
+            .then(|| candidate.to_string_lossy().into_owned());
+    }
+
     let candidates = [
         // macOS
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -513,6 +525,17 @@ pub fn som_fallback(som: &crate::som::types::Som) -> serde_json::Value {
 mod tests {
     use super::*;
 
+    fn should_skip_optional_chromium_test(
+        chrome_is_available: bool,
+        evidence_is_required: bool,
+    ) -> bool {
+        assert!(
+            chrome_is_available || !evidence_is_required,
+            "PLASMATE_REQUIRE_CHROME_EVIDENCE is set, but the exact Chrome/Chromium test binary is unavailable"
+        );
+        !chrome_is_available
+    }
+
     #[test]
     fn hardened_renderer_configuration_is_explicit_and_has_no_unsafe_file_switches() {
         let directory = std::path::Path::new("/owned-render-dir");
@@ -595,7 +618,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn chromium_boundary_blocks_script_execution_and_cross_file_rendering() {
-        if !chrome_available() {
+        let evidence_is_required = std::env::var_os("PLASMATE_REQUIRE_CHROME_EVIDENCE").is_some();
+        if should_skip_optional_chromium_test(chrome_available(), evidence_is_required) {
             return;
         }
 
@@ -649,6 +673,18 @@ mod tests {
             hostile_image, baseline_image,
             "script execution or cross-file rendering changed the pixels"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "the exact Chrome/Chromium test binary is unavailable")]
+    fn required_chromium_evidence_cannot_silently_skip() {
+        should_skip_optional_chromium_test(false, true);
+    }
+
+    #[test]
+    fn optional_chromium_evidence_may_skip_without_a_browser() {
+        assert!(should_skip_optional_chromium_test(false, false));
+        assert!(!should_skip_optional_chromium_test(true, true));
     }
 
     #[test]

--- a/tests/v8_compatibility.rs
+++ b/tests/v8_compatibility.rs
@@ -89,3 +89,40 @@ fn required_ci_enforces_the_v8_compatibility_contract() {
         "the required action-manifest job must enforce V8 compatibility drift"
     );
 }
+
+#[test]
+fn required_ci_enforces_real_chrome_rendering_evidence() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml"))
+        .expect("read required CI workflow");
+    let test_job = ci
+        .split_once("  test:\n")
+        .and_then(|(_, jobs)| jobs.split_once("  action-manifest:\n"))
+        .map(|(job, _)| job)
+        .expect("test job must precede action-manifest job");
+
+    assert!(
+        test_job.contains("      - name: Resolve Chrome rendering evidence binary\n"),
+        "required CI must resolve a real Chrome/Chromium executable"
+    );
+    assert!(
+        test_job.contains("        id: chrome-evidence-browser\n"),
+        "the evidence step must receive the validated browser path"
+    );
+    assert!(
+        test_job.contains("          timeout 15s \"$chrome_bin\" --version\n"),
+        "browser discovery must prove the resolved executable responds within a hard deadline"
+    );
+    assert!(
+        test_job.contains(
+            "          PLASMATE_CHROME_TEST_BINARY: ${{ steps.chrome-evidence-browser.outputs.binary }}\n          PLASMATE_REQUIRE_CHROME_EVIDENCE: '1'\n"
+        ),
+        "the containment test must use the exact validated binary and fail instead of skipping"
+    );
+    assert!(
+        test_job.contains(
+            "          timeout 2m cargo test --locked --lib\n          screenshot::tests::chromium_boundary_blocks_script_execution_and_cross_file_rendering\n          -- --exact --nocapture\n"
+        ),
+        "required CI must run the non-skipping Chromium containment assertion with a hard deadline"
+    );
+}


### PR DESCRIPTION
## Outcome
- require an executable Chrome/Chromium binary in the Ubuntu protected CI path
- pass the exact validated browser into the pixel containment test through a test-only override
- fail closed instead of silently skipping when evidence is required
- protect the workflow contract with regression tests and hard deadlines

## Independent verification
- real Chrome 150 containment test passed against baseline/control/hostile rendering
- fail-closed regression and workflow contract tests passed
- Rust 1.88 formatting and diff checks passed

Production browser discovery and screenshot behavior are unchanged.