### PR TITLE
fix(sdk): include compiled list items in FindByText

### DIFF
--- a/sdk/go/query.go
+++ b/sdk/go/query.go
@@ -102,8 +102,8 @@ func collectInteractive(elements []Element, result *[]Element) {
 }
 
 // FindByText returns all elements whose text contains the given substring
-// (case-insensitive). Labels are searched as well because many controls expose
-// their human-facing text through label instead of text.
+// (case-insensitive). Labels and compiled list-item copy are searched as well
+// because lists keep item text in attrs.items and leave element.text empty.
 func FindByText(som *Som, text string) []Element {
 	lower := strings.ToLower(text)
 	var result []Element
@@ -115,9 +115,7 @@ func FindByText(som *Som, text string) []Element {
 
 func collectByText(elements []Element, lowerText string, result *[]Element) {
 	for _, el := range elements {
-		if el.Text != nil && strings.Contains(strings.ToLower(*el.Text), lowerText) {
-			*result = append(*result, el)
-		} else if el.Label != nil && strings.Contains(strings.ToLower(*el.Label), lowerText) {
+		if elementMatchesText(el, lowerText) {
 			*result = append(*result, el)
 		}
 		collectByText(el.Children, lowerText, result)
@@ -125,6 +123,23 @@ func collectByText(elements []Element, lowerText string, result *[]Element) {
 			collectByText(el.Shadow.Elements, lowerText, result)
 		}
 	}
+}
+
+func elementMatchesText(el Element, lowerText string) bool {
+	if el.Text != nil && strings.Contains(strings.ToLower(*el.Text), lowerText) {
+		return true
+	}
+	if el.Label != nil && strings.Contains(strings.ToLower(*el.Label), lowerText) {
+		return true
+	}
+	if el.Attrs != nil {
+		for _, item := range el.Attrs.Items {
+			if strings.Contains(strings.ToLower(item.Text), lowerText) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // FindByAction returns all elements that expose a specific action.

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -398,6 +398,56 @@ func TestFindByText(t *testing.T) {
 	}
 }
 
+func TestFindByTextCompiledListItems(t *testing.T) {
+	ordered := false
+	som := &Som{
+		SOMVersion: "1.0",
+		URL:        "https://example.com",
+		Title:      "Lists",
+		Lang:       "en",
+		Regions: []Region{
+			{
+				ID:   "r_main",
+				Role: "main",
+				Elements: []Element{
+					{
+						ID:   "e_list",
+						Role: "list",
+						Attrs: &ElementAttrs{
+							Ordered: &ordered,
+							Items: []ListItem{
+								{Text: "Install"},
+								{Text: "Configure"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := FindByText(som, "install")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(install) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_list" {
+		t.Errorf("ID = %q, want e_list", results[0].ID)
+	}
+
+	results = FindByText(som, "Configure")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(Configure) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_list" {
+		t.Errorf("ID = %q, want e_list", results[0].ID)
+	}
+
+	empty := FindByText(som, "nonexistent")
+	if len(empty) != 0 {
+		t.Errorf("FindByText(nonexistent) = %d, want 0", len(empty))
+	}
+}
+
 func TestFlatElements(t *testing.T) {
 	som := mustParse(t)
 


### PR DESCRIPTION
## Summary
SOM lists compile item copy into `attrs.items` and leave `element.text` empty. Go SDK `FindByText` only searched `text`/`label`, so agents could not locate compiled lists by item copy.

This run matches compiled list item text for case-insensitive substring lookup.

## Proof
Focused: `go test -count=1 -run 'TestFindByText' .` in `sdk/go` (ok).

Plasmate MCP: `https://docs.plasmate.app` (fetch_page, selector=main) and `https://plasmate.app` (extract_text, selector=main).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #127 (Node parser `toMarkdown` tables), #128 (Python parser `find_by_text` lists), #130 (Python SDK `find_by_text` lists), #131 (Node SDK `findByText` lists), #132 (Node parser `findByText` tables), and #133 (Python parser `find_by_text` tables).