### PR TITLE
fix(cli): include nested and shadow text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1586,12 +1586,7 @@ fn render_som_output(
             }
             for region in &som.regions {
                 for el in &region.elements {
-                    if let Some(ref text) = el.text {
-                        let t = text.trim();
-                        if !t.is_empty() {
-                            parts.push(t);
-                        }
-                    }
+                    collect_text(el, &mut parts);
                 }
             }
             Ok(parts.join("\n"))
@@ -1621,6 +1616,26 @@ fn render_som_output(
             Ok(urls.join("\n"))
         }
         _ => Ok(serde_json::to_string_pretty(som)?),
+    }
+}
+
+/// Recursively collect visible text from a SOM element tree.
+fn collect_text<'a>(el: &'a som::types::Element, parts: &mut Vec<&'a str>) {
+    if let Some(ref text) = el.text {
+        let t = text.trim();
+        if !t.is_empty() {
+            parts.push(t);
+        }
+    }
+    if let Some(ref children) = el.children {
+        for child in children {
+            collect_text(child, parts);
+        }
+    }
+    if let Some(ref shadow) = el.shadow {
+        for child in &shadow.elements {
+            collect_text(child, parts);
+        }
     }
 }
 
@@ -2089,5 +2104,75 @@ mod tests {
         let links = render_som_output(&som, "links").expect("links output should render");
 
         assert_eq!(links, "/docs");
+    }
+
+    #[test]
+    fn text_format_includes_nested_and_shadow_content() {
+        let som = Som {
+            som_version: "0.1".to_string(),
+            url: "https://example.test".to_string(),
+            title: "Settings".to_string(),
+            lang: "en".to_string(),
+            regions: vec![Region {
+                id: "r_main".to_string(),
+                role: RegionRole::Main,
+                label: None,
+                action: None,
+                method: None,
+                target: None,
+                enctype: None,
+                novalidate: None,
+                accept_charset: None,
+                autocomplete: None,
+                elements: vec![Element {
+                    id: "e_host".to_string(),
+                    role: ElementRole::Section,
+                    html_id: None,
+                    text: None,
+                    label: None,
+                    actions: None,
+                    attrs: None,
+                    children: Some(vec![Element {
+                        id: "e_nested".to_string(),
+                        role: ElementRole::Paragraph,
+                        html_id: None,
+                        text: Some("Nested paragraph".to_string()),
+                        label: None,
+                        actions: None,
+                        attrs: None,
+                        children: None,
+                        hints: None,
+                        shadow: None,
+                    }]),
+                    hints: None,
+                    shadow: Some(ShadowRoot {
+                        mode: "open".to_string(),
+                        elements: vec![Element {
+                            id: "e_shadow_text".to_string(),
+                            role: ElementRole::Paragraph,
+                            html_id: None,
+                            text: Some("Shadow copy".to_string()),
+                            label: None,
+                            actions: None,
+                            attrs: None,
+                            children: None,
+                            hints: None,
+                            shadow: None,
+                        }],
+                    }),
+                }],
+            }],
+            meta: SomMeta {
+                html_bytes: 1,
+                som_bytes: 1,
+                element_count: 3,
+                interactive_count: 0,
+            },
+            structured_data: None,
+        };
+
+        let text = render_som_output(&som, "text").expect("text output should render");
+
+        assert_eq!(text, "Settings\nNested paragraph\nShadow copy");
     }
 }


### PR DESCRIPTION
## Outcome

CLI `--format text` now includes nested container text and shadow-root text, matching MCP `extract_text` and the existing `--format links` walker.

This update also pins `h2` to 0.4.16 so required check `Rust advisory audit` can pass RUSTSEC-2026-0258.

## Root cause

`render_som_output` for `text` walked only top-level region elements. Nested children and shadow-root content already exist in the SOM and are exposed by MCP `extract_text`, but CLI text dropped them.

`Cargo.lock` still pinned `h2` 0.4.13. Advisory RUSTSEC-2026-0258 requires `h2` >= 0.4.16.

## Change

- Recurse into container children when rendering text.
- Recurse into shadow-root elements.
- Add a focused regression for nested paragraph text and shadow copy.
- Rebase onto current `master` by merge.
- Lockfile-only `h2` 0.4.16 pin. No `windows-sys` or other crate churn.

## Before and after evidence

- Before: `--format text` on a section host returned only the page title.
- After: the same snapshot includes `Nested paragraph` and `Shadow copy`.
- Before: `Cargo.lock` had `h2` 0.4.13.
- After: `cargo metadata --locked` and `cargo tree -i h2 --locked` resolve `h2` 0.4.16.

## Checks

- `rustfmt --edition 2021 --check src/main.rs`
- `cargo test --bin plasmate text_format_includes_nested_and_shadow_content`
- `cargo metadata --locked`
- `cargo tree -i h2 --locked`
- `git diff --check`

This change does not alter network behavior, sessions, cache behavior, release state, or public claims.