### PR TITLE
fix(langchain): keep async tools off event loop

### DIFF
--- a/integrations/langchain/langchain_plasmate/tools.py
+++ b/integrations/langchain/langchain_plasmate/tools.py
@@ -163,16 +163,6 @@ class PlasmateFetchTool(BaseTool):
         som = self.client.fetch_page(url, **kwargs)
         return som_to_text(som)
 
-    async def _arun(
-        self,
-        url: str,
-        budget: Optional[int] = None,
-        javascript: bool = True,
-        selector: Optional[str] = None,
-    ) -> str:
-        return self._run(url, budget, javascript, selector)
-
-
 class PlasmateNavigateTool(BaseTool):
     """Navigate to a URL in a persistent browser session.
 
@@ -195,10 +185,6 @@ class PlasmateNavigateTool(BaseTool):
         som = self.browser.navigate(url)
         return som_to_text(som)
 
-    async def _arun(self, url: str) -> str:
-        return self._run(url)
-
-
 class PlasmateClickTool(BaseTool):
     """Click an interactive element by its SOM ID."""
 
@@ -217,10 +203,6 @@ class PlasmateClickTool(BaseTool):
         som = self.browser.click(element_id)
         return som_to_text(som)
 
-    async def _arun(self, element_id: str) -> str:
-        return self._run(element_id)
-
-
 class PlasmateTypeTool(BaseTool):
     """Type text into a form field by its SOM ID."""
 
@@ -238,10 +220,6 @@ class PlasmateTypeTool(BaseTool):
     def _run(self, element_id: str, text: str) -> str:
         som = self.browser.type_text(element_id, text)
         return som_to_text(som)
-
-    async def _arun(self, element_id: str, text: str) -> str:
-        return self._run(element_id, text)
-
 
 # ---------------------------------------------------------------------------
 # Convenience constructor

--- a/integrations/langchain/tests/test_tools.py
+++ b/integrations/langchain/tests/test_tools.py
@@ -1,6 +1,15 @@
+import asyncio
+import time
 from unittest.mock import Mock, call
 
-from langchain_plasmate import PlasmateFetchTool
+import pytest
+
+from langchain_plasmate import (
+    PlasmateClickTool,
+    PlasmateFetchTool,
+    PlasmateNavigateTool,
+    PlasmateTypeTool,
+)
 
 
 def _som() -> dict:
@@ -51,6 +60,56 @@ def test_fetch_tool_forwards_budget_javascript_and_selector() -> None:
         javascript=False,
         selector="main",
     )
+
+
+def _blocking_som(*args: object, **kwargs: object) -> dict:
+    time.sleep(0.08)
+    return _som()
+
+
+def _fetch_tool() -> PlasmateFetchTool:
+    client = Mock()
+    client.fetch_page.side_effect = _blocking_som
+    return PlasmateFetchTool(client=client)
+
+
+def _navigate_tool() -> PlasmateNavigateTool:
+    browser = Mock()
+    browser.navigate.side_effect = _blocking_som
+    return PlasmateNavigateTool(browser=browser)
+
+
+def _click_tool() -> PlasmateClickTool:
+    browser = Mock()
+    browser.click.side_effect = _blocking_som
+    return PlasmateClickTool(browser=browser)
+
+
+def _type_tool() -> PlasmateTypeTool:
+    browser = Mock()
+    browser.type_text.side_effect = _blocking_som
+    return PlasmateTypeTool(browser=browser)
+
+
+@pytest.mark.parametrize(
+    ("factory", "tool_input"),
+    [
+        (_fetch_tool, {"url": "fixture"}),
+        (_navigate_tool, "fixture"),
+        (_click_tool, {"element_id": "e1"}),
+        (_type_tool, {"element_id": "e1", "text": "x"}),
+    ],
+    ids=["fetch", "navigate", "click", "type"],
+)
+def test_async_tools_do_not_block_event_loop(factory, tool_input) -> None:
+    async def exercise() -> None:
+        tool = factory()
+        call_task = asyncio.create_task(tool.ainvoke(tool_input))
+        await asyncio.sleep(0.01)
+        assert not call_task.done()
+        await asyncio.wait_for(call_task, timeout=1)
+
+    asyncio.run(exercise())
 
 
 def test_fetch_tool_async_forwards_fetch_options() -> None:


### PR DESCRIPTION
## Summary

- remove four redundant `_arun` overrides so LangChain runs the existing synchronous tool implementation in its executor
- add one parameterized regression proof for fetch, navigate, click, and type

## Agent impact

The old async hooks called blocking Plasmate operations directly on the event loop. An async agent could stop serving other work while a page read or interaction was in progress. The change keeps the existing sync client and session behavior and only restores LangChain's standard executor path.

## Validation

- base probe: an 80 ms synthetic blocking client delayed the event loop for all four tools
- after proof: LangChain tests 7/7 and full integration suite 10/10
- action-manifest conformance: quick mode passed
- Rust: `cargo fmt --all -- --check`, full `cargo test`, and strict `cargo clippy --all-targets --all-features -- -D warnings` passed

The evidence is synthetic wrapper compatibility proof, not live agent task-success evidence.