### PR TITLE
fix(parser): include compiled table rows in find_by_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -64,6 +64,27 @@ def find_by_html_id(som: Som, html_id: str) -> Optional[SomElement]:
     return None
 
 
+def _searchable_text_parts(el: SomElement) -> List[str]:
+    parts: List[str] = []
+    if el.text:
+        parts.append(el.text)
+    if el.label:
+        parts.append(el.label)
+    if el.attrs:
+        if el.attrs.items:
+            parts.extend(item.text for item in el.attrs.items if item.text)
+        if el.attrs.headers:
+            for header in el.attrs.headers:
+                if header:
+                    parts.append(header)
+        if el.attrs.rows:
+            for row in el.attrs.rows:
+                for cell in row:
+                    if cell:
+                        parts.append(cell)
+    return parts
+
+
 def find_by_text(
     som: Som, text: str, *, exact: bool = False
 ) -> List[SomElement]:
@@ -77,9 +98,7 @@ def find_by_text(
     """
     results: List[SomElement] = []
     for el in get_all_elements(som):
-        parts = [el.text or "", el.label or ""]
-        if el.attrs and el.attrs.items:
-            parts.extend(item.text for item in el.attrs.items if item.text)
+        parts = _searchable_text_parts(el)
         if exact:
             if text in parts:
                 results.append(el)

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -514,6 +514,42 @@ class TestFindByText:
         assert [el.id for el in find_by_text(som, "Configure", exact=True)] == ["e_list"]
         assert find_by_text(som, "configure", exact=True) == []
 
+    def test_finds_compiled_table_rows(self):
+        som = parse_som(
+            {
+                **FIXTURE_SOM,
+                "regions": [
+                    {
+                        "id": "r_main",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e_table",
+                                "role": "table",
+                                "attrs": {
+                                    "headers": ["Plan", "Price"],
+                                    "rows": [
+                                        ["Starter", "$9"],
+                                        ["Pro", "$29"],
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 100,
+                    "som_bytes": 50,
+                    "element_count": 1,
+                    "interactive_count": 0,
+                },
+            }
+        )
+
+        assert [el.id for el in find_by_text(som, "starter")] == ["e_table"]
+        assert [el.id for el in find_by_text(som, "Pro", exact=True)] == ["e_table"]
+        assert find_by_text(som, "pro", exact=True) == []
+
 
 class TestGetInteractiveElements:
     def test_count(self, som: Som):


### PR DESCRIPTION
## Summary
SOM tables compile cell copy into `attrs.headers`/`attrs.rows` and leave `element.text` empty. Python `find_by_text` only searched `text`/`label`, so agents could not locate compiled tables by cell copy.

This run matches compiled table header and row text for both substring and exact lookup.

## Proof
Focused: `PYTHONPATH=. python3 -m pytest tests/test_parser.py` in `packages/som-parser-python` (81 passed).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).

## Governor
One small parser-query delta. No security, cache, or protocol changes. Unique from open #127 (Node `toMarkdown` tables), #128 (Python `find_by_text` lists), #130 (Python SDK `find_by_text` lists), #131 (Node SDK `findByText` lists), and #132 (Node `findByText` tables).