### PR TITLE
fix(parser): include compiled table rows in getText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -590,6 +590,15 @@ function visibleTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  const headers = el.attrs?.headers ?? [];
+  if (headers.length) {
+    parts.push(headers.join(' | '));
+  }
+  for (const row of el.attrs?.rows ?? []) {
+    if (row.length) {
+      parts.push(row.join(' | '));
+    }
+  }
   return parts;
 }
 

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -733,6 +733,49 @@ describe('getText', () => {
     expect(byRegion[0].text).toContain('Install');
     expect(byRegion[0].text).toContain('Configure');
   });
+
+  it('includes compiled table rows', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const text = getText(som);
+    expect(text).toContain('Plan | Price');
+    expect(text).toContain('Starter | $9');
+    expect(text).toContain('Pro | $29');
+
+    const byRegion = getTextByRegion(som);
+    expect(byRegion).toHaveLength(1);
+    expect(byRegion[0].role).toBe('main');
+    expect(byRegion[0].text).toContain('Plan | Price');
+    expect(byRegion[0].text).toContain('Starter | $9');
+    expect(byRegion[0].text).toContain('Pro | $29');
+  });
 });
 
 describe('getTextByRegion', () => {


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers` / `attrs.rows` and leave `element.text` empty. Node `getText` / `getTextByRegion` only read `text`/`label`, so agents using som-parser-node dropped table content.

This run surfaces compiled table headers and rows in both helpers.

## Proof
Focused: `npx vitest run tests/parser.test.ts -t "getText"` in `packages/som-parser-node` (3 passed).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-text delta. No security, cache, or protocol changes. Unique from open #122 (Python list items) and #123 (Node list items).