### PR TITLE
fix(sdk/python): bound tool error diagnostics

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -79,6 +79,18 @@ def _tool_text(result: Any) -> str:
     return text if isinstance(text, str) else ""
 
 
+MAX_TOOL_ERROR_CHARS = 200
+
+
+def _bounded_tool_error(text: str) -> str:
+    """Keep agent-visible MCP tool diagnostics within a small Unicode limit."""
+    if not text:
+        return "Unknown error"
+    if len(text) <= MAX_TOOL_ERROR_CHARS:
+        return text
+    return f"{text[: MAX_TOOL_ERROR_CHARS - 1]}…"
+
+
 class Plasmate:
     """
     Synchronous Plasmate client.
@@ -216,7 +228,7 @@ class Plasmate:
 
         text = _tool_text(result)
         if result and result.get("isError"):
-            raise RuntimeError(text or "Unknown error")
+            raise RuntimeError(_bounded_tool_error(text))
 
         if name == "extract_text":
             return text
@@ -447,7 +459,7 @@ class AsyncPlasmate:
 
         text = _tool_text(result)
         if result and result.get("isError"):
-            raise RuntimeError(text or "Unknown error")
+            raise RuntimeError(_bounded_tool_error(text))
 
         if name == "extract_text":
             return text

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -41,6 +41,16 @@ for line in sys.stdin:
                 "result": {"content": [], "isError": True},
             })
             continue
+        if tool_name == "oversized_error":
+            send({
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "result": {
+                    "content": [{"type": "text", "text": "x" * 5000}],
+                    "isError": True,
+                },
+            })
+            continue
         content = {
             "type": "text",
             "text": "Plain text fixture"
@@ -112,6 +122,29 @@ def test_async_empty_error_content_has_bounded_message(tmp_path: Path) -> None:
         try:
             with pytest.raises(RuntimeError, match="Unknown error"):
                 await client._call_tool("empty_error", {})
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_oversized_tool_error_has_bounded_message(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        with pytest.raises(RuntimeError) as error:
+            client._call_tool("oversized_error", {})
+        assert str(error.value) == f"{'x' * 199}…"
+    finally:
+        client.close()
+
+
+def test_async_oversized_tool_error_has_bounded_message(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            with pytest.raises(RuntimeError) as error:
+                await client._call_tool("oversized_error", {})
+            assert str(error.value) == f"{'x' * 199}…"
         finally:
             await client.close()
 


### PR DESCRIPTION
## Summary

- Bound synchronous and asynchronous Python SDK MCP tool-error diagnostics to 200 Unicode code points.
- Preserve the existing `Unknown error` fallback and successful tool responses.
- Add child-process regressions for a 5,000-character tool diagnostic.

## Agent outcome

Before this change, both Python SDK clients forwarded a 5,000-character MCP tool error unchanged. The focused sync and async regressions failed on clean `master` while the existing protocol tests passed. The new formatter returns the first 199 characters plus an ellipsis, keeping the agent-visible diagnostic bounded without changing successful reads.

The change is limited to the Python SDK error path and its protocol fixture. It does not change page fetching, session handling, process lifecycle, dependency manifests, or public-network behavior.

## Checks

- `PYTHONPATH=src python3 -m pytest tests/test_protocol.py -q` — 10 passed
- `PYTHONPATH=src python3 -m pytest tests/ -q` — 69 passed
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test` — all repository tests passed
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `PYTHON=/Users/dbhurley/Git/plasmate/integrations/langchain/.venv/bin/python ./scripts/action-manifest-conformance.sh --quick`
- `git diff --check`
