### PR TITLE
fix(browser-use): bound malformed-output errors

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -333,7 +333,7 @@ class PlasmateExtractor:
         som = _extract_last_json(result.stdout)
         if som is None:
             raise RuntimeError(
-                f"plasmate returned no valid JSON for {url}: {result.stdout[:200]}"
+                f"plasmate returned no valid JSON: {_bounded_cli_detail(result.stdout)}"
             )
         return som
 
@@ -359,10 +359,11 @@ class PlasmateExtractor:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
         if proc.returncode != 0:
             raise RuntimeError(_format_cli_failure(stderr.decode(errors="replace")))
-        som = _extract_last_json(stdout.decode())
+        stdout_text = stdout.decode()
+        som = _extract_last_json(stdout_text)
         if som is None:
             raise RuntimeError(
-                f"plasmate returned no valid JSON for {url}: {stdout.decode()[:200]}"
+                f"plasmate returned no valid JSON: {_bounded_cli_detail(stdout_text)}"
             )
         return som
 

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -181,6 +181,60 @@ def test_async_extract_cli_error_is_bounded():
     asyncio.run(exercise())
 
 
+def test_invalid_json_error_is_bounded_and_omits_unbounded_url():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    url = "U" * 5000
+    completed = SimpleNamespace(
+        returncode=0,
+        stdout="not-json-" + "x" * 5000,
+        stderr="",
+    )
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ):
+        with pytest.raises(RuntimeError) as error:
+            extractor.extract(url)
+
+    message = str(error.value)
+    assert message.startswith("plasmate returned no valid JSON: ")
+    assert "not-json-" in message
+    assert len(message) <= 256
+    assert url not in message
+
+
+def test_async_invalid_json_error_is_bounded_and_omits_unbounded_url():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    url = "U" * 5000
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"not-json-" + b"x" * 5000, b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return FakeProcess()
+
+    async def exercise():
+        with patch(
+            "plasmate_browser_use.extractor.asyncio.create_subprocess_exec",
+            new=fake_create_subprocess_exec,
+        ):
+            with pytest.raises(RuntimeError) as error:
+                await extractor.extract_async(url)
+        message = str(error.value)
+        assert message.startswith("plasmate returned no valid JSON: ")
+        assert "not-json-" in message
+        assert len(message) <= 256
+        assert url not in message
+
+    asyncio.run(exercise())
+
+
 def test_binary_verification_error_is_bounded():
     extractor = PlasmateExtractor.__new__(PlasmateExtractor)
     extractor.plasmate_bin = "plasmate"


### PR DESCRIPTION
## Summary

- Bound Browser Use sync and async malformed-output errors to the existing 200-character CLI detail limit.
- Stop echoing the configured URL when the CLI exits successfully but returns no valid JSON.
- Add sync and async regressions with synthetic 5,000-character URL and output values.

## Agent outcome

Before this change, a successful CLI exit with malformed output produced an agent-visible error that included the full configured URL and 200 output characters. A clean-base synthetic fixture produced a 5,238-character error. After this change, both paths preserve a short output detail, omit the unbounded URL, and keep the error within the existing diagnostic bound.

The change is limited to Browser Use error formatting. It does not change fetching, sessions, process lifecycle, network policy, or public claims.

## Checks

- Clean-base focused proof: 13 passed, 2 new regressions failed.
- After-change Browser Use adapter tests: 15 passed.
- Quick action-manifest conformance across the WPT corpus, Python and Node parsers, Go/Python/Node SDKs, Browser Use, LangChain, and Vercel AI.
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`: 445 library tests, 61 binary tests, all integration and doc-test groups passed.
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

The optional Vercel preview is not required for this code-only outcome.
