### PR TITLE
fix(som): align Unicode action cache keys

### DIFF
--- a/integrations/langchain/langchain_plasmate/som_output.py
+++ b/integrations/langchain/langchain_plasmate/som_output.py
@@ -165,8 +165,8 @@ def _element_to_text(elem: dict[str, Any], indent: int = 1) -> str:
 
 def _fnv1a32(value: str) -> str:
     hash_value = 0x811C9DC5
-    for char in value:
-        hash_value ^= ord(char)
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
         hash_value = (hash_value * 0x01000193) & 0xFFFFFFFF
     return f"{hash_value:08x}"
 
@@ -190,7 +190,7 @@ def _action_cache_key(elem: dict[str, Any]) -> str:
         _compact_string(attrs.get("group")),
         _compact_string(attrs.get("placeholder")),
     ]
-    encoded = json.dumps(parts, separators=(",", ":"))
+    encoded = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
     return f"plasmate-action:v1:{_fnv1a32(encoded)}"
 
 

--- a/integrations/langchain/tests/test_som_output.py
+++ b/integrations/langchain/tests/test_som_output.py
@@ -199,3 +199,25 @@ def test_action_target_index_resolves_replay_targets():
     ]
     assert "e_plan" in enabled_index["by_id"]
     assert find_action_target(som, "settings-save", enabled_only=True) is None
+
+
+def test_uses_utf8_bytes_for_unicode_cache_keys():
+    som = {
+        "regions": [
+            {
+                "elements": [
+                    {
+                        "id": "e_é",
+                        "role": "button",
+                        "actions": ["click"],
+                        "label": "Réserver",
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert (
+        action_target_index(som)["by_id"]["e_é"]["cache_key"]
+        == "plasmate-action:v1:0fe120a1"
+    )

--- a/integrations/vercel-ai/src/index.ts
+++ b/integrations/vercel-ai/src/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { createMCPClient } from '@ai-sdk/mcp'
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
 
@@ -231,8 +232,8 @@ function stableActionTargetParts(target: PlasmateActionTarget) {
 function fnv1a32(input: string): string {
   let hash = 0x811c9dc5
 
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index)
+  for (const byte of Buffer.from(input, 'utf8')) {
+    hash ^= byte
     hash = Math.imul(hash, 0x01000193)
   }
 

--- a/integrations/vercel-ai/tests/action-plan.test.mjs
+++ b/integrations/vercel-ai/tests/action-plan.test.mjs
@@ -92,6 +92,17 @@ assert.deepEqual(email, {
 const save = targets.find((target) => target.id === 'e_save')
 assert.equal(isPlasmateActionTargetAvailable(save), false)
 assert.equal(getPlasmateActionTargetCacheKey(save), save.cache_key)
+
+assert.equal(
+  getPlasmateActionTargetCacheKey({
+    id: 'e_é',
+    role: 'button',
+    actions: ['click'],
+    enabled: true,
+    label: 'Réserver',
+  }),
+  'plasmate-action:v1:0fe120a1',
+)
 assert.equal(save.enabled, false)
 assert.equal(save.disabled, true)
 assert.equal(save.blocked_reason, 'disabled')

--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import type {
   Som,
   SomElement,
@@ -245,8 +246,8 @@ function stableActionPlanParts(item: Omit<ActionPlanItem, 'cache_key'> | ActionP
 
 function fnv1a32(input: string): string {
   let hash = 0x811c9dc5;
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index);
+  for (const byte of Buffer.from(input, 'utf8')) {
+    hash ^= byte;
     hash = Math.imul(hash, 0x01000193);
   }
   return (hash >>> 0).toString(16).padStart(8, '0');

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -475,6 +475,18 @@ describe('getActionPlan', () => {
     ).toBe('plasmate-action:v1:0b6b537f');
   });
 
+  it('uses UTF-8 bytes for Unicode cache keys', () => {
+    expect(
+      getActionPlanCacheKey({
+        id: 'e_é',
+        role: 'button',
+        actions: ['click'],
+        enabled: true,
+        label: 'Réserver',
+      }),
+    ).toBe('plasmate-action:v1:0fe120a1');
+  });
+
   it('matches the shared action availability manifest', () => {
     const { som, action_targets } = loadActionAvailabilityFixture();
 

--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -137,8 +137,8 @@ def get_interactive_elements(som: Som) -> List[SomElement]:
 
 def _fnv1a32(value: str) -> str:
     hash_value = 0x811C9DC5
-    for char in value:
-        hash_value ^= ord(char)
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
         hash_value = (hash_value * 0x01000193) & 0xFFFFFFFF
     return f"{hash_value:08x}"
 
@@ -162,7 +162,7 @@ def get_action_plan_cache_key(item: Dict[str, object]) -> str:
         _compact_string(item.get("group")),
         _compact_string(item.get("placeholder")),
     ]
-    encoded = json.dumps(parts, separators=(",", ":"))
+    encoded = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
     return f"plasmate-action:v1:{_fnv1a32(encoded)}"
 
 

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -614,6 +614,20 @@ class TestGetActionPlan:
             == "plasmate-action:v1:0b6b537f"
         )
 
+    def test_uses_utf8_bytes_for_unicode_cache_keys(self):
+        assert (
+            get_action_plan_cache_key(
+                {
+                    "id": "e_é",
+                    "role": "button",
+                    "actions": ["click"],
+                    "enabled": True,
+                    "label": "Réserver",
+                }
+            )
+            == "plasmate-action:v1:0fe120a1"
+        )
+
     def test_matches_shared_action_availability_manifest(self):
         som, expected_targets = _load_action_availability_fixture()
 

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -508,6 +508,21 @@ func TestGetActionPlanDisabledTarget(t *testing.T) {
 	}
 }
 
+func TestGetActionPlanCacheKeyUsesUTF8Bytes(t *testing.T) {
+	label := "Réserver"
+	item := ActionPlanItem{
+		ID:      "e_é",
+		Role:    "button",
+		Actions: []string{"click"},
+		Enabled: true,
+		Label:   &label,
+	}
+
+	if got := GetActionPlanCacheKey(item); got != "plasmate-action:v1:0fe120a1" {
+		t.Fatalf("GetActionPlanCacheKey = %q, want plasmate-action:v1:0fe120a1", got)
+	}
+}
+
 func TestGetActionPlanMatchesSharedAvailabilityManifest(t *testing.T) {
 	somBytes, err := os.ReadFile("../../integrations/fixtures/action-availability.som.json")
 	if err != nil {

--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -313,6 +313,19 @@ describe('getActionPlan', () => {
     );
   });
 
+  it('uses UTF-8 bytes for Unicode cache keys', () => {
+    assert.equal(
+      getActionPlanCacheKey({
+        id: 'e_é',
+        role: 'button',
+        actions: ['click'],
+        enabled: true,
+        label: 'Réserver',
+      }),
+      'plasmate-action:v1:0fe120a1',
+    );
+  });
+
   it('indexes action targets for replay', () => {
     const { som, action_targets } = loadActionAvailabilityFixture();
     const save = action_targets.find((target) => target.id === 'e_save')!;

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -2,6 +2,7 @@
  * SOM query helpers for searching and traversing Semantic Object Model documents.
  */
 
+import { Buffer } from 'node:buffer';
 import type { Som, SomRegion, SomElement, RegionRole, ElementRole, ElementAction } from './types';
 
 /** Find all regions matching a given role. */
@@ -200,8 +201,8 @@ function stableActionPlanParts(item: Omit<ActionPlanItem, 'cache_key'> | ActionP
 
 function fnv1a32(input: string): string {
   let hash = 0x811c9dc5;
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index);
+  for (const byte of Buffer.from(input, 'utf8')) {
+    hash ^= byte;
     hash = Math.imul(hash, 0x01000193);
   }
   return (hash >>> 0).toString(16).padStart(8, '0');

--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -64,8 +64,8 @@ def find_interactive(som: Som) -> List[SomElement]:
 
 def _fnv1a32(value: str) -> str:
     hash_value = 0x811C9DC5
-    for char in value:
-        hash_value ^= ord(char)
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
         hash_value = (hash_value * 0x01000193) & 0xFFFFFFFF
     return f"{hash_value:08x}"
 
@@ -89,7 +89,7 @@ def get_action_plan_cache_key(item: Dict[str, object]) -> str:
         _compact_string(item.get("group")),
         _compact_string(item.get("placeholder")),
     ]
-    encoded = json.dumps(parts, separators=(",", ":"))
+    encoded = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
     return f"plasmate-action:v1:{_fnv1a32(encoded)}"
 
 

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -353,6 +353,20 @@ class TestGetActionPlan:
             == "plasmate-action:v1:5b218ab1"
         )
 
+    def test_uses_utf8_bytes_for_unicode_cache_keys(self) -> None:
+        assert (
+            get_action_plan_cache_key(
+                {
+                    "id": "e_é",
+                    "role": "button",
+                    "actions": ["click"],
+                    "enabled": True,
+                    "label": "Réserver",
+                }
+            )
+            == "plasmate-action:v1:0fe120a1"
+        )
+
     def test_indexes_action_targets_for_replay(self) -> None:
         fixture_dir = REPO_ROOT / "integrations" / "fixtures"
         som = Som.model_validate(


### PR DESCRIPTION
## What changed

- Hash action-plan cache identities from canonical UTF-8 bytes across Python, Node, Go, LangChain, and Vercel AI surfaces.
- Preserve existing ASCII cache keys.
- Add Unicode parity regressions to every affected parser, SDK, and adapter path.

## Why

The same non-ASCII action target produced different `plasmate-action:v1` keys in Python and Node, while the Go implementation used UTF-8 bytes. Agents could not reliably reuse a cached action across runtimes.

## Evidence

- Before: Python returned `plasmate-action:v1:daba8abb`; Node returned `plasmate-action:v1:e4773da5` for the same synthetic target.
- After: Python, Node, Go, LangChain, and Vercel AI return `plasmate-action:v1:0fe120a1`.
- No public page, private session, credential, customer data, MCP lifecycle, process containment, or network policy was accessed or changed.

## Checks

- Full action-manifest conformance
- Python SDK: 68 tests
- Python parser: 77 tests
- Node SDK: 34 tests
- Node parser: 63 tests
- Browser Use: 12 tests
- LangChain: 12 tests
- Vercel AI tests and typecheck
- Go tests, race, vet, and format
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
