### PR TITLE
docs(browser-use): align token claim with evidence

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/__init__.py
+++ b/integrations/browser-use/plasmate_browser_use/__init__.py
@@ -2,7 +2,8 @@
 Plasmate SOM integration for Browser Use.
 
 Provides SOM-based content extraction that can replace or complement
-Browser Use's default DOM serialization, reducing token costs by 90%+.
+Browser Use's default DOM serialization. Output size, tokenization, and cost
+depend on the page and workflow; measure the target workload before estimating.
 
 Example::
 

--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -1,7 +1,8 @@
 """Plasmate SOM extractor for Browser Use.
 
 Provides SOM-based content extraction that can replace or complement
-Browser Use's default DOM serialization, reducing token costs by 90%+.
+Browser Use's default DOM serialization. Output size, tokenization, and cost
+depend on the page and workflow; measure the target workload before estimating.
 """
 
 import asyncio


### PR DESCRIPTION
## Summary

- remove the unsupported fixed “90%+ token cost” statement from the Browser Use package module docstrings
- align the source-facing guidance with the retained serialized-byte evidence and the package README
- keep runtime behavior unchanged

## Evidence

Before: both public module docstrings claimed the integration reduced token costs by 90%+.

After: both state that output size, tokenization, and cost depend on the page and workflow and should be measured.

## Checks

- Browser Use focused suite: 12 passed
- action-manifest conformance: passed
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
