### PR TITLE
fix(parser): include compiled list items in get_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -575,14 +575,25 @@ def get_headings(som: Som) -> List[Dict[str, object]]:
     return headings
 
 
+def _visible_text_parts(el: SomElement) -> List[str]:
+    """Return element text plus compiled list items when present."""
+    parts: List[str] = []
+    if el.text:
+        parts.append(el.text)
+    elif el.label:
+        parts.append(el.label)
+    if el.attrs and el.attrs.items:
+        for item in el.attrs.items:
+            if item.text:
+                parts.append(item.text)
+    return parts
+
+
 def get_text(som: Som) -> str:
     """Extract all visible text content from the SOM."""
     parts: List[str] = []
     for el in get_all_elements(som):
-        if el.text:
-            parts.append(el.text)
-        elif el.label:
-            parts.append(el.label)
+        parts.extend(_visible_text_parts(el))
     return "\n".join(parts)
 
 
@@ -592,10 +603,7 @@ def get_text_by_region(som: Som) -> List[Dict[str, object]]:
     for region in som.regions:
         texts: List[str] = []
         for el in _collect_elements(region.elements):
-            if el.text:
-                texts.append(el.text)
-            elif el.label:
-                texts.append(el.label)
+            texts.extend(_visible_text_parts(el))
         results.append({
             "region_id": region.id,
             "role": region.role.value,

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -770,6 +770,45 @@ class TestGetText:
         assert "Search" in text
         assert "Go" in text
 
+    def test_includes_compiled_list_items(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_list",
+                            "role": "list",
+                            "attrs": {
+                                "ordered": False,
+                                "items": [
+                                    {"text": "Install"},
+                                    {"text": "Configure"},
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        text = get_text(som)
+        assert "Install" in text
+        assert "Configure" in text
+
+        regions = get_text_by_region(som)
+        assert regions[0]["role"] == "main"
+        assert "Install" in regions[0]["text"]
+        assert "Configure" in regions[0]["text"]
+
 
 class TestGetTextByRegion:
     def test_regions(self, som: Som):


### PR DESCRIPTION
## Summary
SOM list roles compile item copy into `attrs.items` and set `element.text` to none. Python `get_text` / `get_text_by_region` only read `text`/`label`, so agents using som-parser (including Browser Use) dropped list content.

This run surfaces compiled list item text in both helpers.

## Proof
Focused: `python3 -m pytest tests/test_parser.py::TestGetText -v` in `packages/som-parser-python` (2 passed).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (fetch_page, selector=main).

## Governor
One small parser-text delta. No security, cache, or protocol changes.