### PR TITLE
fix(sdk): include compiled list items in find_by_text

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -469,7 +469,7 @@ def find_action_target_by_label(
 
 
 def find_by_text(som: Som, text: str) -> List[SomElement]:
-    """Find all elements whose text or label contains the substring."""
+    """Find all elements whose text, label, or compiled list items contain the substring."""
     results: List[SomElement] = []
     lower = text.lower()
     for region in som.regions:
@@ -549,9 +549,14 @@ def _collect_interactive(element: SomElement, results: List[SomElement]) -> None
 
 
 def _collect_by_text(element: SomElement, lower_text: str, results: List[SomElement]) -> None:
-    if (element.text and lower_text in element.text.lower()) or (
-        element.label and lower_text in element.label.lower()
-    ):
+    parts = []
+    if element.text:
+        parts.append(element.text)
+    if element.label:
+        parts.append(element.label)
+    if element.attrs and element.attrs.items:
+        parts.extend(item.text for item in element.attrs.items if item.text)
+    if any(lower_text in part.lower() for part in parts):
         results.append(element)
     if element.children:
         for child in element.children:

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -8,6 +8,7 @@ import pytest
 from plasmate.types import (
     ElementAttrs,
     ElementRole,
+    ListItem,
     RegionRole,
     SemanticHint,
     SelectOption,
@@ -452,6 +453,44 @@ class TestFindByText:
 
     def test_no_match_returns_empty(self, sample_som: Som) -> None:
         assert find_by_text(sample_som, "zzz_no_match") == []
+
+    def test_finds_compiled_list_items(self) -> None:
+        som = Som(
+            som_version="1.0",
+            url="https://example.com/list",
+            title="List Page",
+            lang="en",
+            regions=[
+                SomRegion(
+                    id="r_main",
+                    role=RegionRole.main,
+                    elements=[
+                        SomElement(
+                            id="e_list",
+                            role=ElementRole.list,
+                            attrs=ElementAttrs(
+                                ordered=False,
+                                items=[
+                                    ListItem(text="Install"),
+                                    ListItem(text="Configure"),
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+            meta=SomMeta(
+                html_bytes=100,
+                som_bytes=50,
+                element_count=1,
+                interactive_count=0,
+            ),
+        )
+
+        results = find_by_text(som, "install")
+        assert [el.id for el in results] == ["e_list"]
+        assert find_by_text(som, "Configure")[0].id == "e_list"
+        assert find_by_text(som, "zzz_no_match") == []
 
 
 class TestFlatElements:


### PR DESCRIPTION
## Summary
SOM lists compile item copy into `attrs.items` and leave `element.text` empty. Python SDK `find_by_text` only searched `text`/`label`, so agents could not locate compiled lists by item copy.

This run matches compiled list item text for substring lookup.

## Proof
Focused: `PYTHONPATH=src python3 -m pytest tests/test_query.py::TestFindByText -v` in `sdk/python` (8 passed).

Plasmate MCP: `https://docs.plasmate.app` (fetch_page, selector=main) and `https://plasmate.app` (extract_text).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #127 (Node `toMarkdown` tables), #128 (Python parser `find_by_text` lists), and #129 (Node parser `findByText` lists).