### PR TITLE
fix(langchain): render nested SOM elements

### DIFF
--- a/integrations/langchain/langchain_plasmate/som_output.py
+++ b/integrations/langchain/langchain_plasmate/som_output.py
@@ -39,9 +39,7 @@ def som_to_text(som: dict[str, Any]) -> str:
     for region in som.get("regions", []):
         lines.append(_region_header(region))
         for elem in region.get("elements", []):
-            text = _element_to_text(elem)
-            if text:
-                lines.append(text)
+            _append_element_text(lines, elem)
         lines.append("")
 
     # Compression stats
@@ -57,6 +55,27 @@ def som_to_text(som: dict[str, Any]) -> str:
     )
 
     return "\n".join(lines)
+
+
+def _append_element_text(
+    lines: list[str], elem: dict[str, Any], indent: int = 1
+) -> None:
+    text = _element_to_text(elem, indent)
+    if text:
+        lines.append(text)
+
+    children = elem.get("children")
+    if isinstance(children, list):
+        for child in children:
+            if isinstance(child, dict):
+                _append_element_text(lines, child, indent + 1)
+
+    shadow = elem.get("shadow")
+    shadow_elements = shadow.get("elements") if isinstance(shadow, dict) else None
+    if isinstance(shadow_elements, list):
+        for child in shadow_elements:
+            if isinstance(child, dict):
+                _append_element_text(lines, child, indent + 1)
 
 
 def _region_header(region: dict[str, Any]) -> str:

--- a/integrations/langchain/tests/test_som_output.py
+++ b/integrations/langchain/tests/test_som_output.py
@@ -30,6 +30,56 @@ def load_action_availability_expectations():
     return json.loads(EXPECTATIONS_PATH.read_text())["action_targets"]
 
 
+def test_som_to_text_includes_nested_and_shadow_interactive_elements():
+    som = {
+        "title": "Nested fixture",
+        "url": "fixture",
+        "regions": [
+            {
+                "role": "main",
+                "elements": [
+                    {
+                        "id": "container",
+                        "role": "section",
+                        "attrs": {"section_label": "Nested controls"},
+                        "children": [
+                            {
+                                "id": "child-button",
+                                "role": "button",
+                                "text": "Child",
+                                "actions": ["click"],
+                            }
+                        ],
+                        "shadow": {
+                            "mode": "open",
+                            "elements": [
+                                {
+                                    "id": "shadow-link",
+                                    "role": "link",
+                                    "label": "Shadow",
+                                    "actions": ["click"],
+                                    "attrs": {"href": "/shadow"},
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+        "meta": {
+            "html_bytes": 1,
+            "som_bytes": 1,
+            "element_count": 3,
+            "interactive_count": 2,
+        },
+    }
+
+    text = som_to_text(som)
+
+    assert '[child-button] button "Child"' in text
+    assert '[shadow-link] link "Shadow" -> /shadow' in text
+
+
 def test_som_to_text_surfaces_interactive_state():
     som = load_action_availability_fixture()
     expected_targets = load_action_availability_expectations()


### PR DESCRIPTION
## Summary

- Render nested SOM children and shadow-root elements in LangChain text output.
- Preserve indentation so nested controls remain visible to agents.
- Add a regression fixture for child and shadow interactive elements.

## Agent outcome

Before this change, `som_to_text()` only visited direct region elements. A synthetic SOM with one nested child button and one shadow-root link omitted both agent-facing IDs. After this change, both controls are rendered with their existing action metadata and indentation.

## Checks

- Clean-base synthetic failure reproduced before the change.
- LangChain tests: 12 passed.
- Quick action-manifest conformance passed.
- cargo fmt --all -- --check
- cargo test: 445 library tests, 61 binary tests, all integration and doc-test groups passed.
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

This is limited to LangChain SOM text rendering. It does not change fetching, sessions, network policy, MCP lifecycle, cache behavior, or public claims.
