### PR TITLE
fix(parser): include compiled table captions in toMarkdown

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -711,6 +711,11 @@ export function toMarkdown(som: Som): string {
         case 'table': {
           const headers = el.attrs?.headers ?? [];
           let emitted = false;
+          if (el.attrs?.caption) {
+            lines.push(el.attrs.caption);
+            lines.push('');
+            emitted = true;
+          }
           if (headers.length) {
             lines.push('| ' + headers.join(' | ') + ' |');
             lines.push('| ' + headers.map(() => '---').join(' | ') + ' |');

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -1013,6 +1013,44 @@ describe('toMarkdown', () => {
     expect(md).toContain('| Starter | $9 |');
     expect(md).toContain('| Pro | $29 |');
   });
+
+  it('includes compiled table captions', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                caption: 'Plans',
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const md = toMarkdown(som);
+    expect(md).toContain('Plans');
+    expect(md.indexOf('Plans')).toBeLessThan(md.indexOf('| Plan | Price |'));
+    expect(md).toContain('| Plan | Price |');
+    expect(md).toContain('| Starter | $9 |');
+  });
 });
 
 describe('filter', () => {


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. Node parser `toMarkdown` only emitted headers/rows, so agents lost the table title.

This run emits compiled captions above the markdown table, matching CLI markdown.

## Proof
Focused: `npm test -- tests/parser.test.ts -t toMarkdown` in `packages/som-parser-node` (9 passed, 63 skipped).

Plasmate MCP: `https://docs.plasmate.app` (fetch_page, selector=main) and `https://plasmate.app` (extract_text, selector=main).

## Governor
One small parser markdown delta. No security, cache, or protocol changes. Unique from open #141 (Python parser `to_markdown` table captions), #135 (Go SDK `FindByText` table rows), and #136 (Python SDK `find_by_text` table rows).