### PR TITLE
fix(sdk): include compiled table rows in FindByText

### DIFF
--- a/sdk/go/query.go
+++ b/sdk/go/query.go
@@ -102,9 +102,10 @@ func collectInteractive(elements []Element, result *[]Element) {
 }
 
 // FindByText returns all elements whose text contains the given substring
-// (case-insensitive). Labels, compiled list-item copy, and table captions are
-// searched as well because lists keep item text in attrs.items and tables keep
-// titles in attrs.caption, leaving element.text empty.
+// (case-insensitive). Labels, compiled list-item copy, table captions, and
+// table header/cell copy are searched as well because lists keep item text
+// in attrs.items and tables keep titles and cells in attrs.caption /
+// attrs.headers / attrs.rows, leaving element.text empty.
 func FindByText(som *Som, text string) []Element {
 	lower := strings.ToLower(text)
 	var result []Element
@@ -141,6 +142,18 @@ func elementMatchesText(el Element, lowerText string) bool {
 		}
 		if el.Attrs.Caption != nil && strings.Contains(strings.ToLower(*el.Attrs.Caption), lowerText) {
 			return true
+		}
+		for _, header := range el.Attrs.Headers {
+			if strings.Contains(strings.ToLower(header), lowerText) {
+				return true
+			}
+		}
+		for _, row := range el.Attrs.Rows {
+			for _, cell := range row {
+				if strings.Contains(strings.ToLower(cell), lowerText) {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -499,6 +499,55 @@ func TestFindByTextCompiledTableCaptions(t *testing.T) {
 	}
 }
 
+func TestFindByTextCompiledTableRows(t *testing.T) {
+	som := &Som{
+		SOMVersion: "1.0",
+		URL:        "https://example.com",
+		Title:      "Tables",
+		Lang:       "en",
+		Regions: []Region{
+			{
+				ID:   "r_main",
+				Role: "main",
+				Elements: []Element{
+					{
+						ID:   "e_table",
+						Role: "table",
+						Attrs: &ElementAttrs{
+							Headers: []string{"Plan", "Price"},
+							Rows: [][]string{
+								{"Starter", "$9"},
+								{"Pro", "$29"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := FindByText(som, "starter")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(starter) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_table" {
+		t.Errorf("ID = %q, want e_table", results[0].ID)
+	}
+
+	results = FindByText(som, "Price")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(Price) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_table" {
+		t.Errorf("ID = %q, want e_table", results[0].ID)
+	}
+
+	empty := FindByText(som, "nonexistent")
+	if len(empty) != 0 {
+		t.Errorf("FindByText(nonexistent) = %d, want 0", len(empty))
+	}
+}
+
 func TestFlatElements(t *testing.T) {
 	som := mustParse(t)
 


### PR DESCRIPTION
## Summary
SOM tables compile header and cell copy into `attrs.headers`/`attrs.rows` and leave `element.text` empty. Go SDK `FindByText` already searched text, labels, compiled list items, and captions, so agents still could not locate compiled tables by cell copy.

This run matches compiled table header and cell text for case-insensitive substring lookup.

## Proof
Focused: `go test -count=1 -run 'TestFindByText' .` in `sdk/go` (ok).

Plasmate MCP: `https://docs.plasmate.app` (fetch_page, selector=main) and `https://plasmate.app` (extract_text, selector=main).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Rebased onto current `master` so it no longer conflicts with merged caption/list-item FindByText work. Unique from merged #136 (Python SDK table rows), #137 (Node SDK table rows), and #144 (Go SDK table captions).