### PR TITLE
fix(cli): include compiled list items in text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1650,6 +1650,16 @@ fn collect_text(el: &som::types::Element, parts: &mut Vec<String>) {
                 }
             }
         }
+        if let Some(items) = attrs.get("items").and_then(|value| value.as_array()) {
+            for item in items {
+                if let Some(text) = item.get("text").and_then(|value| value.as_str()) {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        parts.push(trimmed.to_string());
+                    }
+                }
+            }
+        }
     }
     if let Some(ref children) = el.children {
         for child in children {
@@ -2285,6 +2295,20 @@ mod tests {
         assert!(text.contains("Plan | Price"));
         assert!(text.contains("Starter | $9"));
         assert!(text.contains("Pro | $29"));
+    }
+
+    #[test]
+    fn text_format_includes_compiled_list_items() {
+        let som = plasmate::som::compiler::compile(
+            "<main><h1>Docs</h1><ul><li>Install</li><li>Configure</li></ul></main>",
+            "https://example.test/docs",
+        )
+        .expect("list fixture should compile");
+
+        let text = render_som_output(&som, "text").expect("text output should render");
+
+        assert!(text.contains("Install"));
+        assert!(text.contains("Configure"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The compiler stores list entries in `attrs.items` and clears list text. CLI `--format text` already reads compiled table attrs but not list items, so compiled lists disappeared from agent text.

Read `attrs.items` in `collect_text`.

## Proof
- Before: compiled list attrs produced no CLI text output for `Install` / `Configure`.
- After: `tests::text_format_includes_compiled_list_items` passes and the text contains `Install` and `Configure`.

Focused check: `cargo test --bin plasmate text_format_includes -- --nocapture`

Governor merge of remaining compiled-list CLI text surface after the automation PR queue emptied. MCP `extract_text` and CLI markdown already read `attrs.items`.

Not a governor merge. Please review and dispose.