### PR TITLE
fix(parser): include compiled table captions in findByText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -59,6 +59,9 @@ function searchableTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  if (el.attrs?.caption) {
+    parts.push(el.attrs.caption);
+  }
   for (const header of el.attrs?.headers ?? []) {
     if (header) {
       parts.push(header);

--- a/packages/som-parser-node/src/types.ts
+++ b/packages/som-parser-node/src/types.ts
@@ -103,6 +103,7 @@ export interface SomElementAttrs {
   items?: ListItem[];
   headers?: string[];
   rows?: string[][];
+  caption?: string;
   section_label?: string;
   legend?: string;
   open?: boolean;

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -457,6 +457,44 @@ describe('findByText', () => {
     ]);
     expect(findByText(som, 'pro', { exact: true })).toEqual([]);
   });
+
+  it('finds compiled table captions', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                caption: 'Plans',
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    expect(findByText(som, 'plans').map((el) => el.id)).toEqual(['e_table']);
+    expect(findByText(som, 'Plans', { exact: true }).map((el) => el.id)).toEqual([
+      'e_table',
+    ]);
+    expect(findByText(som, 'plans', { exact: true })).toEqual([]);
+  });
 });
 
 describe('getInteractiveElements', () => {


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. The Node parser dropped that field, so `findByText` could not locate compiled tables by caption.

This run retains `attrs.caption` and matches it for case-insensitive substring lookup.

## Proof
Focused: `npm test -- --reporter=dot tests/parser.test.ts -t findByText` in `packages/som-parser-node` (8 passed, including `finds compiled table captions`).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.

## Governor
One small parser query delta. No security, cache, or protocol changes. Unique from open #138 (Python parser `find_by_text` captions), #137/#136/#135 (SDK table *rows*), and merged #132 (Node parser `findByText` table *rows*).