### PR TITLE
fix(sdk/python): bound empty MCP errors

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -67,6 +67,18 @@ def _extract_last_json(text: str) -> Any:
     return None
 
 
+def _tool_text(result: Any) -> str:
+    """Return the first MCP text block, or an empty string when absent."""
+    content = result.get("content") if isinstance(result, dict) else None
+    if not isinstance(content, list) or not content:
+        return ""
+    first = content[0]
+    if not isinstance(first, dict):
+        return ""
+    text = first.get("text", "")
+    return text if isinstance(text, str) else ""
+
+
 class Plasmate:
     """
     Synchronous Plasmate client.
@@ -182,11 +194,10 @@ class Plasmate:
         self._ensure_started()
         result = self._rpc("tools/call", {"name": name, "arguments": arguments})
 
+        text = _tool_text(result)
         if result and result.get("isError"):
-            msg = result.get("content", [{}])[0].get("text", "Unknown error")
-            raise RuntimeError(msg)
+            raise RuntimeError(text or "Unknown error")
 
-        text = result.get("content", [{}])[0].get("text", "")
         if name == "extract_text":
             return text
         if not text:
@@ -409,11 +420,10 @@ class AsyncPlasmate:
         await self._ensure_started()
         result = await self._rpc("tools/call", {"name": name, "arguments": arguments})
 
+        text = _tool_text(result)
         if result and result.get("isError"):
-            msg = result.get("content", [{}])[0].get("text", "Unknown error")
-            raise RuntimeError(msg)
+            raise RuntimeError(text or "Unknown error")
 
-        text = result.get("content", [{}])[0].get("text", "")
         if name == "extract_text":
             return text
         if not text:

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -5,6 +5,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from plasmate.client import AsyncPlasmate, Plasmate
 
 
@@ -29,6 +31,13 @@ for line in sys.stdin:
             send({"jsonrpc": "2.0", "id": request["id"], "result": {"stale": True}})
     elif method == "tools/call":
         tool_name = request.get("params", {}).get("name")
+        if tool_name == "empty_error":
+            send({
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "result": {"content": [], "isError": True},
+            })
+            continue
         content = {
             "type": "text",
             "text": "Plain text fixture"
@@ -79,6 +88,27 @@ def test_async_extract_text_preserves_plain_text(tmp_path: Path) -> None:
         client = AsyncPlasmate(binary=_fixture(tmp_path))
         try:
             assert await client.extract_text("fixture") == "Plain text fixture"
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_empty_error_content_has_bounded_message(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        with pytest.raises(RuntimeError, match="Unknown error"):
+            client._call_tool("empty_error", {})
+    finally:
+        client.close()
+
+
+def test_async_empty_error_content_has_bounded_message(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            with pytest.raises(RuntimeError, match="Unknown error"):
+                await client._call_tool("empty_error", {})
         finally:
             await client.close()
 


### PR DESCRIPTION
## What changed

The Python SDK now reads MCP tool text through a small defensive helper in both sync and async clients. Empty or malformed `content` blocks on an error result now raise the bounded `Unknown error` message instead of raising an indexing exception.

## Why

An MCP error response with `isError: true` and an empty `content` array made both clients fail with `IndexError: list index out of range`, hiding the agent-visible error state.

## Validation

- Synthetic base probe reproduced `IndexError: list index out of range`.
- Python SDK focused protocol tests: 6 passed.
- Full Python SDK suite: 65 passed.
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test` (445 library, 61 binary, all integration and doc tests passed)
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`

This change does not access pages, credentials, sessions, or customer data.
