### PR TITLE
fix(sdk/python): use canonical SOM byte estimates

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -490,13 +490,21 @@ def flat_elements(som: Som) -> List[SomElement]:
 def get_token_estimate(som: Union[Som, dict]) -> int:
     """Estimate the token count of a SOM document.
 
-    Uses a simple heuristic of ~4 characters per token on the JSON representation.
+    Uses the canonical ``meta.som_bytes`` count with a ~4 bytes-per-token
+    heuristic. Dicts without SOM metadata keep the legacy JSON-size fallback.
     """
     if isinstance(som, Som):
-        text = som.model_dump_json()
+        som_bytes = som.meta.som_bytes
     else:
-        text = json.dumps(som)
-    return len(text) // 4
+        meta = som.get("meta")
+        som_bytes = meta.get("som_bytes") if isinstance(meta, dict) else None
+        if (
+            not isinstance(som_bytes, int)
+            or isinstance(som_bytes, bool)
+            or som_bytes < 0
+        ):
+            return len(json.dumps(som)) // 4
+    return (som_bytes + 3) // 4
 
 
 # ---- Internal helpers ----

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -475,6 +475,21 @@ class TestFlatElements:
 
 
 class TestGetTokenEstimate:
+    def test_uses_canonical_som_bytes_for_dict(self) -> None:
+        som = {
+            "som_version": "1.0",
+            "url": "fixture",
+            "title": "Fixture",
+            "regions": [],
+            "meta": {
+                "html_bytes": 20,
+                "som_bytes": 5,
+                "element_count": 0,
+                "interactive_count": 0,
+            },
+        }
+        assert get_token_estimate(som) == 2
+
     def test_returns_positive_int(self, sample_som: Som) -> None:
         estimate = get_token_estimate(sample_som)
         assert isinstance(estimate, int)


### PR DESCRIPTION
Align the Python SDK token estimate with the canonical meta.som_bytes field used by the Node and Go SDKs. Keep the legacy serialized-size fallback for dictionaries without SOM metadata.\n\nBefore: the same synthetic metadata with som_bytes = 5 returned 12 in Python and 2 in Node. After: Python and Node both return 2. Focused and full Python SDK tests, full Rust formatting/tests/Clippy, and action-manifest conformance pass. No public pages, credentials, sessions, customer data, or network policy were involved.