### PR TITLE
fix(sdk/go): round token estimates up

### DIFF
--- a/sdk/go/query.go
+++ b/sdk/go/query.go
@@ -699,10 +699,15 @@ func copyFormContext(item *ActionPlanItem, region Region) {
 }
 
 // TokenEstimate returns a rough estimate of the number of tokens in the SOM.
-// Uses the heuristic of SOM bytes / 4.
+// Uses the heuristic of SOM bytes / 4, rounding up partial tokens.
 func TokenEstimate(som *Som) int {
-	if som.Meta.SOMBytes == 0 {
+	somBytes := som.Meta.SOMBytes
+	if somBytes == 0 {
 		return 0
 	}
-	return som.Meta.SOMBytes / 4
+	estimate := somBytes / 4
+	if somBytes > 0 && somBytes%4 != 0 {
+		estimate++
+	}
+	return estimate
 }

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -683,6 +683,14 @@ func TestTokenEstimate(t *testing.T) {
 	}
 }
 
+func TestTokenEstimateRoundsUpCanonicalBytes(t *testing.T) {
+	som := &Som{Meta: SomMeta{SOMBytes: 5}}
+
+	if est := TokenEstimate(som); est != 2 {
+		t.Errorf("TokenEstimate = %d, want 2 for 5 SOM bytes", est)
+	}
+}
+
 func TestSDKVersionMatchesVersionFile(t *testing.T) {
 	version, err := os.ReadFile("VERSION")
 	if err != nil {


### PR DESCRIPTION
## What changed

Round positive Go SDK `TokenEstimate` results up when `meta.som_bytes` is not divisible by four.

## Why

The Go SDK previously used integer floor division. A 5-byte SOM returned 1 token, while the Python and Node SDKs return 2 for the same canonical metadata. This can understate the context budget for an AI agent.

## Proof

- Added a regression for a synthetic 5-byte SOM; it failed on the base with `TokenEstimate = 1, want 2`.
- Go focused and full tests pass.
- `go test -race ./...` passes.
- `go vet ./...` passes.
- Full action-manifest conformance passes.
- `cargo fmt --all -- --check`, `cargo test`, and strict Clippy pass.

This preserves the existing zero and whole-division behavior. The estimate remains a rough 4-bytes-per-token heuristic, not a live tokenization measurement.
