### PR TITLE
Fix SDK selector reads and MCP initialization

### DIFF
--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -53,9 +53,9 @@ browser.close();
 
 ### Stateless (one-shot)
 
-- **`som(url, options?)`** - Convenience alias for `fetchPage`, returns typed `Som`
-- **`fetchPage(url, options?)`** - Returns SOM JSON
-- **`extractText(url, options?)`** - Returns clean text
+- **`som(url, options?)`** - Convenience alias for `fetchPage`, returns typed `Som`; options include `budget`, `javascript`, and `selector`
+- **`fetchPage(url, options?)`** - Returns SOM JSON; options include `budget`, `javascript`, and `selector`
+- **`extractText(url, options?)`** - Returns clean text; options include `maxChars` and `selector`
 
 ### Stateful (interactive sessions)
 

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
-    "test": "npm run build && node --test dist/query.test.js",
+    "test": "npm run build && node --test dist/query.test.js dist/client.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { Plasmate } from './index';
+
+type ToolCall = { name: string; args: Record<string, unknown> };
+
+describe('read selectors', () => {
+  it('forwards selector options through fetch and text reads', async () => {
+    const browser = new Plasmate({ binary: 'unused' });
+    const calls: ToolCall[] = [];
+    const client = browser as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+    client.callTool = async (name, args) => {
+      calls.push({ name, args });
+      return name === 'extract_text' ? 'text' : {};
+    };
+
+    await browser.fetchPage('fixture', { selector: 'main' });
+    await browser.som('fixture', { selector: 'interactive' });
+    await browser.extractText('fixture', { selector: 'content' });
+
+    assert.deepEqual(calls, [
+      { name: 'fetch_page', args: { url: 'fixture', selector: 'main' } },
+      { name: 'fetch_page', args: { url: 'fixture', selector: 'interactive' } },
+      { name: 'extract_text', args: { url: 'fixture', selector: 'content' } },
+    ]);
+    browser.close();
+  });
+});

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -266,10 +266,12 @@ export class Plasmate extends EventEmitter {
    * @param url - URL to fetch
    * @param options.budget - Maximum output tokens (SOM will be truncated)
    * @param options.javascript - Enable JS execution (default: true)
+   * @param options.selector - Optional SOM region, role, action, or element-id filter
    */
   async som(url: string, options?: {
     budget?: number;
     javascript?: boolean;
+    selector?: string;
   }): Promise<Som> {
     return this.fetchPage(url, options);
   }
@@ -280,14 +282,17 @@ export class Plasmate extends EventEmitter {
    * @param url - URL to fetch
    * @param options.budget - Maximum output tokens (SOM will be truncated)
    * @param options.javascript - Enable JS execution (default: true)
+   * @param options.selector - Optional SOM region, role, action, or element-id filter
    */
   async fetchPage(url: string, options?: {
     budget?: number;
     javascript?: boolean;
+    selector?: string;
   }): Promise<Som> {
     const args: Record<string, unknown> = { url };
     if (options?.budget != null) args.budget = options.budget;
     if (options?.javascript != null) args.javascript = options.javascript;
+    if (options?.selector != null) args.selector = options.selector;
     return await this.callTool('fetch_page', args) as Som;
   }
 
@@ -296,12 +301,15 @@ export class Plasmate extends EventEmitter {
    *
    * @param url - URL to fetch
    * @param options.maxChars - Maximum characters to return
+   * @param options.selector - Optional SOM region, role, action, or element-id filter
    */
   async extractText(url: string, options?: {
     maxChars?: number;
+    selector?: string;
   }): Promise<string> {
     const args: Record<string, unknown> = { url };
     if (options?.maxChars != null) args.max_chars = options.maxChars;
+    if (options?.selector != null) args.selector = options.selector;
     return await this.callTool('extract_text', args) as string;
   }
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -70,8 +70,8 @@ with Plasmate() as browser:
 
 ### Stateless (one-shot)
 
-- **`fetch_page(url, *, budget=None, javascript=True)`** - Returns SOM dict
-- **`extract_text(url, *, max_chars=None)`** - Returns clean text string
+- **`fetch_page(url, *, budget=None, javascript=True, selector=None)`** - Returns SOM dict; optionally scopes the result to a region, role, action, or element ID
+- **`extract_text(url, *, max_chars=None, selector=None)`** - Returns clean text string; optionally scopes extraction before text collection
 
 ### Stateful (interactive sessions)
 

--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -116,12 +116,8 @@ class Plasmate:
         # Send initialized notification
         self._send({
             "jsonrpc": "2.0",
-            "id": self._next_id,
             "method": "notifications/initialized",
         })
-        self._next_id += 1
-        # Read the notification response (if any)
-        # Some servers respond, some don't - read with timeout
         self._initialized = True
 
     def close(self) -> None:
@@ -350,10 +346,8 @@ class AsyncPlasmate:
 
         await self._send({
             "jsonrpc": "2.0",
-            "id": self._next_id,
             "method": "notifications/initialized",
         })
-        self._next_id += 1
         self._initialized = True
 
     async def close(self) -> None:

--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -204,6 +204,7 @@ class Plasmate:
         *,
         budget: Optional[int] = None,
         javascript: bool = True,
+        selector: Optional[str] = None,
     ) -> dict:
         """
         Fetch a page and return its Semantic Object Model.
@@ -212,6 +213,7 @@ class Plasmate:
             url: URL to fetch
             budget: Maximum output tokens (SOM will be truncated)
             javascript: Enable JS execution (default: True)
+            selector: Optional SOM region, role, action, or element-id filter
 
         Returns:
             SOM dict with title, url, regions, and meta
@@ -221,6 +223,8 @@ class Plasmate:
             args["budget"] = budget
         if not javascript:
             args["javascript"] = False
+        if selector is not None:
+            args["selector"] = selector
         return self._call_tool("fetch_page", args)
 
     def extract_text(
@@ -228,6 +232,7 @@ class Plasmate:
         url: str,
         *,
         max_chars: Optional[int] = None,
+        selector: Optional[str] = None,
     ) -> str:
         """
         Fetch a page and return clean, readable text only.
@@ -235,6 +240,7 @@ class Plasmate:
         Args:
             url: URL to fetch
             max_chars: Maximum characters to return
+            selector: Optional SOM region, role, action, or element-id filter
 
         Returns:
             Clean text content
@@ -242,6 +248,8 @@ class Plasmate:
         args: dict[str, Any] = {"url": url}
         if max_chars is not None:
             args["max_chars"] = max_chars
+        if selector is not None:
+            args["selector"] = selector
         return self._call_tool("extract_text", args)
 
     # ---- Stateful Tools ----
@@ -415,20 +423,37 @@ class AsyncPlasmate:
 
         return _extract_last_json(text)
 
-    async def fetch_page(self, url: str, *, budget: Optional[int] = None, javascript: bool = True) -> dict:
+    async def fetch_page(
+        self,
+        url: str,
+        *,
+        budget: Optional[int] = None,
+        javascript: bool = True,
+        selector: Optional[str] = None,
+    ) -> dict:
         """Fetch a page and return its Semantic Object Model."""
         args: dict[str, Any] = {"url": url}
         if budget is not None:
             args["budget"] = budget
         if not javascript:
             args["javascript"] = False
+        if selector is not None:
+            args["selector"] = selector
         return await self._call_tool("fetch_page", args)
 
-    async def extract_text(self, url: str, *, max_chars: Optional[int] = None) -> str:
+    async def extract_text(
+        self,
+        url: str,
+        *,
+        max_chars: Optional[int] = None,
+        selector: Optional[str] = None,
+    ) -> str:
         """Fetch a page and return clean, readable text only."""
         args: dict[str, Any] = {"url": url}
         if max_chars is not None:
             args["max_chars"] = max_chars
+        if selector is not None:
+            args["selector"] = selector
         return await self._call_tool("extract_text", args)
 
     async def open_page(self, url: str) -> dict:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,37 @@
+"""Tests for public SDK read-option forwarding."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, call
+
+from plasmate.client import AsyncPlasmate, Plasmate
+
+
+def test_sync_read_methods_forward_selector() -> None:
+    browser = Plasmate()
+    calls = Mock(side_effect=[{}, "text"])
+    browser._call_tool = calls  # type: ignore[method-assign]
+
+    assert browser.fetch_page("fixture", selector="main") == {}
+    assert browser.extract_text("fixture", selector="content") == "text"
+
+    assert calls.call_args_list == [
+        call("fetch_page", {"url": "fixture", "selector": "main"}),
+        call("extract_text", {"url": "fixture", "selector": "content"}),
+    ]
+
+
+def test_async_read_methods_forward_selector() -> None:
+    async def exercise() -> None:
+        browser = AsyncPlasmate()
+        calls = AsyncMock(side_effect=[{}, "text"])
+        browser._call_tool = calls  # type: ignore[method-assign]
+
+        assert await browser.fetch_page("fixture", selector="main") == {}
+        assert await browser.extract_text("fixture", selector="content") == "text"
+
+        assert calls.call_args_list == [
+            call("fetch_page", {"url": "fixture", "selector": "main"}),
+            call("extract_text", {"url": "fixture", "selector": "content"}),
+        ]
+
+    asyncio.run(exercise())

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -1,0 +1,59 @@
+"""Protocol lifecycle regression tests for the Python SDK clients."""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from plasmate.client import AsyncPlasmate, Plasmate
+
+
+def _fixture(tmp_path: Path) -> str:
+    path = tmp_path / "mcp-fixture.py"
+    path.write_text(
+        '''#!/usr/bin/env python3
+import json
+import sys
+
+def send(value):
+    sys.stdout.write(json.dumps(value, separators=(",", ":")) + "\\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": request.get("id"), "result": {"protocolVersion": "2024-11-05"}})
+    elif method == "notifications/initialized":
+        if "id" in request:
+            send({"jsonrpc": "2.0", "id": request["id"], "result": {"stale": True}})
+    elif method == "tools/call":
+        send({
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "result": {"content": [{"type": "text", "text": json.dumps({"ok": True})}]},
+        })
+''',
+        encoding="utf-8",
+    )
+    os.chmod(path, 0o755)
+    return str(path)
+
+
+def test_sync_first_tool_call_does_not_consume_notification_response(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        assert client._call_tool("fixture_tool", {}) == {"ok": True}
+    finally:
+        client.close()
+
+
+def test_async_first_tool_call_does_not_consume_notification_response(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            assert await client._call_tool("fixture_tool", {}) == {"ok": True}
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## What changed

- expose selector-scoped reads in the Node and Python SDKs
- send `notifications/initialized` as a true MCP notification without an `id`
- add sync and async regression coverage for both behaviors

## Why

The selector option was supported by Plasmate but not forwarded by both SDK read surfaces. The Python SDK also labeled the initialized notification as a request, allowing a non-compliant response to be consumed as the first tool result.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Python SDK: 61 tests passed
- Node SDK: 29 tests passed