### PR TITLE
fix(node): preserve reserved action plan keys

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -210,6 +210,14 @@ export interface ActionPlanIndex {
   byAction: Record<string, ActionPlanItem[]>;
 }
 
+function createActionPlanIndexMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function hasOwnActionPlanKey<T>(map: Record<string, T>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(map, key);
+}
+
 export type ActionTargetLookupKey = 'auto' | 'id' | 'cache_key' | 'html_id' | 'test_id' | 'label';
 
 export interface ActionTargetLookupOptions {
@@ -410,24 +418,26 @@ export function getActionPlanIndex(
 ): ActionPlanIndex {
   const plan = options?.enabledOnly ? getEnabledActionPlan(som) : getActionPlan(som);
   const index: ActionPlanIndex = {
-    byId: {},
-    byCacheKey: {},
-    byHtmlId: {},
-    byTestId: {},
-    byLabel: {},
-    byRole: {},
-    byAction: {},
+    byId: createActionPlanIndexMap(),
+    byCacheKey: createActionPlanIndexMap(),
+    byHtmlId: createActionPlanIndexMap(),
+    byTestId: createActionPlanIndexMap(),
+    byLabel: createActionPlanIndexMap(),
+    byRole: createActionPlanIndexMap(),
+    byAction: createActionPlanIndexMap(),
   };
   for (const item of plan) {
-    if (index.byId[item.id] === undefined) index.byId[item.id] = item;
-    if (index.byCacheKey[item.cache_key] === undefined) index.byCacheKey[item.cache_key] = item;
-    if (item.html_id && index.byHtmlId[item.html_id] === undefined) {
+    if (!hasOwnActionPlanKey(index.byId, item.id)) index.byId[item.id] = item;
+    if (!hasOwnActionPlanKey(index.byCacheKey, item.cache_key)) {
+      index.byCacheKey[item.cache_key] = item;
+    }
+    if (item.html_id && !hasOwnActionPlanKey(index.byHtmlId, item.html_id)) {
       index.byHtmlId[item.html_id] = item;
     }
-    if (item.test_id && index.byTestId[item.test_id] === undefined) {
+    if (item.test_id && !hasOwnActionPlanKey(index.byTestId, item.test_id)) {
       index.byTestId[item.test_id] = item;
     }
-    if (item.label && index.byLabel[item.label] === undefined) {
+    if (item.label && !hasOwnActionPlanKey(index.byLabel, item.label)) {
       index.byLabel[item.label] = item;
     }
     (index.byRole[item.role] ??= []).push(item);

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -540,6 +540,56 @@ describe('getActionPlan', () => {
     expect(index.byAction.click.map((target) => target.id)).toEqual(['e_billing']);
     expect(index.byId.e_plan).toBeDefined();
   });
+
+  it('preserves replay targets with reserved object-property names', () => {
+    const identifierSom: Som = {
+      som_version: '1.0',
+      url: 'fixture',
+      title: '',
+      lang: 'en',
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: '__proto__',
+              role: 'button',
+              html_id: 'constructor',
+              label: 'toString',
+              actions: ['click'],
+              attrs: { test_id: 'hasOwnProperty' },
+            },
+          ],
+        },
+      ],
+      meta: { html_bytes: 1, som_bytes: 1, element_count: 1, interactive_count: 1 },
+    };
+    const index = getActionPlanIndex(identifierSom);
+
+    expect(index.byId['__proto__']?.id).toBe('__proto__');
+    expect(index.byHtmlId.constructor?.id).toBe('__proto__');
+    expect(index.byTestId.hasOwnProperty?.id).toBe('__proto__');
+    expect(index.byLabel.toString?.id).toBe('__proto__');
+
+    const bucketSom = {
+      ...identifierSom,
+      regions: [
+        {
+          ...identifierSom.regions[0],
+          elements: [{ id: 'bucket-collision', role: '__proto__', actions: ['__proto__'] }],
+        },
+      ],
+    } as unknown as Som;
+    const bucketIndex = getActionPlanIndex(bucketSom);
+
+    expect(bucketIndex.byRole['__proto__'].map((target) => target.id)).toEqual([
+      'bucket-collision',
+    ]);
+    expect(bucketIndex.byAction['__proto__'].map((target) => target.id)).toEqual([
+      'bucket-collision',
+    ]);
+  });
 });
 
 describe('getLinks', () => {

--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -372,6 +372,59 @@ describe('getActionPlan', () => {
     assert.deepEqual(index.byAction.click.map((target) => target.id), ['e_billing']);
     assert.notEqual(index.byId.e_plan, undefined);
   });
+
+  it('preserves replay targets with reserved object-property names', () => {
+    const identifierSom: Som = {
+      som_version: '1.0',
+      url: 'fixture',
+      title: '',
+      lang: 'en',
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: '__proto__',
+              role: 'button',
+              html_id: 'constructor',
+              label: 'toString',
+              actions: ['click'],
+              attrs: { test_id: 'hasOwnProperty' },
+            },
+          ],
+        },
+      ],
+      meta: { html_bytes: 1, som_bytes: 1, element_count: 1, interactive_count: 1 },
+    };
+    const index = getActionPlanIndex(identifierSom);
+    const byHtmlId = index.byHtmlId as Record<string, { id?: string }>;
+    const byTestId = index.byTestId as Record<string, { id?: string }>;
+    const byLabel = index.byLabel as Record<string, { id?: string }>;
+
+    assert.equal(index.byId['__proto__']?.id, '__proto__');
+    assert.equal(byHtmlId['constructor']?.id, '__proto__');
+    assert.equal(byTestId['hasOwnProperty']?.id, '__proto__');
+    assert.equal(byLabel['toString']?.id, '__proto__');
+
+    const bucketSom = {
+      ...identifierSom,
+      regions: [
+        {
+          ...identifierSom.regions[0],
+          elements: [{ id: 'bucket-collision', role: '__proto__', actions: ['__proto__'] }],
+        },
+      ],
+    } as unknown as Som;
+    const bucketIndex = getActionPlanIndex(bucketSom);
+
+    assert.deepEqual(bucketIndex.byRole['__proto__'].map((target) => target.id), [
+      'bucket-collision',
+    ]);
+    assert.deepEqual(bucketIndex.byAction['__proto__'].map((target) => target.id), [
+      'bucket-collision',
+    ]);
+  });
 });
 
 describe('flatElements', () => {

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -165,6 +165,14 @@ export interface ActionPlanIndex {
   byAction: Record<string, ActionPlanItem[]>;
 }
 
+function createActionPlanIndexMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function hasOwnActionPlanKey<T>(map: Record<string, T>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(map, key);
+}
+
 export type ActionTargetLookupKey = 'auto' | 'id' | 'cache_key' | 'html_id' | 'test_id' | 'label';
 
 export interface ActionTargetLookupOptions {
@@ -367,24 +375,26 @@ export function getActionPlanIndex(
 ): ActionPlanIndex {
   const plan = options?.enabledOnly ? getEnabledActionPlan(som) : getActionPlan(som);
   const index: ActionPlanIndex = {
-    byId: {},
-    byCacheKey: {},
-    byHtmlId: {},
-    byTestId: {},
-    byLabel: {},
-    byRole: {},
-    byAction: {},
+    byId: createActionPlanIndexMap(),
+    byCacheKey: createActionPlanIndexMap(),
+    byHtmlId: createActionPlanIndexMap(),
+    byTestId: createActionPlanIndexMap(),
+    byLabel: createActionPlanIndexMap(),
+    byRole: createActionPlanIndexMap(),
+    byAction: createActionPlanIndexMap(),
   };
   for (const item of plan) {
-    if (index.byId[item.id] === undefined) index.byId[item.id] = item;
-    if (index.byCacheKey[item.cache_key] === undefined) index.byCacheKey[item.cache_key] = item;
-    if (item.html_id && index.byHtmlId[item.html_id] === undefined) {
+    if (!hasOwnActionPlanKey(index.byId, item.id)) index.byId[item.id] = item;
+    if (!hasOwnActionPlanKey(index.byCacheKey, item.cache_key)) {
+      index.byCacheKey[item.cache_key] = item;
+    }
+    if (item.html_id && !hasOwnActionPlanKey(index.byHtmlId, item.html_id)) {
       index.byHtmlId[item.html_id] = item;
     }
-    if (item.test_id && index.byTestId[item.test_id] === undefined) {
+    if (item.test_id && !hasOwnActionPlanKey(index.byTestId, item.test_id)) {
       index.byTestId[item.test_id] = item;
     }
-    if (item.label && index.byLabel[item.label] === undefined) {
+    if (item.label && !hasOwnActionPlanKey(index.byLabel, item.label)) {
       index.byLabel[item.label] = item;
     }
     (index.byRole[item.role] ??= []).push(item);


### PR DESCRIPTION
## What changed

Use null-prototype maps and own-key checks for replay action-plan indexes in the Node SDK and Node SOM parser.

## Why

Page-controlled IDs, HTML IDs, test IDs, labels, roles, and actions can use names such as `__proto__`, `constructor`, and `hasOwnProperty`. Normal JavaScript objects can drop those targets or treat role/action buckets as inherited values.

## Agent impact

Node action-plan lookup and role/action grouping now preserve these targets without changing the public `Record`-shaped API.

## Proof

- Added matching regression coverage to both Node surfaces.
- Before the implementation, the new tests failed on the base: 30/31 SDK tests and 61/62 parser tests passed.
- After the implementation, SDK tests passed 31/31 and parser tests passed 62/62.
- Independent synthetic probe passed for reserved identifiers and reserved role/action buckets in both packages.
- `cargo fmt --all -- --check` passed.
- `cargo test` passed: 445 library tests, 61 binary tests, all integration groups, and doc tests.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- The action-manifest conformance harness reached its fixture check but could not continue because this host has Python 3.9.6 and no Python 3.11+ environment.

No release, package publication, deployment, or public performance claim is included.
