### PR TITLE
fix(browser-use): scope markdown extraction

### DIFF
--- a/integrations/browser-use/README.md
+++ b/integrations/browser-use/README.md
@@ -137,9 +137,15 @@ stay aligned with other adapters.
 ### Markdown extraction
 
 ```python
-md = extractor.extract_markdown("https://example.com")
+md = extractor.extract_markdown(
+    "https://example.com",
+    selector="main",
+)
 print(md)
 ```
+
+Pass any supported SOM selector to keep only the page region or action surface
+needed by the agent before Markdown conversion.
 
 ### Async support
 

--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -303,19 +303,30 @@ class PlasmateExtractor:
             )
         return som
 
-    def extract_markdown(self, url: str) -> str:
+    def extract_markdown(self, url: str, *, selector: Optional[str] = None) -> str:
         """Fetch a URL and return SOM content as markdown.
 
         This is the simplest integration -- just get readable text
-        with structure preserved.
+        with structure preserved. ``selector`` may scope the SOM before
+        markdown conversion.
         """
-        som_data = self.extract(url)
+        som_data = (
+            self.extract(url, selector=selector)
+            if selector is not None
+            else self.extract(url)
+        )
         som = parse_som(som_data)
         return to_markdown(som)
 
-    async def extract_markdown_async(self, url: str) -> str:
-        """Async version of extract_markdown."""
-        som_data = await self.extract_async(url)
+    async def extract_markdown_async(
+        self, url: str, *, selector: Optional[str] = None
+    ) -> str:
+        """Async version of extract_markdown with optional SOM scoping."""
+        som_data = (
+            await self.extract_async(url, selector=selector)
+            if selector is not None
+            else await self.extract_async(url)
+        )
         som = parse_som(som_data)
         return to_markdown(som)
 

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -86,6 +86,63 @@ def test_async_page_context_forwards_selector_to_cli():
     )
 
 
+def test_markdown_forwards_selector_to_cli():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    completed = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps(som),
+        stderr="",
+    )
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ) as run:
+        extractor.extract_markdown("fixture", selector="main")
+
+    run.assert_called_once_with(
+        ["plasmate", "fetch", "fixture", "--selector", "main"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_async_markdown_forwards_selector_to_cli():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    calls = []
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return json.dumps(som).encode(), b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeProcess()
+
+    with patch(
+        "plasmate_browser_use.extractor.asyncio.create_subprocess_exec",
+        new=fake_create_subprocess_exec,
+    ):
+        asyncio.run(
+            extractor.extract_markdown_async("fixture", selector="main")
+        )
+
+    assert calls[0][0] == (
+        "plasmate",
+        "fetch",
+        "fixture",
+        "--selector",
+        "main",
+    )
+
+
 def test_build_context_surfaces_action_availability():
     extractor = PlasmateExtractor.__new__(PlasmateExtractor)
     som = load_action_availability_fixture()

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -33,6 +33,16 @@ func main() {
     }
     fmt.Println(som.Title, len(som.Regions), "regions")
 
+    // Scope a read when the agent only needs one page region or action surface.
+    selector := "interactive"
+    scoped, err := client.FetchPageWithOptions("https://example.com", plasmate.FetchPageOptions{
+        Selector: &selector,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println("Scoped regions:", len(scoped.Regions))
+
     // Query helpers
     links := plasmate.FindByTag(som, "link")
     fmt.Printf("Found %d links\n", len(links))
@@ -119,7 +129,7 @@ all := plasmate.FlatElements(som)
 |--------|-------------|
 | `NewClient(opts...)` | Create client (spawns `plasmate mcp` on first call) |
 | `FetchPage(url)` | Fetch page as SOM |
-| `FetchPageWithOptions(url, opts)` | Fetch with budget/JS options |
+| `FetchPageWithOptions(url, opts)` | Fetch with budget, JS, or an optional SOM selector |
 | `ExtractText(url)` | Fetch page as plain text |
 | `OpenPage(url)` | Open interactive session |
 | `Evaluate(sessionID, expr)` | Run JS in page context |

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -63,10 +63,10 @@ type jsonRPCRequest struct {
 
 // jsonRPCResponse is a JSON-RPC 2.0 response.
 type jsonRPCResponse struct {
-	JSONRPC string           `json:"jsonrpc"`
-	ID      *int             `json:"id"`
-	Result  json.RawMessage  `json:"result,omitempty"`
-	Error   *jsonRPCError    `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int            `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
 }
 
 type jsonRPCError struct {
@@ -248,12 +248,12 @@ func (c *Client) FetchPage(url string) (*Som, error) {
 
 // FetchPageOptions holds optional parameters for FetchPageWithOptions.
 type FetchPageOptions struct {
-	Budget     *int  // Maximum output tokens
-	JavaScript *bool // Enable JS execution
+	Budget     *int    // Maximum output tokens
+	JavaScript *bool   // Enable JS execution
+	Selector   *string // Optional SOM region, role, action, or element-id filter
 }
 
-// FetchPageWithOptions fetches a page with additional options.
-func (c *Client) FetchPageWithOptions(url string, opts FetchPageOptions) (*Som, error) {
+func fetchPageArguments(url string, opts FetchPageOptions) map[string]interface{} {
 	args := map[string]interface{}{"url": url}
 	if opts.Budget != nil {
 		args["budget"] = *opts.Budget
@@ -261,6 +261,15 @@ func (c *Client) FetchPageWithOptions(url string, opts FetchPageOptions) (*Som, 
 	if opts.JavaScript != nil {
 		args["javascript"] = *opts.JavaScript
 	}
+	if opts.Selector != nil {
+		args["selector"] = *opts.Selector
+	}
+	return args
+}
+
+// FetchPageWithOptions fetches a page with additional options.
+func (c *Client) FetchPageWithOptions(url string, opts FetchPageOptions) (*Som, error) {
+	args := fetchPageArguments(url, opts)
 	raw, err := c.callTool("fetch_page", args)
 	if err != nil {
 		return nil, err

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,0 +1,35 @@
+package plasmate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFetchPageArgumentsIncludeSelector(t *testing.T) {
+	budget := 512
+	javascript := false
+	selector := "interactive"
+
+	got := fetchPageArguments("fixture", FetchPageOptions{
+		Budget:     &budget,
+		JavaScript: &javascript,
+		Selector:   &selector,
+	})
+	want := map[string]interface{}{
+		"url":        "fixture",
+		"budget":     512,
+		"javascript": false,
+		"selector":   "interactive",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fetchPage arguments = %#v, want %#v", got, want)
+	}
+}
+
+func TestFetchPageArgumentsOmitNilSelector(t *testing.T) {
+	got := fetchPageArguments("fixture", FetchPageOptions{})
+	if _, ok := got["selector"]; ok {
+		t.Fatalf("fetchPage arguments unexpectedly included nil selector: %#v", got)
+	}
+}


### PR DESCRIPTION
## What changed

- Add an optional keyword-only `selector` to Browser Use `extract_markdown` and `extract_markdown_async`.
- Forward the existing selector to the Plasmate CLI before Markdown conversion.
- Add sync and async regression tests and an implementation-aligned README example.

## Why

Browser Use already supported scoped raw SOM and page-context reads, but its Markdown convenience methods rejected the same option before any fetch. This lets an agent request only the needed SOM region or action surface on that content path.

## Checks

- Before fixture reproduced `TypeError: extract_markdown() got an unexpected keyword argument 'selector'`.
- Supported-runtime execution passed all 8 Browser Use extractor tests, including both new selector tests.
- `cargo fmt --check`
- `cargo test som::filter` (11 passed)
- `cargo test` (445 library tests plus all binary/integration targets passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

The default Python 3.9 interpreter cannot collect this package because its declared runtime is Python 3.11 or newer; the affected test functions passed under the bundled Python 3.14 interpreter.
