### PR TITLE
docs: align Claude Desktop screenshot tool name

### DIFF
--- a/docs/claude-desktop-config.md
+++ b/docs/claude-desktop-config.md
@@ -51,7 +51,7 @@ Claude now has access to these tools:
 | `type_text` | Type into form fields |
 | `navigate_to` | Navigate to a new URL in an open session; reports `cache_restored` on validated page-state cache hits |
 | `scroll` | Scroll the page |
-| `screenshot` | Take a screenshot |
+| `screenshot_page` | Take a screenshot |
 | `evaluate` | Run JavaScript on the page |
 
 ### Tips

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3305,6 +3305,15 @@ mod tests {
     use crate::som::metadata::StructuredData;
     use crate::som::types::{Element, ElementRole, Region, RegionRole, ShadowRoot, SomMeta};
 
+    #[test]
+    fn claude_desktop_setup_names_registered_screenshot_tool() {
+        let docs = include_str!("../../docs/claude-desktop-config.md");
+        let registered_name = screenshot_page_definition().name;
+
+        assert!(docs.contains(&format!("| `{registered_name}` |")));
+        assert!(!docs.contains("| `screenshot` |"));
+    }
+
     fn stateful_worker_fixture() -> PathBuf {
         static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
         FIXTURE


### PR DESCRIPTION
## Summary

- Correct the Claude Desktop setup guide to name the registered `screenshot_page` MCP tool.
- Add a Rust regression that derives the documented name from the registered tool definition and rejects the stale `screenshot` entry.

## Agent outcome

Before this change, the setup guide told an AI agent to call `screenshot`, but the MCP registry exposed `screenshot_page`. The pre-change contract probe failed because the documented registered name was absent. After this change, the guide and registry name are aligned and the regression prevents the stale name from returning.

## Checks

- Pre-change documentation contract probe failed with exit 1.
- Focused Rust regression passed.
- `cargo fmt --all -- --check`
- `cargo test` (445 library tests, 62 binary tests, all integration and doc-test groups)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

This changes documentation and its alignment proof only. It does not change MCP runtime behavior, fetching, sessions, network policy, cache behavior, or public claims.
