### PR TITLE
fix(sdk/go): bound tool error diagnostics

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -84,6 +84,19 @@ type toolContent struct {
 	Text string `json:"text"`
 }
 
+const maxToolErrorChars = 200
+
+func boundedToolError(text string) string {
+	if text == "" {
+		return "unknown error"
+	}
+	runes := []rune(text)
+	if len(runes) <= maxToolErrorChars {
+		return text
+	}
+	return string(runes[:maxToolErrorChars-1]) + "…"
+}
+
 func (c *Client) ensureStarted() error {
 	if c.initialized {
 		return nil
@@ -225,11 +238,10 @@ func (c *Client) callTool(name string, args map[string]interface{}) (json.RawMes
 		return nil, fmt.Errorf("plasmate: unmarshal tool result: %w", err)
 	}
 	if result.IsError {
-		msg := "unknown error"
-		if len(result.Content) > 0 && result.Content[0].Text != "" {
-			msg = result.Content[0].Text
+		if len(result.Content) == 0 {
+			return nil, errors.New("unknown error")
 		}
-		return nil, errors.New(msg)
+		return nil, errors.New(boundedToolError(result.Content[0].Text))
 	}
 	if len(result.Content) == 0 || result.Content[0].Text == "" {
 		return nil, nil

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,9 +1,11 @@
 package plasmate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -85,5 +87,37 @@ done
 	_, err := client.FetchPage("fixture")
 	if err == nil || err.Error() != "unknown error" {
 		t.Fatalf("FetchPage error = %v, want bounded unknown error", err)
+	}
+}
+
+func TestToolErrorDiagnosticIsBounded(t *testing.T) {
+	diagnostic := strings.Repeat("x", 5000)
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "mcp-fixture.sh")
+	script := fmt.Sprintf(`#!/bin/sh
+while IFS= read -r request; do
+  case "$request" in
+    *'"method":"initialize"'*)
+      printf '%%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}'
+      ;;
+    *'"method":"tools/call"'*)
+      printf '%%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"%s"}],"isError":true}}'
+      ;;
+  esac
+done
+`, diagnostic)
+	if err := os.WriteFile(fixture, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	client := NewClient(WithBinary(fixture))
+	defer client.Close()
+	_, err := client.FetchPage("fixture")
+	if err == nil {
+		t.Fatal("FetchPage returned nil error for a failed tool result")
+	}
+	got := []rune(err.Error())
+	if len(got) != 200 || got[len(got)-1] != '…' {
+		t.Fatalf("FetchPage error length/marker = %d/%q, want 200/ellipsis", len(got), got[len(got)-1])
 	}
 }


### PR DESCRIPTION
## Summary
- cap Go SDK MCP tool diagnostics at 200 UTF-8-safe characters
- preserve the existing unknown-error behavior for empty content
- add a local MCP fixture regression for oversized diagnostics

## Proof
- base regression failed with a 5,000-character agent-visible error
- focused Go regression passes after the fix
- `go test ./...`, `go test -race ./...`, and `go vet ./...`
- action-manifest conformance, `cargo fmt --all -- --check`, full `cargo test`, and strict Clippy

No public pages, credentials, sessions, or customer data were used.