### PR TITLE
fix(parser): remediate nanoid audit

### DIFF
--- a/packages/som-parser-node/package-lock.json
+++ b/packages/som-parser-node/package-lock.json
@@ -1350,9 +1350,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/packages/som-parser-node/package.json
+++ b/packages/som-parser-node/package.json
@@ -32,6 +32,7 @@
     "vitest": "^3.0.0"
   },
   "overrides": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "nanoid": "3.3.17"
   }
 }


### PR DESCRIPTION
## What changed

- Add a root npm override for transitive `nanoid` at `3.3.17`.
- Refresh the parser package lockfile to the fixed version and integrity.

## Why

The required parser-package full audit failed on `nanoid@3.3.16` through `tsup` → `postcss`, while the production-only audit was already clean. The smallest remediation is a package-local override and lockfile update; no runtime code, API, release metadata, or CI policy changes are included.

## Agent outcome

AI-agent projects that build or audit the Node SOM parser now receive a reproducible dependency graph without the reported high-severity development dependency advisory.

## Checks

- `npm ci --ignore-scripts`
- `npm audit --package-lock-only --audit-level=high`
- `npm audit --package-lock-only --omit=dev --audit-level=high`
- `npm test` (62 passed)
- `npm run build`
- `PYTHON=/Users/dbhurley/Git/plasmate/integrations/langchain/.venv/bin/python ./scripts/action-manifest-conformance.sh --quick`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

No public pages, credentials, sessions, or customer data were accessed.
