### PR TITLE
fix(parser): validate SOM metadata

### DIFF
--- a/packages/som-parser-node/src/parser.ts
+++ b/packages/som-parser-node/src/parser.ts
@@ -22,13 +22,27 @@ export function isValidSom(input: unknown): input is Som {
   if (typeof o.url !== 'string') return false;
   if (typeof o.title !== 'string') return false;
   if (!Array.isArray(o.regions)) return false;
-  if (o.meta == null || typeof o.meta !== 'object') return false;
+  if (!isValidMeta(o.meta)) return false;
   if (!o.regions.every(isValidRegion)) return false;
   return true;
 }
 
 function isRecord(input: unknown): input is Record<string, unknown> {
   return input !== null && typeof input === 'object' && !Array.isArray(input);
+}
+
+function isNonNegativeInteger(input: unknown): input is number {
+  return typeof input === 'number' && Number.isInteger(input) && input >= 0;
+}
+
+function isValidMeta(input: unknown): boolean {
+  if (!isRecord(input)) return false;
+  return (
+    isNonNegativeInteger(input.html_bytes) &&
+    isNonNegativeInteger(input.som_bytes) &&
+    isNonNegativeInteger(input.element_count) &&
+    isNonNegativeInteger(input.interactive_count)
+  );
 }
 
 function isValidElementTree(input: unknown): boolean {

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -211,6 +211,20 @@ describe('parseSom', () => {
     expect(isValidSom(malformed)).toBe(false);
     expect(() => parseSom(malformed as object)).toThrow('Invalid SOM');
   });
+
+  it('rejects incomplete or invalid metadata before query helpers can misread it', () => {
+    const malformedInputs: unknown[] = [
+      { ...FIXTURE, meta: {} },
+      { ...FIXTURE, meta: { ...FIXTURE.meta, som_bytes: -1 } },
+      { ...FIXTURE, meta: { ...FIXTURE.meta, som_bytes: 1.5 } },
+      { ...FIXTURE, meta: { ...FIXTURE.meta, som_bytes: '50' } },
+    ];
+
+    for (const malformed of malformedInputs) {
+      expect(isValidSom(malformed)).toBe(false);
+      expect(() => parseSom(malformed as object)).toThrow('Invalid SOM');
+    }
+  });
 });
 
 describe('isValidSom', () => {


### PR DESCRIPTION
## Summary

- Validate the four required SOM metadata counters before accepting a document.
- Reject missing, negative, fractional, and string counter values before parser consumers read them.
- Add a regression for the malformed metadata cases.

## Evidence

On the clean base, the Node parser accepted `meta: {}` as valid. The focused regression failed before the source change and passed after it.

## Checks

- `npm test` in `packages/som-parser-node` (65 passed)
- `npm run build` in `packages/som-parser-node`
- `PYTHON="$PWD/integrations/langchain/.venv/bin/python" ./scripts/action-manifest-conformance.sh`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`

No issue is linked. This is a parser-only contract fix.