### PR TITLE
fix(sdk/node): bound empty tool errors

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -71,4 +71,43 @@ input.on('line', (line) => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
+  it('keeps a bounded message for empty tool errors', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'plasmate-node-sdk-'));
+    const fixture = join(directory, 'mcp-fixture.js');
+    writeFileSync(
+      fixture,
+      `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const input = createInterface({ input: process.stdin });
+
+input.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05' } });
+  } else if (request.method === 'tools/call') {
+    send({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { isError: true, content: [{ type: 'text', text: '' }] },
+    });
+  }
+});
+`,
+      'utf8',
+    );
+    chmodSync(fixture, 0o755);
+
+    const browser = new Plasmate({ binary: fixture });
+    try {
+      await assert.rejects(browser.fetchPage('fixture'), (error: unknown) => {
+        return error instanceof Error && error.message === 'Unknown error';
+      });
+    } finally {
+      browser.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
 });

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -242,7 +242,7 @@ export class Plasmate extends EventEmitter {
     };
 
     if (result.isError) {
-      const msg = result.content?.[0]?.text ?? 'Unknown error';
+      const msg = result.content?.[0]?.text || 'Unknown error';
       throw new Error(msg);
     }
 


### PR DESCRIPTION
## Summary
- preserve the Node SDK's bounded `Unknown error` message when an MCP error result contains an empty text block
- add a real stdio regression fixture for the malformed error result

## Evidence
- the new fixture failed on the base with an empty `Error` message
- `npm test` passes 32/32 in `sdk/node`
- the direct compiled-client probe returns `Unknown error`
- the quick action-manifest conformance check passes
- `cargo fmt --all -- --check` passes
- `cargo test` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes
