### PR TITLE
fix(vercel-ai): preserve link metadata in action plans

### DIFF
--- a/integrations/vercel-ai/src/index.ts
+++ b/integrations/vercel-ai/src/index.ts
@@ -721,6 +721,11 @@ export function formatPlasmateActionPlan(
       const id = target.id ? `[${target.id}] ` : ''
       const cacheKey = target.cache_key ? ` [cache_key=${target.cache_key}]` : ''
       const htmlId = target.html_id ? ` [html_id=${target.html_id}]` : ''
+      const href = target.href ? ` [href=${target.href}]` : ''
+      const hreflang = target.hreflang ? ` [hreflang=${target.hreflang}]` : ''
+      const referrerpolicy = target.referrerpolicy
+        ? ` [referrerpolicy=${target.referrerpolicy}]`
+        : ''
       const role = target.role ?? 'target'
       const name = target.label ?? target.text ?? ''
       const actions = target.actions?.length
@@ -881,7 +886,7 @@ export function formatPlasmateActionPlan(
         ? ` [description=${target.description}]`
         : ''
 
-      return `${id}${role}${name ? ` "${name}"` : ''}${actions}${state}${cacheKey}${htmlId}${blockedReason}${required}${readonly}${inert}${linkTarget}${rel}${download}${inputType}${value}${nameAttr}${accept}${capture}${multiple}${selectedValues}${size}${autocomplete}${inputmode}${enterkeyhint}${autocapitalize}${dirname}${form}${formAction}${formMethod}${formTarget}${formEnctype}${formNoValidate}${formAcceptCharset}${formAutocomplete}${list}${popovertarget}${popovertargetaction}${commandfor}${command}${popover}${buttonType}${submitFormAction}${submitFormMethod}${submitFormEnctype}${submitFormTarget}${submitNoValidate}${accesskey}${title}${sourceRole}${testId}${spellcheck}${draggable}${placeholder}${minlength}${maxlength}${min}${max}${step}${pattern}${checked}${expanded}${pressed}${selected}${multiline}${multiselectable}${current}${controls}${haspopup}${invalid}${ariaLabel}${labelledby}${describedby}${ariaPlaceholder}${ariaAutocomplete}${activeDescendant}${errorMessage}${keyshortcuts}${roledescription}${grabbed}${dropeffect}${busy}${live}${atomic}${relevant}${owns}${flowto}${details}${orientation}${sort}${level}${posinset}${setsize}${valuemin}${valuemax}${valuenow}${valuetext}${group}${description}`
+      return `${id}${role}${name ? ` "${name}"` : ''}${actions}${state}${cacheKey}${htmlId}${href}${hreflang}${referrerpolicy}${blockedReason}${required}${readonly}${inert}${linkTarget}${rel}${download}${inputType}${value}${nameAttr}${accept}${capture}${multiple}${selectedValues}${size}${autocomplete}${inputmode}${enterkeyhint}${autocapitalize}${dirname}${form}${formAction}${formMethod}${formTarget}${formEnctype}${formNoValidate}${formAcceptCharset}${formAutocomplete}${list}${popovertarget}${popovertargetaction}${commandfor}${command}${popover}${buttonType}${submitFormAction}${submitFormMethod}${submitFormEnctype}${submitFormTarget}${submitNoValidate}${accesskey}${title}${sourceRole}${testId}${spellcheck}${draggable}${placeholder}${minlength}${maxlength}${min}${max}${step}${pattern}${checked}${expanded}${pressed}${selected}${multiline}${multiselectable}${current}${controls}${haspopup}${invalid}${ariaLabel}${labelledby}${describedby}${ariaPlaceholder}${ariaAutocomplete}${activeDescendant}${errorMessage}${keyshortcuts}${roledescription}${grabbed}${dropeffect}${busy}${live}${atomic}${relevant}${owns}${flowto}${details}${orientation}${sort}${level}${posinset}${setsize}${valuemin}${valuemax}${valuenow}${valuetext}${group}${description}`
     })
     .join('\n')
 }

--- a/integrations/vercel-ai/tests/action-plan.test.mjs
+++ b/integrations/vercel-ai/tests/action-plan.test.mjs
@@ -237,6 +237,7 @@ assert.match(
   /\[e_quota\].*\[orientation=horizontal\].*\[valuemin=1\].*\[valuemax=100\].*\[valuenow=40\].*\[valuetext=40 seats\]/
 )
 assert.match(formatted, /\[e_billing\].*\[current=page\]/)
+assert.match(formatted, /\[e_billing\].*\[href=\/billing\].*\[hreflang=en-US\].*\[referrerpolicy=no-referrer\]/)
 assert.match(formatted, /\[e_billing\].*\[target=_blank\]/)
 assert.match(formatted, /\[e_billing\].*\[rel=noopener\]/)
 assert.match(formatted, /\[e_billing\].*\[download=billing\.csv\]/)


### PR DESCRIPTION
## Summary

- Include extracted link `href`, `hreflang`, and `referrerpolicy` fields in Vercel AI action-plan prompt text.
- Add a regression using the shared action-availability fixture.

## Agent outcome

Vercel AI agents can now see the link metadata that the adapter already extracts when they choose or reuse an action target. The formatter previously dropped these fields before the prompt was built.

## Checks

- `npm test` in `integrations/vercel-ai`
- `npm run typecheck` in `integrations/vercel-ai`
- `PYTHON="$PWD/integrations/langchain/.venv/bin/python" ./scripts/action-manifest-conformance.sh --full`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test --quiet`
- `~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

The focused regression failed before the formatter change and passes after it. No issue is linked.
