### PR TITLE
fix(sdk): include compiled table rows in findByText

### DIFF
--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -328,6 +328,40 @@ describe('findByText', () => {
     );
     assert.deepEqual(findByText(som, 'nonexistent'), []);
   });
+
+  it('finds compiled table rows', () => {
+    const som: Som = {
+      ...fixture,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const results = findByText(som, 'starter');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, 'e_table');
+    assert.deepEqual(
+      findByText(som, 'Pro').map((el) => el.id),
+      ['e_table'],
+    );
+    assert.deepEqual(findByText(som, 'nonexistent'), []);
+  });
 });
 
 describe('getActionPlan', () => {

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -519,6 +519,18 @@ function searchableTextParts(el: SomElement): string[] {
   if (el.attrs?.caption) {
     parts.push(el.attrs.caption);
   }
+  for (const header of el.attrs?.headers ?? []) {
+    if (header) {
+      parts.push(header);
+    }
+  }
+  for (const row of el.attrs?.rows ?? []) {
+    for (const cell of row) {
+      if (cell) {
+        parts.push(cell);
+      }
+    }
+  }
   return parts;
 }
 


### PR DESCRIPTION
## Summary
SOM tables compile header and cell copy into `attrs.headers`/`attrs.rows` and leave `element.text` empty. Node SDK `findByText` already searched compiled list items but not table cells, so agents could not locate compiled tables by header or cell copy.

This run matches compiled table header and cell text for case-insensitive substring lookup.

## Proof
Focused: `npm test` in `sdk/node` (36 passed, including `finds compiled table rows`).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #136 (Python SDK `find_by_text` tables) and #135 (Go SDK `FindByText` tables), and from merged #131 (Node SDK `findByText` lists).