### PR TITLE
fix(sdk/node): recover after initialization timeout

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { Plasmate } from './index';
@@ -106,6 +106,52 @@ input.on('line', (line) => {
       await assert.rejects(browser.fetchPage('fixture'), (error: unknown) => {
         return error instanceof Error && error.message === 'Unknown error';
       });
+    } finally {
+      browser.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('restarts initialization after a timeout', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'plasmate-node-sdk-'));
+    const fixture = join(directory, 'mcp-fixture.js');
+    const marker = join(directory, 'initialized-once');
+    writeFileSync(
+      fixture,
+      `#!/usr/bin/env node
+import { existsSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+const marker = ${JSON.stringify(marker)};
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const input = createInterface({ input: process.stdin });
+
+input.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.method === 'initialize') {
+    if (!existsSync(marker)) {
+      writeFileSync(marker, 'delayed');
+      return;
+    }
+    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05' } });
+  } else if (request.method === 'tools/call') {
+    send({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { content: [{ type: 'text', text: JSON.stringify({ ok: true }) }] },
+    });
+  }
+});
+`,
+      'utf8',
+    );
+    chmodSync(fixture, 0o755);
+
+    const browser = new Plasmate({ binary: fixture, timeout: 500 });
+    try {
+      await assert.rejects(browser.fetchPage('fixture'), /Timeout waiting for response to initialize/);
+      assert.equal(existsSync(marker), true);
+      assert.deepEqual(await browser.fetchPage('fixture'), { ok: true });
     } finally {
       browser.close();
       rmSync(directory, { recursive: true, force: true });

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -134,20 +134,30 @@ export class Plasmate extends EventEmitter {
     if (this.initialized) return;
     if (this.initPromise) return this.initPromise;
 
-    this.initPromise = this.start();
-    return this.initPromise;
+    const initPromise = this.start();
+    this.initPromise = initPromise;
+    try {
+      await initPromise;
+    } catch (error) {
+      if (this.initPromise === initPromise) {
+        this.close();
+      }
+      throw error;
+    }
   }
 
   private async start(): Promise<void> {
-    this.process = spawn(this.binary, ['mcp'], {
+    const child = spawn(this.binary, ['mcp'], {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+    this.process = child;
 
-    this.process.on('error', (err) => {
+    child.on('error', (err) => {
       this.emit('error', err);
     });
 
-    this.process.on('exit', (code) => {
+    child.on('exit', (code) => {
+      if (this.process !== child) return;
       this.initialized = false;
       this.initPromise = null;
       // Reject all pending requests
@@ -159,12 +169,12 @@ export class Plasmate extends EventEmitter {
     });
 
     // Capture stderr for debugging
-    this.process.stderr?.on('data', (data: Buffer) => {
+    child.stderr?.on('data', (data: Buffer) => {
       this.emit('log', data.toString());
     });
 
     // Parse stdout as newline-delimited JSON
-    this.readline = createInterface({ input: this.process.stdout! });
+    this.readline = createInterface({ input: child.stdout! });
     this.readline.on('line', (line: string) => {
       if (!line.trim()) return;
       try {


### PR DESCRIPTION
## What changed

- Reset a failed Node SDK initialization attempt and close its child process.
- Ignore exit events from an old child after a retry starts.
- Add a local MCP fixture regression for timeout, restart, and successful retry.

## Why

A response timeout during MCP initialization left the rejected initialization promise cached. A later agent call on the same client failed immediately instead of starting a fresh child. The first retry attempt also showed that the old child’s delayed exit event could reject the new child’s initialization.

## Validation

- Node SDK `npm test`: 34 passed.
- Cross-runtime action-manifest conformance: passed.
- `cargo fmt --all -- --check`: passed.
- `cargo test`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `git diff --check`: passed.

The regression uses only a local synthetic MCP child process and does not access a public page, credential, session, or customer data.