### PR TITLE
fix(parser): include compiled table captions in find_by_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -73,6 +73,8 @@ def _searchable_text_parts(el: SomElement) -> List[str]:
     if el.attrs:
         if el.attrs.items:
             parts.extend(item.text for item in el.attrs.items if item.text)
+        if el.attrs.caption:
+            parts.append(el.attrs.caption)
         if el.attrs.headers:
             for header in el.attrs.headers:
                 if header:

--- a/packages/som-parser-python/som_parser/types.py
+++ b/packages/som-parser-python/som_parser/types.py
@@ -112,6 +112,7 @@ class SomElementAttrs(BaseModel):
     items: Optional[List[ListItem]] = None
     headers: Optional[List[str]] = None
     rows: Optional[List[List[str]]] = None
+    caption: Optional[str] = None
     section_label: Optional[str] = None
     legend: Optional[str] = None
     open: Optional[bool] = None

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -550,6 +550,43 @@ class TestFindByText:
         assert [el.id for el in find_by_text(som, "Pro", exact=True)] == ["e_table"]
         assert find_by_text(som, "pro", exact=True) == []
 
+    def test_finds_compiled_table_captions(self):
+        som = parse_som(
+            {
+                **FIXTURE_SOM,
+                "regions": [
+                    {
+                        "id": "r_main",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e_table",
+                                "role": "table",
+                                "attrs": {
+                                    "caption": "Plans",
+                                    "headers": ["Plan", "Price"],
+                                    "rows": [
+                                        ["Starter", "$9"],
+                                        ["Pro", "$29"],
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 100,
+                    "som_bytes": 50,
+                    "element_count": 1,
+                    "interactive_count": 0,
+                },
+            }
+        )
+
+        assert [el.id for el in find_by_text(som, "plans")] == ["e_table"]
+        assert [el.id for el in find_by_text(som, "Plans", exact=True)] == ["e_table"]
+        assert find_by_text(som, "plans", exact=True) == []
+
 
 class TestGetInteractiveElements:
     def test_count(self, som: Som):


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. The Python parser dropped that field, so `find_by_text` could not locate compiled tables by caption.

This run retains `attrs.caption` and matches it for case-insensitive substring lookup.

## Proof
Focused: `python3 -m pytest tests/test_parser.py::TestFindByText -v` in `packages/som-parser-python` (10 passed, including `test_finds_compiled_table_captions`).

Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.

## Governor
One small parser query delta. No security, cache, or protocol changes. Unique from open #137/#136/#135 (SDK table *rows*) and merged #133 (parser table *rows*).