### PR TITLE
fix(parser): include compiled table captions in to_markdown

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -712,6 +712,10 @@ def _element_to_markdown(el: SomElement, lines: List[str]) -> None:
     elif role == ElementRole.TABLE:
         emitted = False
         if el.attrs:
+            if el.attrs.caption:
+                lines.append(el.attrs.caption)
+                lines.append("")
+                emitted = True
             headers = el.attrs.headers or []
             if headers:
                 lines.append("| " + " | ".join(headers) + " |")

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -1085,6 +1085,43 @@ class TestToMarkdown:
         assert "| Starter | $9 |" in md
         assert "| Pro | $29 |" in md
 
+    def test_includes_compiled_table_captions(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_table",
+                            "role": "table",
+                            "attrs": {
+                                "caption": "Plans",
+                                "headers": ["Plan", "Price"],
+                                "rows": [
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        md = to_markdown(som)
+        assert "Plans" in md
+        assert md.index("Plans") < md.index("| Plan | Price |")
+        assert "| Plan | Price |" in md
+        assert "| Starter | $9 |" in md
+
 
 class TestFilterElements:
     def test_filter_by_actions(self, som: Som):


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. Python parser `to_markdown` only emitted headers/rows, so agents lost the table title.

This run emits compiled captions above the markdown table, matching CLI markdown.

## Proof
Focused: `python3 -m pytest tests/test_parser.py::TestToMarkdown -v` in `packages/som-parser-python` (12 passed).

Plasmate MCP: `https://plasmate.app` (extract_text, selector=main) and `https://docs.plasmate.app` (extract_text, selector=main).

## Governor
One small parser markdown delta. No security, cache, or protocol changes. Unique from open #135 (Go SDK `FindByText` table rows) and #136 (Python SDK `find_by_text` table rows), and from merged find-by-text caption work (#138–#140).