### PR TITLE
fix(parser): include compiled table rows in to_markdown

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -687,6 +687,23 @@ def _element_to_markdown(el: SomElement, lines: List[str]) -> None:
         if el.attrs and el.attrs.items:
             for item in el.attrs.items:
                 lines.append(f"- {item.text}")
+    elif role == ElementRole.TABLE:
+        emitted = False
+        if el.attrs:
+            headers = el.attrs.headers or []
+            if headers:
+                lines.append("| " + " | ".join(headers) + " |")
+                lines.append("| " + " | ".join("---" for _ in headers) + " |")
+                emitted = True
+            for row in el.attrs.rows or []:
+                if row:
+                    lines.append("| " + " | ".join(row) + " |")
+                    emitted = True
+        elif el.text:
+            lines.append(el.text)
+            emitted = True
+        if emitted:
+            lines.append("")
     elif role == ElementRole.SEPARATOR:
         lines.append("---")
     else:

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -942,6 +942,41 @@ class TestToMarkdown:
         md = to_markdown(som)
         assert "Input: Search" in md
 
+    def test_includes_compiled_table_rows(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_table",
+                            "role": "table",
+                            "attrs": {
+                                "headers": ["Plan", "Price"],
+                                "rows": [
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        md = to_markdown(som)
+        assert "| Plan | Price |" in md
+        assert "| Starter | $9 |" in md
+        assert "| Pro | $29 |" in md
+
 
 class TestFilterElements:
     def test_filter_by_actions(self, som: Som):


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers` / `attrs.rows` and leave `element.text` empty. Python `to_markdown` only rendered lists and `element.text`, so agents using som-parser or browser-use `extract_markdown` dropped table content.

This run renders compiled table headers and rows as markdown tables.

## Proof
- Before: compiled table attrs produced no `to_markdown` output.
- After: `TestToMarkdown::test_includes_compiled_table_rows` passes and the markdown contains `| Plan | Price |`, `| Starter | $9 |`, and `| Pro | $29 |`.

Focused: `python3 -m pytest tests/test_parser.py::TestToMarkdown -v` in `packages/som-parser-python` (11 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-markdown delta. No security, cache, or protocol changes. Unique from merged #125 (Python get_text table rows) and #124 (Node getText table rows). Node `toMarkdown` remains a later surface.

Not a governor merge. Please review and dispose.