### PR TITLE
fix(sdk/python): preserve extract_text responses

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -187,6 +187,8 @@ class Plasmate:
             raise RuntimeError(msg)
 
         text = result.get("content", [{}])[0].get("text", "")
+        if name == "extract_text":
+            return text
         if not text:
             return None
 
@@ -412,6 +414,8 @@ class AsyncPlasmate:
             raise RuntimeError(msg)
 
         text = result.get("content", [{}])[0].get("text", "")
+        if name == "extract_text":
+            return text
         if not text:
             return None
 

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -28,10 +28,17 @@ for line in sys.stdin:
         if "id" in request:
             send({"jsonrpc": "2.0", "id": request["id"], "result": {"stale": True}})
     elif method == "tools/call":
+        tool_name = request.get("params", {}).get("name")
+        content = {
+            "type": "text",
+            "text": "Plain text fixture"
+            if tool_name == "extract_text"
+            else json.dumps({"ok": True}),
+        }
         send({
             "jsonrpc": "2.0",
             "id": request.get("id"),
-            "result": {"content": [{"type": "text", "text": json.dumps({"ok": True})}]},
+            "result": {"content": [content]},
         })
 ''',
         encoding="utf-8",
@@ -53,6 +60,25 @@ def test_async_first_tool_call_does_not_consume_notification_response(tmp_path: 
         client = AsyncPlasmate(binary=_fixture(tmp_path))
         try:
             assert await client._call_tool("fixture_tool", {}) == {"ok": True}
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_extract_text_preserves_plain_text(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        assert client.extract_text("fixture") == "Plain text fixture"
+    finally:
+        client.close()
+
+
+def test_async_extract_text_preserves_plain_text(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            assert await client.extract_text("fixture") == "Plain text fixture"
         finally:
             await client.close()
 


### PR DESCRIPTION
## Agent outcome

The Python SDK now returns MCP extract_text content as text for both sync and async clients. Other tool responses keep the existing JSON decoder.

## Before evidence

A synthetic MCP response containing Plain text fixture returned None from both clients. The new sync and async regression tests failed 2/2 on the base.

## After evidence

- PYTHONPATH=src python3 -m pytest tests/ -v (63 passed)
- ~/.cargo/bin/cargo fmt --all -- --check
- ~/.cargo/bin/cargo test (445 library tests and all integration/doc-test groups passed)
- ~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings

## Scope

Bounded SDK protocol-compatibility fix. No network policy, session, cache, secret, release, package, or deployment behavior changed.