### PR TITLE
fix(parser): include compiled table rows in findByText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -59,6 +59,18 @@ function searchableTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  for (const header of el.attrs?.headers ?? []) {
+    if (header) {
+      parts.push(header);
+    }
+  }
+  for (const row of el.attrs?.rows ?? []) {
+    for (const cell of row) {
+      if (cell) {
+        parts.push(cell);
+      }
+    }
+  }
   return parts;
 }
 

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -420,6 +420,43 @@ describe('findByText', () => {
     ]);
     expect(findByText(som, 'configure', { exact: true })).toEqual([]);
   });
+
+  it('finds compiled table rows', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    expect(findByText(som, 'starter').map((el) => el.id)).toEqual(['e_table']);
+    expect(findByText(som, 'Pro', { exact: true }).map((el) => el.id)).toEqual([
+      'e_table',
+    ]);
+    expect(findByText(som, 'pro', { exact: true })).toEqual([]);
+  });
 });
 
 describe('getInteractiveElements', () => {


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers`/`attrs.rows` and leave `element.text` empty. Node `findByText` only searched `text`/`label`/list items, so agents could not locate compiled tables by cell copy.

This run matches compiled table header and row text for both substring and exact lookup.

## Proof
Focused: `npm test -- tests/parser.test.ts` in `packages/som-parser-node` (69 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text, selector=main).

## Governor
One small parser-query delta. No security, cache, or protocol changes. Unique from open #127 (Node `toMarkdown` tables), #128 (Python `find_by_text` lists), #130 (Python SDK `find_by_text` lists), and #131 (Node SDK `findByText` lists).