### PR TITLE
fix(parser): include compiled list items in find_by_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -77,14 +77,15 @@ def find_by_text(
     """
     results: List[SomElement] = []
     for el in get_all_elements(som):
-        el_text = el.text or ""
-        el_label = el.label or ""
+        parts = [el.text or "", el.label or ""]
+        if el.attrs and el.attrs.items:
+            parts.extend(item.text for item in el.attrs.items if item.text)
         if exact:
-            if text == el_text or text == el_label:
+            if text in parts:
                 results.append(el)
         else:
             text_lower = text.lower()
-            if text_lower in el_text.lower() or text_lower in el_label.lower():
+            if any(text_lower in part.lower() for part in parts):
                 results.append(el)
     return results
 

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -479,6 +479,41 @@ class TestFindByText:
         )
         assert find_by_text(som, "inside shadow")[0].id == "shadow_text"
 
+    def test_finds_compiled_list_items(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_list",
+                            "role": "list",
+                            "attrs": {
+                                "ordered": False,
+                                "items": [
+                                    {"text": "Install"},
+                                    {"text": "Configure"},
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        results = find_by_text(som, "install")
+        assert [el.id for el in results] == ["e_list"]
+        assert [el.id for el in find_by_text(som, "Configure", exact=True)] == ["e_list"]
+        assert find_by_text(som, "configure", exact=True) == []
+
 
 class TestGetInteractiveElements:
     def test_count(self, som: Som):


### PR DESCRIPTION
## Summary
SOM lists compile item copy into `attrs.items` and leave `element.text` empty. Python `find_by_text` only searched `text`/`label`, so agents could not locate compiled lists by item copy.

This run matches compiled list item text for both substring and exact lookup.

## Proof
Focused: `python3 -m pytest tests/test_parser.py::TestFindByText -v` in `packages/som-parser-python` (8 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-query delta. No security, cache, or protocol changes. Unique from open #126 (Python `to_markdown` tables) and #127 (Node `toMarkdown` tables).