### PR TITLE
fix(parser): skip JSON progress records in Node parser

### DIFF
--- a/packages/som-parser-node/src/parser.ts
+++ b/packages/som-parser-node/src/parser.ts
@@ -26,6 +26,50 @@ export function isValidSom(input: unknown): input is Som {
   return true;
 }
 
+function extractJsonObjects(text: string): unknown[] {
+  const objects: unknown[] = [];
+
+  for (let start = 0; start < text.length; start += 1) {
+    if (text[start] !== '{') continue;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = start; index < text.length; index += 1) {
+      const character = text[index];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === '{') {
+        depth += 1;
+      } else if (character === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          try {
+            objects.push(JSON.parse(text.slice(start, index + 1)));
+          } catch {
+            // Keep scanning for a later complete JSON object.
+          }
+          start = index;
+          break;
+        }
+      }
+    }
+  }
+
+  return objects;
+}
+
 /**
  * Parse raw Plasmate CLI JSON output into a typed Som.
  * Handles cases where the CLI may emit extra text before or after the JSON.
@@ -47,12 +91,23 @@ export function fromPlasmate(jsonOutput: string): Som {
   try {
     return unwrap(JSON.parse(jsonOutput));
   } catch {
-    // Fall back: look for the first { ... } block
-    const start = jsonOutput.indexOf('{');
-    const end = jsonOutput.lastIndexOf('}');
-    if (start === -1 || end === -1 || end <= start) {
+    // Fall back: scan complete objects and ignore non-SOM progress records.
+    const objects = extractJsonObjects(jsonOutput);
+    if (objects.length === 0) {
       throw new Error('No JSON object found in Plasmate output');
     }
-    return unwrap(JSON.parse(jsonOutput.slice(start, end + 1)));
+
+    let result: Som | undefined;
+    let lastError: unknown;
+    for (const value of objects) {
+      try {
+        result = unwrap(value);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (result) return result;
+    if (lastError !== undefined) throw lastError;
+    throw new Error('Invalid SOM in Plasmate output');
   }
 }

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -247,6 +247,16 @@ describe('fromPlasmate', () => {
     expect(som.title).toBe('Example Domain');
   });
 
+  it('uses the last valid SOM when JSON progress records surround it', () => {
+    const output = [
+      JSON.stringify({ progress: 'starting' }),
+      FIXTURE_JSON,
+      JSON.stringify({ progress: 'done' }),
+    ].join('\n');
+    const som = fromPlasmate(output);
+    expect(som.title).toBe('Example Domain');
+  });
+
   it('throws when no JSON found', () => {
     expect(() => fromPlasmate('no json here')).toThrow();
   });


### PR DESCRIPTION
## Summary

- Scan complete JSON objects in mixed CLI output instead of joining the first and last braces.
- Return the last valid SOM while ignoring structured progress records.
- Add a regression for progress records surrounding a SOM payload.

## Agent outcome

Before this change, the Node parser failed when JSON progress records surrounded a valid SOM because it attempted to parse the combined object range. The clean-base synthetic probe produced a JSON parse error. After this change, the parser returns the valid SOM and preserves existing clean, wrapped, and surrounding-text behavior.

## Checks

- Clean-base synthetic failure reproduced.
- Node parser suite: 63 passed.
- TypeScript no-emit check passed.
- Temporary package build and post-change synthetic probe passed.
- Python parser suite: 77 passed.
- Quick action-manifest conformance passed for the pinned fixture, both parsers, all SDKs, Browser Use, LangChain, and Vercel AI.
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`: 445 library tests, 61 binary tests, all integration and doc-test groups passed.
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

This is limited to Node parser compatibility with mixed CLI output. It does not change fetching, sessions, protocol lifecycle, cache behavior, network policy, or public claims. The four-hour governor owns protected review and merge or rejection.