### PR TITLE
fix(sdk): include compiled table captions in findByText

### DIFF
--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -293,6 +293,41 @@ describe('findByText', () => {
     );
     assert.deepEqual(findByText(som, 'nonexistent'), []);
   });
+
+  it('finds compiled table captions', () => {
+    const som: Som = {
+      ...fixture,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                caption: 'Plans',
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const results = findByText(som, 'plans');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, 'e_table');
+    assert.deepEqual(
+      findByText(som, 'Plans').map((el) => el.id),
+      ['e_table'],
+    );
+    assert.deepEqual(findByText(som, 'nonexistent'), []);
+  });
 });
 
 describe('getActionPlan', () => {

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -516,6 +516,9 @@ function searchableTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  if (el.attrs?.caption) {
+    parts.push(el.attrs.caption);
+  }
   return parts;
 }
 

--- a/sdk/node/src/types.ts
+++ b/sdk/node/src/types.ts
@@ -103,6 +103,7 @@ export interface SomElementAttrs {
   items?: ListItem[];
   headers?: string[];
   rows?: string[][];
+  caption?: string;
   section_label?: string;
   legend?: string;
   open?: boolean;


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. Node SDK `findByText` already searched compiled list items but not table captions, so agents could not locate compiled tables by caption.

This run retains `attrs.caption` and matches it for case-insensitive substring lookup.

## Proof
Focused: `npm test` in `sdk/node` (36 passed, including `finds compiled table captions`).

Plasmate MCP: `https://docs.plasmate.app` (extract_text, selector=main) and `https://plasmate.app` (extract_text, selector=main). GitHub issues: no open READY items; no open issues.

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #139/#138 (parser captions), #137 (Node SDK table *rows*), #136/#135 (other SDK table rows), and merged #131 (Node SDK `findByText` lists).