### PR TITLE
fix(sdk/node): load advertised ESM entry point

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -1,8 +1,9 @@
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { Plasmate } from './index';
 
 type ToolCall = { name: string; args: Record<string, unknown> };
@@ -109,5 +110,23 @@ input.on('line', (line) => {
       browser.close();
       rmSync(directory, { recursive: true, force: true });
     }
+  });
+});
+
+describe('package entry points', () => {
+  it('loads the advertised ESM package entry', () => {
+    const script = `
+      const module = await import('plasmate');
+      if (typeof module.Plasmate !== 'function' || typeof module.findByRole !== 'function') {
+        throw new Error('missing ESM SDK exports');
+      }
+    `;
+
+    assert.doesNotThrow(() => {
+      execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd: resolve(__dirname, '..'),
+        stdio: 'pipe',
+      });
+    });
   });
 });

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -74,7 +74,7 @@ export {
   getActionPlanIndex,
   getEnabledActionPlan,
   getTokenEstimate,
-} from './query';
+} from './query.js';
 
 import type { Som } from './types';
 


### PR DESCRIPTION
## What changed

- Add the `.js` extension to the Node SDK's runtime query export.
- Add a regression test that imports the advertised `plasmate` ESM package entry and checks its public exports.

## Why

The built ESM entry imported `./query` without an extension. Node's standard ESM resolver could not load that module, so consumers using the package's `exports.import` path failed before the SDK could start.

## Agent impact

Node agents can load the advertised ESM package entry point. The CommonJS entry and runtime protocol behavior are unchanged.

## Validation

- Base regression failed 1/33 with `ERR_MODULE_NOT_FOUND` for `dist/esm/query`.
- Node SDK suite passes 33/33 after the fix.
- Direct ESM and package self-import probes pass.
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- Quick cross-runtime action-manifest conformance passes.
