### PR TITLE
docs(langchain): align token guidance with evidence

### DIFF
--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -40,7 +40,7 @@ result = fetch.invoke({
 })
 ```
 
-Output:
+Example output (values are illustrative; actual values vary by page, options, and serializer):
 ```
 Page: Hacker News
 URL: https://news.ycombinator.com
@@ -155,15 +155,20 @@ for doc in docs:
     print()
 ```
 
-## Token Comparison
+## Token usage
 
-| Source | Hacker News | Example.com | Typical News Article |
-|--------|-------------|-------------|---------------------|
-| Raw HTML (WebBaseLoader) | ~22,000 tokens | ~400 tokens | ~45,000 tokens |
-| **SOM (PlasmateSOMLoader)** | **~1,500 tokens** | **~80 tokens** | **~3,000 tokens** |
-| **Savings** | **~15x** | **~5x** | **~15x** |
+Token counts depend on the page, selected SOM scope, serializer, and target
+model tokenizer. This integration does not retain a LangChain token benchmark,
+so it does not publish fixed token or savings values as measured results.
 
-SOM preserves all interactive elements, headings, and content structure while stripping scripts, styles, hidden elements, and layout-only markup.
+The loader exposes `html_bytes` and `som_bytes` in document metadata. Those are
+serialized byte counts, not token counts, and do not imply a fixed savings ratio.
+For a task-specific comparison, run the raw and SOM outputs through the target
+model tokenizer and retain the page set, configuration, tokenizer version, and
+complete input denominator.
+
+SOM preserves supported interactive elements, headings, and content structure
+while stripping scripts, styles, hidden elements, and layout-only markup.
 
 ## Tools Reference
 

--- a/integrations/langchain/tests/test_readme.py
+++ b/integrations/langchain/tests/test_readme.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+README = Path(__file__).parents[1] / "README.md"
+
+
+def test_readme_labels_token_evidence_limits() -> None:
+    readme = README.read_text()
+
+    assert "## Token usage" in readme
+    assert "does not retain a LangChain token benchmark" in readme
+    assert "not token counts" in readme
+    assert "## Token Comparison" not in readme


### PR DESCRIPTION
## What changed

- Replace the fixed LangChain token and savings table with evidence-aligned guidance.
- Label the README byte metadata as serialized bytes, not token counts.
- Mark the sample output values as illustrative.
- Add a regression test that prevents the unsupported token table from returning.

## Why

The README presented fixed token values, but the repository retains no LangChain token benchmark or denominator. The loader exposes page-specific `html_bytes` and `som_bytes` metadata only.

## Agent impact

LangChain users now get truthful guidance for choosing SOM output and measuring task-specific token use with their target tokenizer. The runtime integration is unchanged.

## Validation

- Base regression: 1 focused test failed because the unsupported token table was present.
- After change: LangChain suite passes 11/11.
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- Quick cross-runtime action-manifest conformance passes.
