### PR TITLE
Fix Codex MCP stdio lifecycle and SDK response correlation

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -106,28 +106,45 @@ class Plasmate:
             stderr=subprocess.PIPE,
         )
 
-        # Initialize MCP session
-        self._rpc("initialize", {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "plasmate-python-sdk", "version": SDK_VERSION},
-        })
+        try:
+            # Initialize MCP session
+            self._rpc("initialize", {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "plasmate-python-sdk", "version": SDK_VERSION},
+            })
 
-        # Send initialized notification
-        self._send({
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized",
-        })
+            # Send initialized notification
+            self._send({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            })
+        except BaseException:
+            self.close()
+            raise
         self._initialized = True
 
     def close(self) -> None:
         """Shut down the plasmate process."""
-        if self._process:
-            self._process.terminate()
+        process = self._process
+        if process:
+            if process.stdin:
+                try:
+                    process.stdin.close()
+                except OSError:
+                    pass
             try:
-                self._process.wait(timeout=5)
+                process.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                self._process.kill()
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+            for stream in (process.stdout, process.stderr):
+                if stream:
+                    stream.close()
             self._process = None
         self._initialized = False
 
@@ -149,7 +166,7 @@ class Plasmate:
         self._process.stdin.write(line.encode())
         self._process.stdin.flush()
 
-    def _read_response(self) -> dict:
+    def _read_response(self, request_id: int) -> dict:
         if not self._process or not self._process.stdout:
             raise RuntimeError("Plasmate process is not running")
         while True:
@@ -160,9 +177,11 @@ class Plasmate:
             if not line:
                 continue
             try:
-                return json.loads(line)
+                response = json.loads(line)
             except json.JSONDecodeError:
                 continue  # Skip non-JSON lines (tracing output)
+            if isinstance(response, dict) and response.get("id") == request_id:
+                return response
 
     def _rpc(self, method: str, params: Any = None) -> Any:
         with self._lock:
@@ -172,7 +191,7 @@ class Plasmate:
             if params is not None:
                 request["params"] = params
             self._send(request)
-            response = self._read_response()
+            response = self._read_response(request_id)
 
         if "error" in response and response["error"]:
             raise RuntimeError(response["error"]["message"])
@@ -338,26 +357,41 @@ class AsyncPlasmate:
             stderr=asyncio.subprocess.PIPE,
         )
 
-        await self._rpc("initialize", {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "plasmate-python-sdk", "version": SDK_VERSION},
-        })
+        try:
+            await self._rpc("initialize", {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "plasmate-python-sdk", "version": SDK_VERSION},
+            })
 
-        await self._send({
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized",
-        })
+            await self._send({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            })
+        except BaseException:
+            await self.close()
+            raise
         self._initialized = True
 
     async def close(self) -> None:
         """Shut down the plasmate process."""
-        if self._process:
-            self._process.terminate()
+        process = self._process
+        if process:
+            if process.stdin:
+                process.stdin.close()
+                try:
+                    await process.stdin.wait_closed()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
             try:
-                await asyncio.wait_for(self._process.wait(), timeout=5)
+                await asyncio.wait_for(process.wait(), timeout=5)
             except asyncio.TimeoutError:
-                self._process.kill()
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
             self._process = None
         self._initialized = False
 
@@ -374,7 +408,7 @@ class AsyncPlasmate:
         self._process.stdin.write(line.encode())
         await self._process.stdin.drain()
 
-    async def _read_response(self) -> dict:
+    async def _read_response(self, request_id: int) -> dict:
         if not self._process or not self._process.stdout:
             raise RuntimeError("Plasmate process is not running")
         while True:
@@ -385,9 +419,11 @@ class AsyncPlasmate:
             if not text:
                 continue
             try:
-                return json.loads(text)
+                response = json.loads(text)
             except json.JSONDecodeError:
                 continue
+            if isinstance(response, dict) and response.get("id") == request_id:
+                return response
 
     async def _rpc(self, method: str, params: Any = None) -> Any:
         async with self._lock:
@@ -397,7 +433,7 @@ class AsyncPlasmate:
             if params is not None:
                 request["params"] = params
             await self._send(request)
-            response = await self._read_response()
+            response = await self._read_response(request_id)
 
         if "error" in response and response["error"]:
             raise RuntimeError(response["error"]["message"])

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -28,6 +28,8 @@ for line in sys.stdin:
         if "id" in request:
             send({"jsonrpc": "2.0", "id": request["id"], "result": {"stale": True}})
     elif method == "tools/call":
+        send({"jsonrpc": "2.0", "method": "notifications/progress", "params": {"progress": 1}})
+        send({"jsonrpc": "2.0", "id": request.get("id") + 1000, "result": {"stale": True}})
         send({
             "jsonrpc": "2.0",
             "id": request.get("id"),
@@ -42,18 +44,26 @@ for line in sys.stdin:
 
 def test_sync_first_tool_call_does_not_consume_notification_response(tmp_path: Path) -> None:
     client = Plasmate(binary=_fixture(tmp_path))
+    process = None
     try:
         assert client._call_tool("fixture_tool", {}) == {"ok": True}
+        process = client._process
     finally:
         client.close()
+    assert process is not None
+    assert process.poll() is not None
 
 
 def test_async_first_tool_call_does_not_consume_notification_response(tmp_path: Path) -> None:
     async def exercise() -> None:
         client = AsyncPlasmate(binary=_fixture(tmp_path))
+        process = None
         try:
             assert await client._call_tool("fixture_tool", {}) == {"ok": True}
+            process = client._process
         finally:
             await client.close()
+        assert process is not None
+        assert process.returncode is not None
 
     asyncio.run(exercise())

--- a/smoke/mcp-smoke.py
+++ b/smoke/mcp-smoke.py
@@ -76,6 +76,8 @@ def main():
     base_url = f"http://127.0.0.1:{server.server_port}"
 
     stderr_log = tempfile.TemporaryFile(mode="w+")
+    child_env = os.environ.copy()
+    child_env["PLASMATE_UNSAFE_ALLOW_PRIVATE_NETWORK"] = "1"
     proc = subprocess.Popen(
         [binary, "mcp"],
         stdin=subprocess.PIPE,
@@ -83,6 +85,7 @@ def main():
         stderr=stderr_log,
         text=True,
         bufsize=1,
+        env=child_env,
     )
     selector = selectors.DefaultSelector()
     selector.register(proc.stdout, selectors.EVENT_READ)
@@ -193,17 +196,29 @@ def main():
         # 1. Initialize
         print("1. Initialize")
         r = rpc("initialize", {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {"name": "smoke-test", "version": "1.0"},
         })
         check("server responds", r.get("result") is not None)
         check("server name", r["result"]["serverInfo"]["name"] == "plasmate")
+        check("Codex protocol version", r["result"]["protocolVersion"] == "2025-06-18")
         notify("notifications/initialized")
 
-        # 2. fetch_page (stateless)
-        print("\n2. fetch_page (stateless)")
-        r = rpc("tools/call", {"name": "fetch_page", "arguments": {"url": f"{base_url}/"}})
+        # 2. repeated fetch_page calls on one long-lived transport
+        print("\n2. fetch_page (10 consecutive stateless calls)")
+        fetch_responses = [
+            rpc("tools/call", {
+                "name": "fetch_page",
+                "arguments": {"url": f"{base_url}/", "javascript": False},
+            })
+            for _ in range(10)
+        ]
+        check(
+            "10 calls keep transport healthy",
+            all(not response.get("result", {}).get("isError", False) for response in fetch_responses),
+        )
+        r = fetch_responses[-1]
         som = json.loads(r["result"]["content"][0]["text"])
         check("title", som.get("title") == "MCP Smoke Test", f'got: {som.get("title")}')
         check("has regions", len(som.get("regions", [])) > 0)
@@ -291,6 +306,19 @@ def main():
         check("closed", close_payload.get("closed") is True)
         final_events = close_payload.get("final_trace", {}).get("events", [])
         check("close returns final trace", bool(final_events) and final_events[-1].get("action") == "close_page")
+
+        # 9. A tool error is structured and does not poison the transport.
+        print("\n9. tool error recovery")
+        error_response = rpc("tools/call", {"name": "fetch_page", "arguments": {}})
+        check("fetch error is structured", error_response.get("result", {}).get("isError") is True)
+        healthy = rpc("tools/call", {"name": "cache_status", "arguments": {}})
+        check("cache_status works after error", healthy.get("result", {}).get("isError") is not True)
+
+        # 10. Closing the client pipe must let the stdio child exit cleanly.
+        print("\n10. client disconnect")
+        proc.stdin.close()
+        proc.wait(timeout=5)
+        check("stdio child exits on EOF", proc.returncode == 0, f"status: {proc.returncode}")
 
         print(f"\n=== Results: {passed} passed, {failed} failed ===")
         if failed == 0:

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,6 +1,7 @@
 //! Versioned MCP wire adapters.
 //!
-//! MCP 2024-11-05 and 2025-11-25 use the initialize/initialized lifecycle.
+//! MCP 2024-11-05, 2025-06-18, and 2025-11-25 use the
+//! initialize/initialized lifecycle.
 //! The locked 2026-07-28 release candidate removes that handshake in favor of
 //! `server/discover` and per-request metadata. Keeping those eras explicit
 //! prevents transport and tool handlers from accumulating version checks.
@@ -18,6 +19,7 @@
 use serde_json::{json, Value};
 
 pub const LEGACY_VERSION: &str = "2024-11-05";
+pub const CODEX_COMPAT_VERSION: &str = "2025-06-18";
 pub const STABLE_VERSION: &str = "2025-11-25";
 pub const MODERN_RC_VERSION: &str = "2026-07-28";
 
@@ -32,6 +34,7 @@ const SERVER_INSTRUCTIONS: &str = "Plasmate is the mandatory first route for pub
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProtocolAdapter {
     Legacy2024,
+    Stable2025June,
     Stable2025,
     Modern2026,
 }
@@ -40,6 +43,7 @@ impl ProtocolAdapter {
     pub fn version(self) -> &'static str {
         match self {
             Self::Legacy2024 => LEGACY_VERSION,
+            Self::Stable2025June => CODEX_COMPAT_VERSION,
             Self::Stable2025 => STABLE_VERSION,
             Self::Modern2026 => MODERN_RC_VERSION,
         }
@@ -66,6 +70,7 @@ impl ProtocolState {
     pub fn negotiate_initialize(&mut self, requested: Option<&str>) -> ProtocolAdapter {
         let adapter = match requested {
             Some(LEGACY_VERSION) => ProtocolAdapter::Legacy2024,
+            Some(CODEX_COMPAT_VERSION) => ProtocolAdapter::Stable2025June,
             Some(STABLE_VERSION) => ProtocolAdapter::Stable2025,
             _ => ProtocolAdapter::Stable2025,
         };
@@ -172,7 +177,10 @@ pub fn initialize_result(
     server_version: &str,
 ) -> Value {
     debug_assert!(adapter.uses_initialize());
-    let server_info = if matches!(adapter, ProtocolAdapter::Stable2025) {
+    let server_info = if matches!(
+        adapter,
+        ProtocolAdapter::Stable2025June | ProtocolAdapter::Stable2025
+    ) {
         json!({
             "name": server_name,
             "title": "Plasmate Semantic Browser",
@@ -502,6 +510,10 @@ mod tests {
         assert_eq!(
             state.negotiate_initialize(Some(LEGACY_VERSION)),
             ProtocolAdapter::Legacy2024
+        );
+        assert_eq!(
+            state.negotiate_initialize(Some(CODEX_COMPAT_VERSION)),
+            ProtocolAdapter::Stable2025June
         );
         assert_eq!(
             state.negotiate_initialize(Some(STABLE_VERSION)),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -645,6 +645,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_stdio_version_is_echoed_and_tool_errors_keep_session_healthy() {
+        let mut state = ProtocolState::default();
+        let initialized = route(
+            &request(
+                Some(1),
+                "initialize",
+                Some(json!({
+                    "protocolVersion": protocol::CODEX_COMPAT_VERSION,
+                    "capabilities": {},
+                    "clientInfo": { "name": "codex", "version": "test" }
+                })),
+            ),
+            &mut state,
+        )
+        .await;
+        assert_eq!(
+            initialized.result.unwrap()["protocolVersion"],
+            protocol::CODEX_COMPAT_VERSION
+        );
+
+        route(
+            &request(None, "notifications/initialized", None),
+            &mut state,
+        )
+        .await;
+
+        let failed = route(
+            &request(
+                Some(2),
+                "tools/call",
+                Some(json!({ "name": "fetch_page", "arguments": {} })),
+            ),
+            &mut state,
+        )
+        .await;
+        assert_eq!(failed.result.unwrap()["isError"], true);
+
+        for id in 3..13 {
+            let status = route(
+                &request(
+                    Some(id),
+                    "tools/call",
+                    Some(json!({ "name": "cache_status", "arguments": {} })),
+                ),
+                &mut state,
+            )
+            .await;
+            let result = status.result.unwrap();
+            assert_ne!(result["isError"], true);
+            assert!(result["content"].is_array());
+        }
+    }
+
+    #[tokio::test]
     async fn stable_tool_call_returns_schema_compatible_structured_content() {
         let mut state = ProtocolState::default();
         route(


### PR DESCRIPTION
## What changed

- negotiate Codex's stdio MCP protocol version (`2025-06-18`) exactly instead of responding with the newer `2025-11-25` revision
- correlate synchronous and asynchronous Python SDK responses by JSON-RPC request ID while ignoring notification traffic and unrelated responses
- close SDK stdin first and wait for clean child shutdown, with terminate/kill fallbacks
- extend MCP lifecycle smoke coverage to ten consecutive fetches, error recovery, and client disconnect cleanup

## Root cause

Codex's stdio client initializes with MCP `2025-06-18`. Plasmate did not recognize that revision and returned `2025-11-25`, so Codex rejected the handshake and dropped the transport. The abandoned server remained blocked on an open stdio pipe. Separately, the Python SDK consumed the next JSON message without checking its request ID, allowing notification or stale response traffic to desynchronize calls.

## Impact

Long-lived Codex MCP sessions now negotiate the protocol Codex requested, repeated calls remain on the same healthy transport, structured tool errors do not poison later calls, and clean client disconnects reap the child process. Python SDK calls receive only their own response.

## Validation

- `cargo test` (all Rust unit and integration suites pass)
- `cargo clippy --all-targets --all-features -- -D warnings`
- Python SDK: 61 tests passed
- MCP smoke: 27 checks passed, including ten consecutive fetches and clean EOF shutdown

Fixes #59
