### PR TITLE
feat(sdk/go): add scoped text read options

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -43,6 +43,17 @@ func main() {
     }
     fmt.Println("Scoped regions:", len(scoped.Regions))
 
+    // Scope plain-text reads and optionally cap their size.
+    maxChars := 1200
+    text, err := client.ExtractTextWithOptions("https://example.com", plasmate.ExtractTextOptions{
+        MaxChars: &maxChars,
+        Selector: &selector,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(text)
+
     // Query helpers
     links := plasmate.FindByTag(som, "link")
     fmt.Printf("Found %d links\n", len(links))
@@ -131,6 +142,7 @@ all := plasmate.FlatElements(som)
 | `FetchPage(url)` | Fetch page as SOM |
 | `FetchPageWithOptions(url, opts)` | Fetch with budget, JS, or an optional SOM selector |
 | `ExtractText(url)` | Fetch page as plain text |
+| `ExtractTextWithOptions(url, opts)` | Fetch plain text with max-character and SOM selector options |
 | `OpenPage(url)` | Open interactive session |
 | `Evaluate(sessionID, expr)` | Run JS in page context |
 | `Click(sessionID, elementID)` | Click element, get updated SOM |

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -330,9 +330,32 @@ func (c *Client) ClosePage(sessionID string) error {
 	return err
 }
 
+// ExtractTextOptions holds optional parameters for ExtractTextWithOptions.
+type ExtractTextOptions struct {
+	MaxChars *int    // Maximum characters to return
+	Selector *string // Optional SOM region, role, action, or element-id filter
+}
+
+func extractTextArguments(url string, opts ExtractTextOptions) map[string]interface{} {
+	args := map[string]interface{}{"url": url}
+	if opts.MaxChars != nil {
+		args["max_chars"] = *opts.MaxChars
+	}
+	if opts.Selector != nil {
+		args["selector"] = *opts.Selector
+	}
+	return args
+}
+
 // ExtractText fetches a page and returns clean, readable text.
 func (c *Client) ExtractText(url string) (string, error) {
-	raw, err := c.callTool("extract_text", map[string]interface{}{"url": url})
+	return c.ExtractTextWithOptions(url, ExtractTextOptions{})
+}
+
+// ExtractTextWithOptions fetches a page and returns clean, readable text with
+// optional character and SOM selector limits.
+func (c *Client) ExtractTextWithOptions(url string, opts ExtractTextOptions) (string, error) {
+	raw, err := c.callTool("extract_text", extractTextArguments(url, opts))
 	if err != nil {
 		return "", err
 	}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -33,3 +33,29 @@ func TestFetchPageArgumentsOmitNilSelector(t *testing.T) {
 		t.Fatalf("fetchPage arguments unexpectedly included nil selector: %#v", got)
 	}
 }
+
+func TestExtractTextArgumentsIncludeOptions(t *testing.T) {
+	maxChars := 1200
+	selector := "main"
+
+	got := extractTextArguments("fixture", ExtractTextOptions{
+		MaxChars: &maxChars,
+		Selector: &selector,
+	})
+	want := map[string]interface{}{
+		"url":       "fixture",
+		"max_chars": 1200,
+		"selector":  "main",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("extract_text arguments = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractTextArgumentsOmitNilOptions(t *testing.T) {
+	got := extractTextArguments("fixture", ExtractTextOptions{})
+	if len(got) != 1 || got["url"] != "fixture" {
+		t.Fatalf("extract_text arguments = %#v, want only fixture URL", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ExtractTextWithOptions` to the Go SDK with bounded `max_chars` and SOM `selector` forwarding.
- Keep `ExtractText(url)` backward-compatible and document the scoped text-read journey.

## Agent outcome

Go agents can request only the readable page region they need before prompt construction, with an optional character limit.

## Validation

- Before proof: focused Go test failed because the option type and argument builder were absent.
- Focused proof: `go test ./... -run 'Test(ExtractTextArguments|FetchPageArguments)' -count=1`\n- Go SDK: `go test ./... -count=1`\n- Cross-runtime action manifest: `./scripts/action-manifest-conformance.sh --quick` with Python 3.11 environment\n- Rust formatting: `cargo fmt --all -- --check`\n- Rust tests: `cargo test`\n- Rust lint: `cargo clippy --all-targets --all-features -- -D warnings`