### PR TITLE
fix(parser): include compiled table rows in get_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -576,16 +576,23 @@ def get_headings(som: Som) -> List[Dict[str, object]]:
 
 
 def _visible_text_parts(el: SomElement) -> List[str]:
-    """Return element text plus compiled list items when present."""
+    """Return element text plus compiled list items and table headers/rows."""
     parts: List[str] = []
     if el.text:
         parts.append(el.text)
     elif el.label:
         parts.append(el.label)
-    if el.attrs and el.attrs.items:
-        for item in el.attrs.items:
-            if item.text:
-                parts.append(item.text)
+    if el.attrs:
+        if el.attrs.items:
+            for item in el.attrs.items:
+                if item.text:
+                    parts.append(item.text)
+        if el.attrs.headers:
+            parts.append(" | ".join(el.attrs.headers))
+        if el.attrs.rows:
+            for row in el.attrs.rows:
+                if row:
+                    parts.append(" | ".join(row))
     return parts
 
 

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -809,6 +809,47 @@ class TestGetText:
         assert "Install" in regions[0]["text"]
         assert "Configure" in regions[0]["text"]
 
+    def test_includes_compiled_table_rows(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_table",
+                            "role": "table",
+                            "attrs": {
+                                "headers": ["Plan", "Price"],
+                                "rows": [
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        text = get_text(som)
+        assert "Plan | Price" in text
+        assert "Starter | $9" in text
+        assert "Pro | $29" in text
+
+        regions = get_text_by_region(som)
+        assert regions[0]["role"] == "main"
+        assert "Plan | Price" in regions[0]["text"]
+        assert "Starter | $9" in regions[0]["text"]
+        assert "Pro | $29" in regions[0]["text"]
+
 
 class TestGetTextByRegion:
     def test_regions(self, som: Som):


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers` / `attrs.rows` and leave `element.text` empty. Python `get_text` / `get_text_by_region` only read `text`/`label`, so agents using som-parser dropped table content.

This run surfaces compiled table headers and rows in both helpers.

## Proof
Focused: `python3 -m pytest tests/test_parser.py::TestGetText -v` in `packages/som-parser-python` (2 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-text delta. No security, cache, or protocol changes. Unique from open #122 (Python list items), #123 (Node list items), and #124 (Node table rows).