### PR TITLE
fix(browser-use): bound binary verification errors

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -26,10 +26,15 @@ from som_parser import (
 _CLI_ERROR_DETAIL_LIMIT = 200
 
 
+def _bounded_cli_detail(stderr: str) -> str:
+    """Return a compact diagnostic detail for a failed Plasmate CLI call."""
+    detail = " ".join(stderr.split())[:_CLI_ERROR_DETAIL_LIMIT]
+    return detail or "Unknown error"
+
+
 def _format_cli_failure(stderr: str) -> str:
     """Return a useful, bounded error for a failed Plasmate CLI read."""
-    detail = " ".join(stderr.split())[:_CLI_ERROR_DETAIL_LIMIT]
-    return f"plasmate fetch failed: {detail or 'Unknown error'}"
+    return f"plasmate fetch failed: {_bounded_cli_detail(stderr)}"
 
 
 def _extract_last_json(text: str) -> Any:
@@ -290,7 +295,9 @@ class PlasmateExtractor:
                 capture_output=True, text=True, timeout=5
             )
             if result.returncode != 0:
-                raise RuntimeError(f"plasmate binary not working: {result.stderr}")
+                raise RuntimeError(
+                    f"plasmate binary not working: {_bounded_cli_detail(result.stderr)}"
+                )
         except FileNotFoundError:
             raise RuntimeError(
                 "plasmate binary not found. Install with: cargo install plasmate\n"

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -181,6 +181,21 @@ def test_async_extract_cli_error_is_bounded():
     asyncio.run(exercise())
 
 
+def test_binary_verification_error_is_bounded():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    completed = SimpleNamespace(returncode=1, stderr="E" * 5000)
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ):
+        with pytest.raises(RuntimeError) as error:
+            extractor._verify_binary()
+
+    assert str(error.value) == "plasmate binary not working: " + "E" * 200
+
+
 def test_markdown_forwards_selector_to_cli():
     extractor = PlasmateExtractor.__new__(PlasmateExtractor)
     extractor.plasmate_bin = "plasmate"


### PR DESCRIPTION
## Summary

- Bound the Browser Use adapter's binary-verification diagnostic to the existing 200-character CLI detail limit.
- Reuse the bounded detail helper for fetch failures and preserve the existing `Unknown error` fallback.
- Add a regression for a 5,000-character binary stderr diagnostic.

## Agent outcome

Before this change, `PlasmateExtractor._verify_binary()` forwarded all stderr when the configured binary returned a nonzero status. A local 5,000-character fixture exposed the full diagnostic. The new regression fails on clean `master` and passes after the change; the adapter now returns at most the existing bounded detail for this startup failure.

The change is limited to Browser Use error formatting and its local regression fixture. It does not change page fetching, session handling, process lifecycle, network policy, or public claims.

## Checks

- Browser Use adapter tests: 13 passed
- Full action-manifest conformance: passed across the WPT corpus, Python and Node parsers, Go/Python/Node SDKs, Browser Use, LangChain, and Vercel AI
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`: all repository tests passed
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

The optional Vercel preview is not required for this code-only outcome.
