### PR TITLE
fix(parser): include compiled list items in getText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -578,12 +578,24 @@ export function getHeadings(som: Som): Array<{ level: number; text: string; id: 
   }));
 }
 
+function visibleTextParts(el: SomElement): string[] {
+  const parts: string[] = [];
+  if (el.text) {
+    parts.push(el.text);
+  } else if (el.label) {
+    parts.push(el.label);
+  }
+  for (const item of el.attrs?.items ?? []) {
+    if (item.text) {
+      parts.push(item.text);
+    }
+  }
+  return parts;
+}
+
 /** Extract all visible text content, joined with newlines. */
 export function getText(som: Som): string {
-  return getAllElements(som)
-    .map((el) => el.text ?? el.label ?? '')
-    .filter(Boolean)
-    .join('\n');
+  return getAllElements(som).flatMap(visibleTextParts).join('\n');
 }
 
 /** Extract text grouped by region. */
@@ -593,10 +605,7 @@ export function getTextByRegion(
   return som.regions.map((r) => ({
     region: r.id,
     role: r.role,
-    text: collectElements(r.elements)
-      .map((el) => el.text ?? el.label ?? '')
-      .filter(Boolean)
-      .join('\n'),
+    text: collectElements(r.elements).flatMap(visibleTextParts).join('\n'),
   }));
 }
 

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -695,6 +695,44 @@ describe('getText', () => {
     expect(text).toContain('Search');
     expect(text).toContain('Go');
   });
+
+  it('includes compiled list items', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_list',
+              role: 'list',
+              attrs: {
+                ordered: false,
+                items: [{ text: 'Install' }, { text: 'Configure' }],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const text = getText(som);
+    expect(text).toContain('Install');
+    expect(text).toContain('Configure');
+
+    const byRegion = getTextByRegion(som);
+    expect(byRegion).toHaveLength(1);
+    expect(byRegion[0].role).toBe('main');
+    expect(byRegion[0].text).toContain('Install');
+    expect(byRegion[0].text).toContain('Configure');
+  });
 });
 
 describe('getTextByRegion', () => {


### PR DESCRIPTION
## Summary
SOM list roles compile item copy into `attrs.items` and set `element.text` to none. Node `getText` / `getTextByRegion` only read `text`/`label`, so agents using som-parser-node dropped list content.

This run surfaces compiled list item text in both helpers.

## Proof
Focused: `npx vitest run tests/parser.test.ts -t "getText"` in `packages/som-parser-node` (3 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-text delta. No security, cache, or protocol changes.