### PR TITLE
fix(sdk): include compiled table rows in find_by_text

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -469,7 +469,7 @@ def find_action_target_by_label(
 
 
 def find_by_text(som: Som, text: str) -> List[SomElement]:
-    """Find all elements whose text or label contains the substring."""
+    """Find all elements whose text, label, or compiled table cells contain the substring."""
     results: List[SomElement] = []
     lower = text.lower()
     for region in som.regions:
@@ -548,10 +548,24 @@ def _collect_interactive(element: SomElement, results: List[SomElement]) -> None
             _collect_interactive(child, results)
 
 
+def _compiled_table_text_contains(element: SomElement, lower_text: str) -> bool:
+    attrs = element.attrs
+    if attrs is None:
+        return False
+    if attrs.headers:
+        if any(lower_text in header.lower() for header in attrs.headers):
+            return True
+    if attrs.rows:
+        for row in attrs.rows:
+            if any(lower_text in cell.lower() for cell in row):
+                return True
+    return False
+
+
 def _collect_by_text(element: SomElement, lower_text: str, results: List[SomElement]) -> None:
     if (element.text and lower_text in element.text.lower()) or (
         element.label and lower_text in element.label.lower()
-    ):
+    ) or _compiled_table_text_contains(element, lower_text):
         results.append(element)
     if element.children:
         for child in element.children:

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -453,6 +453,44 @@ class TestFindByText:
     def test_no_match_returns_empty(self, sample_som: Som) -> None:
         assert find_by_text(sample_som, "zzz_no_match") == []
 
+    def test_finds_compiled_table_rows(self) -> None:
+        som = Som(
+            som_version="1.0",
+            url="https://example.com/table",
+            title="Table Page",
+            lang="en",
+            regions=[
+                SomRegion(
+                    id="r_main",
+                    role=RegionRole.main,
+                    elements=[
+                        SomElement(
+                            id="e_table",
+                            role=ElementRole.table,
+                            attrs=ElementAttrs(
+                                headers=["Plan", "Price"],
+                                rows=[
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+            meta=SomMeta(
+                html_bytes=100,
+                som_bytes=50,
+                element_count=1,
+                interactive_count=0,
+            ),
+        )
+
+        results = find_by_text(som, "starter")
+        assert [el.id for el in results] == ["e_table"]
+        assert find_by_text(som, "Price")[0].id == "e_table"
+        assert find_by_text(som, "zzz_no_match") == []
+
 
 class TestFlatElements:
     def test_flattens_all_elements(self, sample_som: Som) -> None:


### PR DESCRIPTION
## Summary
SOM tables compile header and cell copy into `attrs.headers`/`attrs.rows` and leave `element.text` empty. Python SDK `find_by_text` only searched `text`/`label`, so agents could not locate compiled tables by cell copy.

This run matches compiled table header and cell text for substring lookup.

## Proof
Focused: `PYTHONPATH=src python3 -m pytest tests/test_query.py::TestFindByText -v` in `sdk/python` (8 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #130 (Python SDK `find_by_text` lists), #133 (Python parser `find_by_text` tables), and #135 (Go SDK `FindByText` tables).