### PR TITLE
fix(sdk): include compiled list items in findByText

### DIFF
--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -262,6 +262,37 @@ describe('findByText', () => {
   it('returns empty for no match', () => {
     assert.deepEqual(findByText(fixture, 'nonexistent'), []);
   });
+
+  it('finds compiled list items', () => {
+    const som: Som = {
+      ...fixture,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_list',
+              role: 'list',
+              attrs: {
+                ordered: false,
+                items: [{ text: 'Install' }, { text: 'Configure' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const results = findByText(som, 'install');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, 'e_list');
+    assert.deepEqual(
+      findByText(som, 'Configure').map((el) => el.id),
+      ['e_list'],
+    );
+    assert.deepEqual(findByText(som, 'nonexistent'), []);
+  });
 });
 
 describe('getActionPlan', () => {

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -503,13 +503,27 @@ export function findActionTargetByLabel(
   return findActionTarget(som, label, { ...options, by: 'label' });
 }
 
+function searchableTextParts(el: SomElement): string[] {
+  const parts: string[] = [];
+  if (el.text != null) {
+    parts.push(el.text);
+  }
+  if (el.label != null) {
+    parts.push(el.label);
+  }
+  for (const item of el.attrs?.items ?? []) {
+    if (item.text) {
+      parts.push(item.text);
+    }
+  }
+  return parts;
+}
+
 /** Find all elements containing the given text (case-insensitive substring match). */
 export function findByText(som: Som, text: string): SomElement[] {
   const lower = text.toLowerCase();
-  return flatElements(som).filter(
-    (el) =>
-      (el.text != null && el.text.toLowerCase().includes(lower)) ||
-      (el.label != null && el.label.toLowerCase().includes(lower)),
+  return flatElements(som).filter((el) =>
+    searchableTextParts(el).some((part) => part.toLowerCase().includes(lower)),
   );
 }
 


### PR DESCRIPTION
## Summary
SOM lists compile item copy into `attrs.items` and leave `element.text` empty. Node SDK `findByText` only searched `text`/`label`, so agents could not locate compiled lists by item copy.

This run matches compiled list item text for substring lookup.

## Proof
Focused: `npx tsc && node --test dist/query.test.js` in `sdk/node` (30 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #127 (Node parser `toMarkdown` tables), #128 (Python parser `find_by_text` lists), and #130 (Python SDK `find_by_text` lists).