### PR TITLE
fix(langchain): forward fetch controls

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -34,6 +34,8 @@ print(result)
 # the rest of the page.
 result = fetch.invoke({
     "url": "https://news.ycombinator.com",
+    "budget": 2000,
+    "javascript": False,
     "selector": "interactive",
 })
 ```
@@ -172,7 +174,7 @@ Stateless page fetch — returns SOM text for a single URL.
 | Field | Value |
 |-------|-------|
 | Name | `plasmate_fetch` |
-| Input | `url` (string), optional `selector` (string) |
+| Input | `url` (string), optional `budget` (integer), `javascript` (boolean), and `selector` (string) |
 | Output | SOM text with element IDs |
 
 ### `PlasmateNavigateTool`

--- a/integrations/langchain/langchain_plasmate/tools.py
+++ b/integrations/langchain/langchain_plasmate/tools.py
@@ -96,6 +96,14 @@ class _ClickInput(BaseModel):
 
 class _FetchInput(BaseModel):
     url: str = Field(description="The URL to fetch.")
+    budget: Optional[int] = Field(
+        default=None,
+        description="Optional maximum output token budget.",
+    )
+    javascript: bool = Field(
+        default=True,
+        description="Whether to execute JavaScript for dynamic pages.",
+    )
     selector: Optional[str] = Field(
         default=None,
         description="Optional SOM region, role, action, or element-id filter.",
@@ -126,8 +134,8 @@ class PlasmateFetchTool(BaseTool):
         "(navigation, content, forms, interactive elements). "
         "Returns a compact text representation with element IDs "
         "that can be referenced by other tools. "
-        "Input: the URL to fetch, with an optional SOM selector such as "
-        "'main' or 'interactive'."
+        "Input: the URL to fetch, with optional budget, JavaScript, and SOM "
+        "selector controls such as 'main' or 'interactive'."
     )
     args_schema: Type[BaseModel] = _FetchInput
     client: Any = None  # Plasmate instance
@@ -138,15 +146,31 @@ class PlasmateFetchTool(BaseTool):
         super().__init__(**kwargs)
         self.client = client or Plasmate()
 
-    def _run(self, url: str, selector: Optional[str] = None) -> str:
+    def _run(
+        self,
+        url: str,
+        budget: Optional[int] = None,
+        javascript: bool = True,
+        selector: Optional[str] = None,
+    ) -> str:
         kwargs: dict[str, Any] = {}
+        if budget is not None:
+            kwargs["budget"] = budget
+        if not javascript:
+            kwargs["javascript"] = False
         if selector is not None:
             kwargs["selector"] = selector
         som = self.client.fetch_page(url, **kwargs)
         return som_to_text(som)
 
-    async def _arun(self, url: str, selector: Optional[str] = None) -> str:
-        return self._run(url, selector)
+    async def _arun(
+        self,
+        url: str,
+        budget: Optional[int] = None,
+        javascript: bool = True,
+        selector: Optional[str] = None,
+    ) -> str:
+        return self._run(url, budget, javascript, selector)
 
 
 class PlasmateNavigateTool(BaseTool):

--- a/integrations/langchain/tests/test_tools.py
+++ b/integrations/langchain/tests/test_tools.py
@@ -31,13 +31,49 @@ def test_fetch_tool_forwards_selector_and_keeps_string_input() -> None:
     ]
 
 
-def test_fetch_tool_async_forwards_selector() -> None:
+def test_fetch_tool_forwards_budget_javascript_and_selector() -> None:
+    client = Mock()
+    client.fetch_page.return_value = _som()
+    tool = PlasmateFetchTool(client=client)
+
+    tool.invoke(
+        {
+            "url": "fixture",
+            "budget": 128,
+            "javascript": False,
+            "selector": "main",
+        }
+    )
+
+    client.fetch_page.assert_called_once_with(
+        "fixture",
+        budget=128,
+        javascript=False,
+        selector="main",
+    )
+
+
+def test_fetch_tool_async_forwards_fetch_options() -> None:
     import asyncio
 
     client = Mock()
     client.fetch_page.return_value = _som()
     tool = PlasmateFetchTool(client=client)
 
-    asyncio.run(tool.ainvoke({"url": "fixture", "selector": "main"}))
+    asyncio.run(
+        tool.ainvoke(
+            {
+                "url": "fixture",
+                "budget": 128,
+                "javascript": False,
+                "selector": "main",
+            }
+        )
+    )
 
-    client.fetch_page.assert_called_once_with("fixture", selector="main")
+    client.fetch_page.assert_called_once_with(
+        "fixture",
+        budget=128,
+        javascript=False,
+        selector="main",
+    )


### PR DESCRIPTION
## Agent outcome
LangChain agents can now pass the existing Plasmate budget, javascript, and selector fetch controls through PlasmateFetchTool in both sync and async calls. Defaults preserve the existing fetch_page(url) call shape.

## Evidence
Before this change, a synthetic LangChain tool call accepted budget=128 and javascript=False but silently dropped both before calling the Python client. The focused regression now verifies all three controls are forwarded.

## Checks
- Focused and full LangChain integration tests passed in the checked-in Python 3.14 environment.
- cargo fmt --all -- --check passed.
- cargo test passed: 445 library tests and all binary, integration, and doc targets.
- cargo clippy --all-targets --all-features -- -D warnings passed.
- git diff --check passed.

No browser/process, network, auth, cache, release, package, or CI-policy behavior changed.