### PR TITLE
fix(vercel-ai): handle prototype-colliding action keys

### DIFF
--- a/integrations/vercel-ai/src/index.ts
+++ b/integrations/vercel-ai/src/index.ts
@@ -193,6 +193,11 @@ export interface PlasmateActionTargetIndex {
   by_action: Record<string, PlasmateActionTarget[]>
 }
 
+function createActionTargetIndexMap<T>(): Record<string, T> {
+  // SOM identifiers come from page content and may collide with Object.prototype.
+  return Object.create(null) as Record<string, T>
+}
+
 /**
  * System prompt guidance for Vercel AI SDK agents using Plasmate tools.
  *
@@ -607,25 +612,37 @@ export function indexPlasmateActionTargets(
   options: PreparePlasmateActionPlanOptions = {}
 ): PlasmateActionTargetIndex {
   const index: PlasmateActionTargetIndex = {
-    by_id: {},
-    by_cache_key: {},
-    by_html_id: {},
-    by_test_id: {},
-    by_role: {},
-    by_action: {},
+    by_id: createActionTargetIndexMap(),
+    by_cache_key: createActionTargetIndexMap(),
+    by_html_id: createActionTargetIndexMap(),
+    by_test_id: createActionTargetIndexMap(),
+    by_role: createActionTargetIndexMap(),
+    by_action: createActionTargetIndexMap(),
   }
 
   for (const target of preparePlasmateActionPlan(targets, options)) {
-    if (typeof target.id === 'string' && !index.by_id[target.id]) {
+    if (
+      typeof target.id === 'string' &&
+      !Object.prototype.hasOwnProperty.call(index.by_id, target.id)
+    ) {
       index.by_id[target.id] = target
     }
-    if (typeof target.cache_key === 'string' && !index.by_cache_key[target.cache_key]) {
+    if (
+      typeof target.cache_key === 'string' &&
+      !Object.prototype.hasOwnProperty.call(index.by_cache_key, target.cache_key)
+    ) {
       index.by_cache_key[target.cache_key] = target
     }
-    if (typeof target.html_id === 'string' && !index.by_html_id[target.html_id]) {
+    if (
+      typeof target.html_id === 'string' &&
+      !Object.prototype.hasOwnProperty.call(index.by_html_id, target.html_id)
+    ) {
       index.by_html_id[target.html_id] = target
     }
-    if (typeof target.test_id === 'string' && !index.by_test_id[target.test_id]) {
+    if (
+      typeof target.test_id === 'string' &&
+      !Object.prototype.hasOwnProperty.call(index.by_test_id, target.test_id)
+    ) {
       index.by_test_id[target.test_id] = target
     }
     if (typeof target.role === 'string') {

--- a/integrations/vercel-ai/tests/action-plan.test.mjs
+++ b/integrations/vercel-ai/tests/action-plan.test.mjs
@@ -159,6 +159,43 @@ assert.deepEqual(
   ['e_billing']
 )
 
+const prototypeKeyTarget = {
+  id: '__proto__',
+  html_id: 'constructor',
+  test_id: 'hasOwnProperty',
+  role: 'button',
+  actions: ['click'],
+}
+const prototypeBucketTarget = {
+  id: 'e_prototype_bucket',
+  role: '__proto__',
+  actions: ['__proto__'],
+}
+const prototypeIndex = indexPlasmateActionTargets(
+  [prototypeKeyTarget, prototypeBucketTarget],
+  { includeUnavailable: true }
+)
+assert.equal(Object.hasOwn(prototypeIndex.by_id, '__proto__'), true)
+assert.equal(prototypeIndex.by_id['__proto__']?.id, '__proto__')
+assert.equal(Object.hasOwn(prototypeIndex.by_html_id, 'constructor'), true)
+assert.equal(prototypeIndex.by_html_id.constructor?.id, '__proto__')
+assert.equal(Object.hasOwn(prototypeIndex.by_test_id, 'hasOwnProperty'), true)
+assert.equal(prototypeIndex.by_test_id.hasOwnProperty?.id, '__proto__')
+assert.deepEqual(
+  findPlasmateActionTarget(
+    [prototypeKeyTarget],
+    '__proto__',
+    { includeUnavailable: true }
+  )?.id,
+  '__proto__'
+)
+assert.deepEqual(prototypeIndex.by_role['__proto__']?.map((target) => target.id), [
+  'e_prototype_bucket',
+])
+assert.deepEqual(prototypeIndex.by_action['__proto__']?.map((target) => target.id), [
+  'e_prototype_bucket',
+])
+
 const preview = targets.find((target) => target.id === 'e_preview')
 assert.equal(isPlasmateActionTargetAvailable(preview), false)
 assert.equal(preview.enabled, false)


### PR DESCRIPTION
## What changed

Use null-prototype maps for Vercel AI action-plan indexes and preserve explicit own-key checks for replay identifiers.

## Why

SOM identifiers originate in page content. On the previous implementation, a synthetic target with id `__proto__` was not stored, lookup returned `Object.prototype` instead of the target, and a `__proto__` role/action caused a `TypeError` while building the index.

## Agent impact

Vercel AI action-plan replay remains deterministic for page-controlled ids, HTML ids, test ids, roles, and actions, including names that collide with JavaScript object properties.

## Proof

- Before the fix, the new regression fixture failed with: `TypeError: index.by_role[target.role].push is not a function`
- After the fix: `npm test`
- After the fix: `npm run typecheck`
- After the fix: `~/.cargo/bin/cargo fmt --all -- --check`
- After the fix: `~/.cargo/bin/cargo test` (445 tests)
- After the fix: `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
