### PR TITLE
fix(parser): include compiled table rows in toMarkdown

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -679,6 +679,27 @@ export function toMarkdown(som: Som): string {
           if (items.length) lines.push('');
           break;
         }
+        case 'table': {
+          const headers = el.attrs?.headers ?? [];
+          let emitted = false;
+          if (headers.length) {
+            lines.push('| ' + headers.join(' | ') + ' |');
+            lines.push('| ' + headers.map(() => '---').join(' | ') + ' |');
+            emitted = true;
+          }
+          for (const row of el.attrs?.rows ?? []) {
+            if (row.length) {
+              lines.push('| ' + row.join(' | ') + ' |');
+              emitted = true;
+            }
+          }
+          if (!emitted && el.text) {
+            lines.push(el.text);
+            emitted = true;
+          }
+          if (emitted) lines.push('');
+          break;
+        }
         default:
           if (el.text) {
             lines.push(el.text);

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -868,6 +868,42 @@ describe('toMarkdown', () => {
     expect(md).toContain('**Search** (text_input)');
     expect(md).toContain('[Go] (button)');
   });
+
+  it('includes compiled table rows', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const md = toMarkdown(som);
+    expect(md).toContain('| Plan | Price |');
+    expect(md).toContain('| Starter | $9 |');
+    expect(md).toContain('| Pro | $29 |');
+  });
 });
 
 describe('filter', () => {


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers` / `attrs.rows` and leave `element.text` empty. Node `toMarkdown` only rendered lists and `element.text`, so agents using som-parser-node dropped compiled tables.

This run emits compiled table headers and rows as markdown tables.

## Proof
Focused: `npx vitest run tests/parser.test.ts -t "toMarkdown"` in `packages/som-parser-node` (8 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-markdown delta. No security, cache, or protocol changes. Unique from open #126 (Python `to_markdown` tables).