### PR TITLE
fix(langchain): forward scoped page reads

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -29,6 +29,13 @@ from langchain_plasmate import PlasmateFetchTool
 fetch = PlasmateFetchTool()
 result = fetch.invoke("https://news.ycombinator.com")
 print(result)
+
+# Ask the agent for only the interactive action surface when it does not need
+# the rest of the page.
+result = fetch.invoke({
+    "url": "https://news.ycombinator.com",
+    "selector": "interactive",
+})
 ```
 
 Output:
@@ -165,7 +172,7 @@ Stateless page fetch — returns SOM text for a single URL.
 | Field | Value |
 |-------|-------|
 | Name | `plasmate_fetch` |
-| Input | `url` (string) |
+| Input | `url` (string), optional `selector` (string) |
 | Output | SOM text with element IDs |
 
 ### `PlasmateNavigateTool`
@@ -225,6 +232,7 @@ PlasmateSOMLoader(
     urls=["https://example.com"],
     budget=2000,          # optional token budget per page
     javascript=True,      # enable JS execution (default)
+    selector="main",     # optional SOM scope for each page
     client=None,          # optional Plasmate instance
 )
 ```

--- a/integrations/langchain/langchain_plasmate/loader.py
+++ b/integrations/langchain/langchain_plasmate/loader.py
@@ -24,6 +24,7 @@ class PlasmateSOMLoader(BaseLoader):
         client: An existing Plasmate client. If ``None``, one is created.
         budget: Optional per-page SOM token budget.
         javascript: Whether to execute JavaScript (default ``True``).
+        selector: Optional SOM region, role, action, or element-id filter.
 
     Example::
 
@@ -40,11 +41,13 @@ class PlasmateSOMLoader(BaseLoader):
         client: Optional[Plasmate] = None,
         budget: Optional[int] = None,
         javascript: bool = True,
+        selector: Optional[str] = None,
     ):
         self.urls = list(urls)
         self.client = client or Plasmate()
         self.budget = budget
         self.javascript = javascript
+        self.selector = selector
 
     def lazy_load(self) -> Iterator[Document]:
         """Lazily load URLs one at a time, yielding Documents."""
@@ -54,6 +57,8 @@ class PlasmateSOMLoader(BaseLoader):
                 kwargs["budget"] = self.budget
             if not self.javascript:
                 kwargs["javascript"] = False
+            if self.selector is not None:
+                kwargs["selector"] = self.selector
 
             som = self.client.fetch_page(url, **kwargs)
             text = som_to_text(som)

--- a/integrations/langchain/langchain_plasmate/tools.py
+++ b/integrations/langchain/langchain_plasmate/tools.py
@@ -94,6 +94,14 @@ class _ClickInput(BaseModel):
     element_id: str = Field(description="The SOM element ID to click (e.g. 'e_a1b2c3d4e5f6').")
 
 
+class _FetchInput(BaseModel):
+    url: str = Field(description="The URL to fetch.")
+    selector: Optional[str] = Field(
+        default=None,
+        description="Optional SOM region, role, action, or element-id filter.",
+    )
+
+
 class _TypeInput(BaseModel):
     element_id: str = Field(description="The SOM element ID of the input field.")
     text: str = Field(description="The text to type into the element.")
@@ -118,8 +126,10 @@ class PlasmateFetchTool(BaseTool):
         "(navigation, content, forms, interactive elements). "
         "Returns a compact text representation with element IDs "
         "that can be referenced by other tools. "
-        "Input: the URL to fetch."
+        "Input: the URL to fetch, with an optional SOM selector such as "
+        "'main' or 'interactive'."
     )
+    args_schema: Type[BaseModel] = _FetchInput
     client: Any = None  # Plasmate instance
 
     model_config = {"arbitrary_types_allowed": True}
@@ -128,12 +138,15 @@ class PlasmateFetchTool(BaseTool):
         super().__init__(**kwargs)
         self.client = client or Plasmate()
 
-    def _run(self, url: str) -> str:
-        som = self.client.fetch_page(url)
+    def _run(self, url: str, selector: Optional[str] = None) -> str:
+        kwargs: dict[str, Any] = {}
+        if selector is not None:
+            kwargs["selector"] = selector
+        som = self.client.fetch_page(url, **kwargs)
         return som_to_text(som)
 
-    async def _arun(self, url: str) -> str:
-        return self._run(url)
+    async def _arun(self, url: str, selector: Optional[str] = None) -> str:
+        return self._run(url, selector)
 
 
 class PlasmateNavigateTool(BaseTool):

--- a/integrations/langchain/tests/test_loader.py
+++ b/integrations/langchain/tests/test_loader.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+
+from langchain_plasmate import PlasmateSOMLoader
+
+
+def test_loader_forwards_selector() -> None:
+    client = Mock()
+    client.fetch_page.return_value = {
+        "title": "Fixture",
+        "url": "fixture",
+        "regions": [],
+        "meta": {
+            "html_bytes": 0,
+            "som_bytes": 0,
+            "element_count": 0,
+            "interactive_count": 0,
+        },
+    }
+    loader = PlasmateSOMLoader(["fixture"], client=client, selector="main")
+
+    documents = loader.load()
+
+    assert len(documents) == 1
+    client.fetch_page.assert_called_once_with("fixture", selector="main")

--- a/integrations/langchain/tests/test_tools.py
+++ b/integrations/langchain/tests/test_tools.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock, call
+
+from langchain_plasmate import PlasmateFetchTool
+
+
+def _som() -> dict:
+    return {
+        "title": "Fixture",
+        "url": "fixture",
+        "regions": [],
+        "meta": {
+            "html_bytes": 0,
+            "som_bytes": 0,
+            "element_count": 0,
+            "interactive_count": 0,
+        },
+    }
+
+
+def test_fetch_tool_forwards_selector_and_keeps_string_input() -> None:
+    client = Mock()
+    client.fetch_page.return_value = _som()
+    tool = PlasmateFetchTool(client=client)
+
+    tool.invoke({"url": "fixture", "selector": "interactive"})
+    tool.invoke("fixture")
+
+    assert client.fetch_page.call_args_list == [
+        call("fixture", selector="interactive"),
+        call("fixture"),
+    ]
+
+
+def test_fetch_tool_async_forwards_selector() -> None:
+    import asyncio
+
+    client = Mock()
+    client.fetch_page.return_value = _som()
+    tool = PlasmateFetchTool(client=client)
+
+    asyncio.run(tool.ainvoke({"url": "fixture", "selector": "main"}))
+
+    client.fetch_page.assert_called_once_with("fixture", selector="main")


### PR DESCRIPTION
## Summary

- Add an optional SOM selector to the LangChain stateless fetch tool.
- Forward an optional selector through `PlasmateSOMLoader`.
- Preserve the existing string URL invocation and document the scoped calls.

## Agent outcome

LangChain agents can request a bounded semantic page scope such as `main` or `interactive` before page text enters the agent context.

## Root cause

The core Python SDK already accepted selectors, but the LangChain fetch tool rejected a selector argument and the loader constructor did not expose one.

## Validation

- Before proof: current calls raised `TypeError` for both selector entry points.
- Focused LangChain tests: `5 passed`, including sync, async, loader, exact forwarding, and legacy string input.
- `~/.cargo/bin/cargo fmt --check`.
- `git diff --check`.
- `~/.cargo/bin/cargo test`: all Rust unit, integration, and doc tests passed.
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`.
