### PR TITLE
fix(parser): include compiled list items in findByText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -46,6 +46,22 @@ export function findByHtmlId(som: Som, htmlId: string): SomElement | undefined {
   return getAllElements(som).find((el) => el.html_id === htmlId);
 }
 
+function searchableTextParts(el: SomElement): string[] {
+  const parts: string[] = [];
+  if (el.text) {
+    parts.push(el.text);
+  }
+  if (el.label) {
+    parts.push(el.label);
+  }
+  for (const item of el.attrs?.items ?? []) {
+    if (item.text) {
+      parts.push(item.text);
+    }
+  }
+  return parts;
+}
+
 /** Find elements containing text (case-insensitive substring by default). */
 export function findByText(
   som: Som,
@@ -54,13 +70,11 @@ export function findByText(
 ): SomElement[] {
   const all = getAllElements(som);
   if (options?.exact) {
-    return all.filter((el) => el.text === text || el.label === text);
+    return all.filter((el) => searchableTextParts(el).includes(text));
   }
   const lower = text.toLowerCase();
-  return all.filter(
-    (el) =>
-      (el.text && el.text.toLowerCase().includes(lower)) ||
-      (el.label && el.label.toLowerCase().includes(lower)),
+  return all.filter((el) =>
+    searchableTextParts(el).some((part) => part.toLowerCase().includes(lower)),
   );
 }
 

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -386,6 +386,40 @@ describe('findByText', () => {
   it('returns empty for no match', () => {
     expect(findByText(FIXTURE, 'nonexistent')).toHaveLength(0);
   });
+
+  it('finds compiled list items', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_list',
+              role: 'list',
+              attrs: {
+                ordered: false,
+                items: [{ text: 'Install' }, { text: 'Configure' }],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    expect(findByText(som, 'install').map((el) => el.id)).toEqual(['e_list']);
+    expect(findByText(som, 'Configure', { exact: true }).map((el) => el.id)).toEqual([
+      'e_list',
+    ]);
+    expect(findByText(som, 'configure', { exact: true })).toEqual([]);
+  });
 });
 
 describe('getInteractiveElements', () => {


### PR DESCRIPTION
## Summary
SOM lists compile item copy into `attrs.items` and leave `element.text` empty. Node `findByText` only searched `text`/`label`, so agents could not locate compiled lists by item copy.

This run matches compiled list item text for both substring and exact lookup.

## Proof
Focused: `npm test -- tests/parser.test.ts -t findByText` in `packages/som-parser-node` (6 passed).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (fetch_page, selector=main).

## Governor
One small parser-query delta. No security, cache, or protocol changes. Unique from open #126 (Python `to_markdown` tables), #127 (Node `toMarkdown` tables), and #128 (Python `find_by_text` lists).