### PR TITLE
docs(website): align token guidance with evidence

### DIFF
--- a/scripts/test_public_claim_surfaces.py
+++ b/scripts/test_public_claim_surfaces.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SURFACES = (
+    (
+        ("website/docs/src/why-som.md", "website/docs/why-som.html"),
+        "lower token costs, faster inference",
+        "measure output size and token use for the target workflow",
+    ),
+    (
+        ("website/docs/src/som-first-sites.md", "website/docs/som-first-sites.html"),
+        "Reduce token costs by avoiding boilerplate and duplicated content",
+        "measure token use with the target tokenizer",
+    ),
+)
+
+
+class PublicClaimSurfaceTests(unittest.TestCase):
+    def test_public_guidance_uses_evidence_aligned_wording(self) -> None:
+        for paths, stale_wording, aligned_wording in SURFACES:
+            for relative_path in paths:
+                with self.subTest(path=relative_path):
+                    text = (ROOT / relative_path).read_text(encoding="utf-8")
+                    self.assertNotIn(stale_wording, text)
+                    self.assertIn(aligned_wording, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/docs/som-first-sites.html
+++ b/website/docs/som-first-sites.html
@@ -467,7 +467,7 @@
 <hr>
 <h2 id="goals">Goals</h2><ul>
 <li>Make pages easier for agents to understand</li>
-<li>Reduce token costs by avoiding boilerplate and duplicated content</li>
+<li>Keep agent context focused by avoiding boilerplate and duplicated content; measure token use with the target tokenizer</li>
 <li>Make automation more reliable by keeping element structure stable</li>
 <li>Make caching easier by publishing stable, machine-readable representations</li>
 </ul>

--- a/website/docs/src/som-first-sites.md
+++ b/website/docs/src/som-first-sites.md
@@ -14,7 +14,7 @@ This page is a best-practices guide for site owners and a checklist for Plasmate
 ## Goals
 
 - Make pages easier for agents to understand
-- Reduce token costs by avoiding boilerplate and duplicated content
+- Keep agent context focused by avoiding boilerplate and duplicated content; measure token use with the target tokenizer
 - Make automation more reliable by keeping element structure stable
 - Make caching easier by publishing stable, machine-readable representations
 
@@ -124,4 +124,3 @@ All Plasmate Labs properties should aim to:
 - Publish `/.well-known/som.json` and link it from HTML
 
 If a property cannot publish SOM yet, it should at least meet the Level 1 DOM guidelines.
-

--- a/website/docs/src/why-som.md
+++ b/website/docs/src/why-som.md
@@ -148,7 +148,7 @@
       <h2>Who Benefits</h2>
 
       <ul>
-        <li><strong>Agent framework developers</strong> (Browser Use, LangChain, CrewAI): lower token costs, faster inference, structured page data out of the box</li>
+        <li><strong>Agent framework developers</strong> (Browser Use, LangChain, CrewAI): structured page data out of the box; measure output size and token use for the target workflow</li>
         <li><strong>Enterprise AI teams</strong>: predictable, structured web data instead of HTML soup. No more prompt-engineering around broken DOM structures.</li>
         <li><strong>Web processing at scale</strong>: structured output can omit irrelevant markup, but cost impact must be measured on the actual corpus, tokenizer, and task.</li>
         <li><strong>Tool-use agents</strong>: explicit action annotations tell the model exactly what's clickable, typeable, and selectable. No guessing.</li>

--- a/website/docs/why-som.html
+++ b/website/docs/why-som.html
@@ -607,7 +607,7 @@
       <h2>Who Benefits</h2>
 
       <ul>
-        <li><strong>Agent framework developers</strong> (Browser Use, LangChain, CrewAI): lower token costs, faster inference, structured page data out of the box</li>
+        <li><strong>Agent framework developers</strong> (Browser Use, LangChain, CrewAI): structured page data out of the box; measure output size and token use for the target workflow</li>
         <li><strong>Enterprise AI teams</strong>: predictable, structured web data instead of HTML soup. No more prompt-engineering around broken DOM structures.</li>
         <li><strong>Web processing at scale</strong>: structured output can omit irrelevant markup, but cost impact must be measured on the actual corpus, tokenizer, and task.</li>
         <li><strong>Tool-use agents</strong>: explicit action annotations tell the model exactly what's clickable, typeable, and selectable. No guessing.</li>


### PR DESCRIPTION
## Summary

- replace stale website guidance that presents token cost or inference speed as a general benefit
- direct readers to measure output size and token use for the target workflow and tokenizer
- add a regression check for both Markdown sources and generated HTML pages

## Before

The clean base contained two public guidance phrases that conflicted with the repository claim registry: lower token costs and faster inference for framework developers, and a goal to reduce token costs.

## After

The two pages describe structured page data and focused agent context, then require workflow-specific measurement. Runtime behavior is unchanged.

## Checks

- base claim check reproduced the two stale phrases
- regression test passed after the change
- website build passed
- claim registry JSON validation passed
- cargo fmt --all -- --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
