### PR TITLE
fix(parser): validate nested SOM containers

### DIFF
--- a/packages/som-parser-node/src/parser.ts
+++ b/packages/som-parser-node/src/parser.ts
@@ -23,7 +23,60 @@ export function isValidSom(input: unknown): input is Som {
   if (typeof o.title !== 'string') return false;
   if (!Array.isArray(o.regions)) return false;
   if (o.meta == null || typeof o.meta !== 'object') return false;
+  if (!o.regions.every(isValidRegion)) return false;
   return true;
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return input !== null && typeof input === 'object' && !Array.isArray(input);
+}
+
+function isValidElementTree(input: unknown): boolean {
+  if (!isRecord(input) || typeof input.id !== 'string' || typeof input.role !== 'string') {
+    return false;
+  }
+
+  if (
+    input.actions !== undefined &&
+    (!Array.isArray(input.actions) || !input.actions.every((action) => typeof action === 'string'))
+  ) {
+    return false;
+  }
+  if (
+    input.hints !== undefined &&
+    (!Array.isArray(input.hints) || !input.hints.every((hint) => typeof hint === 'string'))
+  ) {
+    return false;
+  }
+  if (
+    input.children !== undefined &&
+    (!Array.isArray(input.children) || !input.children.every(isValidElementTree))
+  ) {
+    return false;
+  }
+
+  if (input.shadow !== undefined) {
+    if (
+      !isRecord(input.shadow) ||
+      typeof input.shadow.mode !== 'string' ||
+      !Array.isArray(input.shadow.elements) ||
+      !input.shadow.elements.every(isValidElementTree)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isValidRegion(input: unknown): boolean {
+  return (
+    isRecord(input) &&
+    typeof input.id === 'string' &&
+    typeof input.role === 'string' &&
+    Array.isArray(input.elements) &&
+    input.elements.every(isValidElementTree)
+  );
 }
 
 function extractJsonObjects(text: string): unknown[] {

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -201,6 +201,16 @@ describe('parseSom', () => {
     expect(() => parseSom({ som_version: '0.1' })).toThrow('Invalid SOM');
     expect(() => parseSom({ som_version: '0.1', url: 'x', title: 'y' })).toThrow('Invalid SOM');
   });
+
+  it('rejects malformed region containers before query helpers can crash', () => {
+    const malformed: unknown = {
+      ...FIXTURE,
+      regions: [null],
+    };
+
+    expect(isValidSom(malformed)).toBe(false);
+    expect(() => parseSom(malformed as object)).toThrow('Invalid SOM');
+  });
 });
 
 describe('isValidSom', () => {


### PR DESCRIPTION
Reject malformed nested SOM containers before parser consumers receive a typed value that crashes during traversal. Before: isValidSom accepted a synthetic SOM with regions: [null]; getAllElements then failed with Cannot read properties of null (reading elements). After: region and element trees validate required containers, including nested children and shadow-root elements; the same fixture returns isValidSom=false and parseSom raises the existing bounded Invalid SOM error. Proof: packages/som-parser-node 64/64 tests, full action-manifest conformance, cargo fmt --all -- --check, full cargo test, and strict all-target/all-feature Clippy pass. No runtime browser, network, auth, session, release, or package-publication behavior changed.