### PR TITLE
fix(sdk/python): enforce MCP response timeouts

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -164,8 +164,28 @@ class Plasmate:
     def _read_response(self) -> dict:
         if not self._process or not self._process.stdout:
             raise RuntimeError("Plasmate process is not running")
+        stdout = self._process.stdout
         while True:
-            line = self._process.stdout.readline()
+            line_result: list[bytes] = []
+            read_error: list[Exception] = []
+            finished = threading.Event()
+
+            def read_line() -> None:
+                try:
+                    line_result.append(stdout.readline())
+                except Exception as exc:
+                    read_error.append(exc)
+                finally:
+                    finished.set()
+
+            threading.Thread(target=read_line, daemon=True).start()
+            if not finished.wait(self._timeout):
+                self.close()
+                raise RuntimeError("Timed out waiting for response")
+            if read_error:
+                raise read_error[0]
+
+            line = line_result[0]
             if not line:
                 raise RuntimeError("Plasmate process closed unexpectedly")
             line = line.decode().strip()
@@ -390,8 +410,13 @@ class AsyncPlasmate:
     async def _read_response(self) -> dict:
         if not self._process or not self._process.stdout:
             raise RuntimeError("Plasmate process is not running")
+        stdout = self._process.stdout
         while True:
-            line = await self._process.stdout.readline()
+            try:
+                line = await asyncio.wait_for(stdout.readline(), timeout=self._timeout)
+            except asyncio.TimeoutError as exc:
+                await self.close()
+                raise RuntimeError("Timed out waiting for response") from exc
             if not line:
                 raise RuntimeError("Plasmate process closed unexpectedly")
             text = line.decode().strip()

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,8 @@ for line in sys.stdin:
             send({"jsonrpc": "2.0", "id": request["id"], "result": {"stale": True}})
     elif method == "tools/call":
         tool_name = request.get("params", {}).get("name")
+        if tool_name == "silent_tool":
+            continue
         if tool_name == "empty_error":
             send({
                 "jsonrpc": "2.0",
@@ -109,6 +112,49 @@ def test_async_empty_error_content_has_bounded_message(tmp_path: Path) -> None:
         try:
             with pytest.raises(RuntimeError, match="Unknown error"):
                 await client._call_tool("empty_error", {})
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_response_timeout_is_bounded(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path), timeout=1)
+    errors: list[Exception] = []
+    thread = None
+
+    def call_tool() -> None:
+        try:
+            client._call_tool("silent_tool", {})
+        except Exception as exc:
+            errors.append(exc)
+
+    try:
+        client._ensure_started()
+        client._timeout = 0.05
+        thread = threading.Thread(target=call_tool)
+        thread.start()
+        thread.join(timeout=0.2)
+        assert not thread.is_alive(), "silent MCP tool call exceeded response timeout"
+        assert len(errors) == 1
+        assert str(errors[0]) == "Timed out waiting for response"
+    finally:
+        client.close()
+        if thread is not None:
+            thread.join(timeout=1)
+
+
+def test_async_response_timeout_is_bounded(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path), timeout=1)
+        try:
+            await client._ensure_started()
+            client._timeout = 0.05
+            with pytest.raises(RuntimeError, match="Timed out waiting for response"):
+                await asyncio.wait_for(
+                    client._call_tool("silent_tool", {}),
+                    timeout=0.2,
+                )
         finally:
             await client.close()
 


### PR DESCRIPTION
## What changed

Enforce the Python SDK's documented response timeout for synchronous and asynchronous MCP reads. A timed-out read now returns a bounded error and resets the child process so the caller can retry explicitly.

## Why

Both clients stored `timeout` but called their stdout readers without applying it. A silent MCP tool could therefore leave an agent waiting indefinitely.

## Validation

- Before proof: the new sync and async silent-tool regressions failed on `master` because the calls remained pending past the guard.
- After proof: Python SDK suite passes 67 tests, including the two timeout regressions.
- Independent probe: both clients timed out within the bound, reset their process state, and completed a normal retry.
- Cross-runtime action-manifest conformance passed.
- `cargo fmt --all -- --check` passed.
- `cargo test` passed all library, binary, integration, and doc-test groups.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
