### PR TITLE
fix(browser-use): bound CLI error diagnostics

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -22,6 +22,15 @@ from som_parser import (
 )
 
 
+_CLI_ERROR_DETAIL_LIMIT = 200
+
+
+def _format_cli_failure(stderr: str) -> str:
+    """Return a useful, bounded error for a failed Plasmate CLI read."""
+    detail = " ".join(stderr.split())[:_CLI_ERROR_DETAIL_LIMIT]
+    return f"plasmate fetch failed: {detail or 'Unknown error'}"
+
+
 def _extract_last_json(text: str) -> Any:
     """Extract the last complete JSON object from potentially mixed output.
 
@@ -312,7 +321,7 @@ class PlasmateExtractor:
             capture_output=True, text=True, timeout=30
         )
         if result.returncode != 0:
-            raise RuntimeError(f"plasmate fetch failed: {result.stderr}")
+            raise RuntimeError(_format_cli_failure(result.stderr))
         som = _extract_last_json(result.stdout)
         if som is None:
             raise RuntimeError(
@@ -341,7 +350,7 @@ class PlasmateExtractor:
         )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
         if proc.returncode != 0:
-            raise RuntimeError(f"plasmate fetch failed: {stderr.decode()}")
+            raise RuntimeError(_format_cli_failure(stderr.decode(errors="replace")))
         som = _extract_last_json(stdout.decode())
         if som is None:
             raise RuntimeError(

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from plasmate_browser_use.extractor import PlasmateExtractor
 
 
@@ -138,6 +140,45 @@ def test_async_extract_forwards_no_javascript_to_cli():
         "fixture",
         "--no-js",
     )
+
+
+def test_extract_cli_error_uses_bounded_fallback_for_empty_stderr():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    completed = SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ):
+        with pytest.raises(RuntimeError, match="plasmate fetch failed: Unknown error"):
+            extractor.extract("fixture")
+
+
+def test_async_extract_cli_error_is_bounded():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+
+    class FakeProcess:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"E" * 600
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return FakeProcess()
+
+    async def exercise():
+        with patch(
+            "plasmate_browser_use.extractor.asyncio.create_subprocess_exec",
+            new=fake_create_subprocess_exec,
+        ):
+            with pytest.raises(RuntimeError) as error:
+                await extractor.extract_async("fixture")
+        assert str(error.value).startswith("plasmate fetch failed: ")
+        assert len(str(error.value)) <= 256
+
+    asyncio.run(exercise())
 
 
 def test_markdown_forwards_selector_to_cli():


### PR DESCRIPTION
## Agent outcome

Browser Use sync and async CLI reads now return bounded, actionable errors when the Plasmate process fails.

## Before evidence

A local child-process fixture with empty stderr produced `plasmate fetch failed: `, and a 600-character diagnostic produced a 623-character exception in both paths.

## After evidence

- Empty diagnostics use `Unknown error`.
- Diagnostic text is whitespace-normalized and capped at 200 characters.
- Invalid UTF-8 from the async child process is decoded with replacement characters.
- Browser Use focused tests pass 12/12.
- The cross-runtime action-manifest quick check passes.

## Checks

- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

This is a bounded Browser Use adapter error-path fix. It does not change page fetching, sessions, network policy, credentials, release behavior, or package publication.
