### PR TITLE
fix(browser-use): support scoped page context

### DIFF
--- a/integrations/browser-use/README.md
+++ b/integrations/browser-use/README.md
@@ -56,6 +56,12 @@ The `get_page_context()` method returns a formatted string optimized for LLM con
 ```python
 context = extractor.get_page_context("https://example.com")
 print(context)
+
+# Ask Plasmate for only the semantic region needed by the agent.
+interactive_context = extractor.get_page_context(
+    "https://example.com/settings",
+    selector="interactive",
+)
 ```
 
 Output:

--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -259,13 +259,17 @@ class PlasmateExtractor:
                 "Or: curl -fsSL https://plasmate.app/install.sh | sh"
             )
 
-    def extract(self, url: str) -> dict:
+    def extract(self, url: str, *, selector: Optional[str] = None) -> dict:
         """Fetch a URL and return parsed SOM output.
 
-        Returns the full SOM dict with regions, elements, meta, etc.
+        ``selector`` may scope the result to a SOM region, role, action, or
+        element id. Without it, returns the full SOM dict.
         """
+        command = [self.plasmate_bin, "fetch", url]
+        if selector is not None:
+            command.extend(["--selector", selector])
         result = subprocess.run(
-            [self.plasmate_bin, "fetch", url],
+            command,
             capture_output=True, text=True, timeout=30
         )
         if result.returncode != 0:
@@ -277,10 +281,15 @@ class PlasmateExtractor:
             )
         return som
 
-    async def extract_async(self, url: str) -> dict:
+    async def extract_async(
+        self, url: str, *, selector: Optional[str] = None
+    ) -> dict:
         """Async version of extract."""
+        command = [self.plasmate_bin, "fetch", url]
+        if selector is not None:
+            command.extend(["--selector", selector])
         proc = await asyncio.create_subprocess_exec(
-            self.plasmate_bin, "fetch", url,
+            *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -405,7 +414,7 @@ class PlasmateExtractor:
         som = parse_som(som_data)
         return find_action_targets_by_action(som, action, enabled_only=enabled_only)
 
-    def get_page_context(self, url: str) -> str:
+    def get_page_context(self, url: str, *, selector: Optional[str] = None) -> str:
         """Get a structured page context string for LLM consumption.
 
         Returns a formatted string with:
@@ -413,13 +422,26 @@ class PlasmateExtractor:
         - Interactive elements (what the agent can do)
         - Content summary
         - Compression stats
+
+        ``selector`` may scope the context to a SOM region, role, action, or
+        element id before it is formatted.
         """
-        som_data = self.extract(url)
+        som_data = (
+            self.extract(url, selector=selector)
+            if selector is not None
+            else self.extract(url)
+        )
         return self._build_context(som_data)
 
-    async def get_page_context_async(self, url: str) -> str:
+    async def get_page_context_async(
+        self, url: str, *, selector: Optional[str] = None
+    ) -> str:
         """Async version of get_page_context."""
-        som_data = await self.extract_async(url)
+        som_data = (
+            await self.extract_async(url, selector=selector)
+            if selector is not None
+            else await self.extract_async(url)
+        )
         return self._build_context(som_data)
 
     def _build_context(self, som_data: dict) -> str:

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -1,5 +1,8 @@
+import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from plasmate_browser_use.extractor import PlasmateExtractor
 
@@ -22,6 +25,65 @@ def load_action_availability_fixture():
 
 def load_action_availability_expectations():
     return json.loads(EXPECTATIONS_PATH.read_text())["action_targets"]
+
+
+def test_page_context_forwards_selector_to_cli():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    completed = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps(som),
+        stderr="",
+    )
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ) as run:
+        context = extractor.get_page_context("fixture", selector="interactive")
+
+    assert "## Interactive Elements" in context
+    run.assert_called_once_with(
+        ["plasmate", "fetch", "fixture", "--selector", "interactive"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_async_page_context_forwards_selector_to_cli():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    calls = []
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return json.dumps(som).encode(), b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeProcess()
+
+    with patch(
+        "plasmate_browser_use.extractor.asyncio.create_subprocess_exec",
+        new=fake_create_subprocess_exec,
+    ):
+        context = asyncio.run(
+            extractor.get_page_context_async("fixture", selector="interactive")
+        )
+
+    assert "## Interactive Elements" in context
+    assert calls[0][0] == (
+        "plasmate",
+        "fetch",
+        "fixture",
+        "--selector",
+        "interactive",
+    )
 
 
 def test_build_context_surfaces_action_availability():


### PR DESCRIPTION
## Summary

- Add an optional SOM selector to the Browser Use extractor and page-context helpers.
- Forward the selector safely as the native `plasmate fetch --selector` argument for sync and async paths.
- Add recording-subprocess regression coverage and a usage example.

## Agent outcome

Browser Use agents can now request a bounded semantic page context such as `interactive` or `main` through the adapter. The default call keeps the existing full-context argv.

## Root cause

The native CLI and Python SDK already accepted selectors, but the Browser Use adapter had no selector parameter and raised `TypeError` when an agent tried to scope `get_page_context()`.

## Validation

- Before proof: compatible Python 3.11 call raised `TypeError: PlasmateExtractor.get_page_context() got an unexpected keyword argument 'selector'`.
- Browser Use adapter tests: `6 passed`.
- `~/.cargo/bin/cargo fmt --check`.
- `git diff --check`.
- `~/.cargo/bin/cargo test`: 445 library tests, 61 binary tests, and all integration/doc tests passed.
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`.
- Shared action-manifest quick checks reached the Python parser (`1 passed`) and Node parser (`1 passed`) before stopping because the Go executable is unavailable in the runner; the affected Browser Use suite passed independently.
