### PR TITLE
fix(sdk/node): bound tool error diagnostics

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -111,6 +111,46 @@ input.on('line', (line) => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
+  it('bounds oversized tool error diagnostics', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'plasmate-node-sdk-'));
+    const fixture = join(directory, 'mcp-fixture.js');
+    writeFileSync(
+      fixture,
+      `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const input = createInterface({ input: process.stdin });
+const diagnostic = 'x'.repeat(5000);
+
+input.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05' } });
+  } else if (request.method === 'tools/call') {
+    send({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { isError: true, content: [{ type: 'text', text: diagnostic }] },
+    });
+  }
+});
+`,
+      'utf8',
+    );
+    chmodSync(fixture, 0o755);
+
+    const browser = new Plasmate({ binary: fixture });
+    try {
+      await assert.rejects(browser.fetchPage('fixture'), (error: unknown) => {
+        return error instanceof Error && error.message === `${'x'.repeat(199)}…`;
+      });
+    } finally {
+      browser.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('package entry points', () => {

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -106,6 +106,15 @@ interface JsonRpcResponse {
   error?: { code: number; message: string; data?: unknown };
 }
 
+const MAX_TOOL_ERROR_CHARS = 200;
+
+function boundedToolError(text: unknown): string {
+  if (typeof text !== 'string' || text.length === 0) return 'Unknown error';
+  const characters = Array.from(text);
+  if (characters.length <= MAX_TOOL_ERROR_CHARS) return text;
+  return `${characters.slice(0, MAX_TOOL_ERROR_CHARS - 1).join('')}…`;
+}
+
 // ---- Client ----
 
 export class Plasmate extends EventEmitter {
@@ -242,8 +251,7 @@ export class Plasmate extends EventEmitter {
     };
 
     if (result.isError) {
-      const msg = result.content?.[0]?.text || 'Unknown error';
-      throw new Error(msg);
+      throw new Error(boundedToolError(result.content?.[0]?.text));
     }
 
     const text = result.content?.[0]?.text;


### PR DESCRIPTION
## Summary

- Cap Node SDK MCP tool-error diagnostics at 200 Unicode characters.
- Preserve the existing `Unknown error` fallback when an error has no usable text.
- Add a child-process regression for an oversized 5,000-character diagnostic.

## Agent outcome

Before this change, the Node SDK forwarded a 5,000-character MCP error unchanged. The focused regression failed on `master` while the existing Node suite passed. The new formatter returns the first 199 characters plus an ellipsis, keeping the agent-visible diagnostic bounded without changing successful tool results.

## Checks

- `npm test` in `sdk/node` — 34 passed
- `npm audit --package-lock-only --audit-level=high` — 0 vulnerabilities
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test` — all repository tests passed
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `PYTHON=/Users/dbhurley/Git/plasmate/integrations/langchain/.venv/bin/python ./scripts/action-manifest-conformance.sh --quick`
- `git diff --check`

The change is limited to the Node SDK error path and its regression fixture. It does not change MCP lifecycle, sessions, page fetching, process containment, or dependency manifests.
