### PR TITLE
fix(sdk/go): bound empty tool errors

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -226,7 +226,7 @@ func (c *Client) callTool(name string, args map[string]interface{}) (json.RawMes
 	}
 	if result.IsError {
 		msg := "unknown error"
-		if len(result.Content) > 0 {
+		if len(result.Content) > 0 && result.Content[0].Text != "" {
 			msg = result.Content[0].Text
 		}
 		return nil, errors.New(msg)

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,6 +1,8 @@
 package plasmate
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -57,5 +59,31 @@ func TestExtractTextArgumentsOmitNilOptions(t *testing.T) {
 	got := extractTextArguments("fixture", ExtractTextOptions{})
 	if len(got) != 1 || got["url"] != "fixture" {
 		t.Fatalf("extract_text arguments = %#v, want only fixture URL", got)
+	}
+}
+
+func TestEmptyToolErrorKeepsBoundedMessage(t *testing.T) {
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "mcp-fixture.sh")
+	if err := os.WriteFile(fixture, []byte(`#!/bin/sh
+while IFS= read -r request; do
+  case "$request" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}'
+      ;;
+    *'"method":"tools/call"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":""}],"isError":true}}'
+      ;;
+  esac
+done
+`), 0o700); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	client := NewClient(WithBinary(fixture))
+	defer client.Close()
+	_, err := client.FetchPage("fixture")
+	if err == nil || err.Error() != "unknown error" {
+		t.Fatalf("FetchPage error = %v, want bounded unknown error", err)
 	}
 }


### PR DESCRIPTION
## What changed

Keep the Go SDK's bounded `unknown error` message when an MCP tool error has an empty text block.

## Why

Before this change, an error result with an empty text block replaced the fallback with an empty string. The agent then received an unhelpful blank error.

A subprocess-backed Go regression fixture reproduces the empty text result and requires the bounded message.

## Validation

- Go focused regression passes.
- `go test ./...` passes.
- `go test -race ./...` passes.
- `go vet ./...` passes.
- `./scripts/action-manifest-conformance.sh --quick` passes.
- `cargo fmt --all -- --check` passes.
- `cargo test` passes.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.

This is a package-level SDK error-path fix. It does not change sessions, containment, network policy, secrets, release behavior, or public performance claims.
