### PR TITLE
fix(browser-use): parse last valid SOM

### DIFF
--- a/integrations/browser-use/plasmate_browser_use/extractor.py
+++ b/integrations/browser-use/plasmate_browser_use/extractor.py
@@ -6,11 +6,11 @@ depend on the page and workflow; measure the target workload before estimating.
 """
 
 import asyncio
-import json
 import subprocess
 from typing import Any, Optional
 
 from som_parser import (
+    from_plasmate,
     find_action_target,
     find_action_targets_by_action,
     find_action_targets_by_role,
@@ -37,42 +37,12 @@ def _format_cli_failure(stderr: str) -> str:
     return f"plasmate fetch failed: {_bounded_cli_detail(stderr)}"
 
 
-def _extract_last_json(text: str) -> Any:
-    """Extract the last complete JSON object from potentially mixed output.
-
-    Handles cases where Plasmate emits progress/log lines alongside the
-    JSON payload.  Returns None if no valid JSON object is found.
-    """
-    if not text:
-        return None
-
-    stripped = text.strip()
-
-    # Fast path: clean output
+def _parse_som_output(text: str) -> Optional[dict[str, Any]]:
+    """Parse the last valid SOM from potentially mixed CLI output."""
     try:
-        return json.loads(stripped)
-    except (json.JSONDecodeError, ValueError):
-        pass
-
-    # Line scan: JSON on its own line (progress line before payload)
-    for line in reversed(stripped.splitlines()):
-        line = line.strip()
-        if line.startswith(("{", "[")):
-            try:
-                return json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                pass
-
-    # Brace walk: JSON embedded in a longer string
-    decoder = json.JSONDecoder()
-    for pos in reversed([i for i, ch in enumerate(stripped) if ch == "{"]):
-        try:
-            value, _ = decoder.raw_decode(stripped, pos)
-            return value
-        except (json.JSONDecodeError, ValueError):
-            continue
-
-    return None
+        return from_plasmate(text).model_dump(mode="json")
+    except (TypeError, ValueError):
+        return None
 
 
 def _fetch_command(
@@ -330,7 +300,7 @@ class PlasmateExtractor:
         )
         if result.returncode != 0:
             raise RuntimeError(_format_cli_failure(result.stderr))
-        som = _extract_last_json(result.stdout)
+        som = _parse_som_output(result.stdout)
         if som is None:
             raise RuntimeError(
                 f"plasmate returned no valid JSON: {_bounded_cli_detail(result.stdout)}"
@@ -360,7 +330,7 @@ class PlasmateExtractor:
         if proc.returncode != 0:
             raise RuntimeError(_format_cli_failure(stderr.decode(errors="replace")))
         stdout_text = stdout.decode()
-        som = _extract_last_json(stdout_text)
+        som = _parse_som_output(stdout_text)
         if som is None:
             raise RuntimeError(
                 f"plasmate returned no valid JSON: {_bounded_cli_detail(stdout_text)}"

--- a/integrations/browser-use/tests/test_extractor.py
+++ b/integrations/browser-use/tests/test_extractor.py
@@ -181,6 +181,60 @@ def test_async_extract_cli_error_is_bounded():
     asyncio.run(exercise())
 
 
+def test_extract_uses_last_valid_som_when_progress_records_follow_it():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    output = "\n".join(
+        [
+            json.dumps({"progress": "starting"}),
+            json.dumps(som),
+            json.dumps({"progress": "done"}),
+        ]
+    )
+    completed = SimpleNamespace(returncode=0, stdout=output, stderr="")
+
+    with patch(
+        "plasmate_browser_use.extractor.subprocess.run",
+        return_value=completed,
+    ):
+        result = extractor.extract("fixture")
+
+    assert result["title"] == som["title"]
+
+
+def test_async_extract_uses_last_valid_som_when_progress_records_follow_it():
+    extractor = PlasmateExtractor.__new__(PlasmateExtractor)
+    extractor.plasmate_bin = "plasmate"
+    som = load_action_availability_fixture()
+    output = "\n".join(
+        [
+            json.dumps({"progress": "starting"}),
+            json.dumps(som),
+            json.dumps({"progress": "done"}),
+        ]
+    )
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return output.encode(), b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return FakeProcess()
+
+    async def exercise():
+        with patch(
+            "plasmate_browser_use.extractor.asyncio.create_subprocess_exec",
+            new=fake_create_subprocess_exec,
+        ):
+            result = await extractor.extract_async("fixture")
+        assert result["title"] == som["title"]
+
+    asyncio.run(exercise())
+
+
 def test_invalid_json_error_is_bounded_and_omits_unbounded_url():
     extractor = PlasmateExtractor.__new__(PlasmateExtractor)
     extractor.plasmate_bin = "plasmate"


### PR DESCRIPTION
## Summary

- Reuse the shared Python SOM parser for Browser Use CLI output.
- Select the last valid SOM when structured progress records surround it.
- Apply the same behavior to synchronous and asynchronous extraction.

## Agent outcome

Before this change, Browser Use selected the last JSON object without validating it. A trailing progress record caused the agent-facing page-context path to raise a SOM validation error even though a valid SOM was present. After this change, the adapter returns the validated SOM and preserves the existing bounded error behavior for invalid output.

## Checks

- Clean-base synthetic failure reproduced with progress/SOM/progress output.
- Browser Use tests: 17 passed.
- Quick action-manifest conformance passed for the pinned fixture, Python and Node parsers, Go/Python/Node SDKs, Browser Use, LangChain, and Vercel AI.
- cargo fmt --all -- --check
- cargo test: 445 library tests, 61 binary tests, all integration and doc-test groups passed.
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

This is limited to Browser Use SOM extraction compatibility. It does not change fetching, sessions, network policy, cache behavior, protocol lifecycle, or public claims. The four-hour governor owns protected review and merge or rejection.