### PR TITLE
fix(sdk): include compiled table captions in find_by_text

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -469,7 +469,7 @@ def find_action_target_by_label(
 
 
 def find_by_text(som: Som, text: str) -> List[SomElement]:
-    """Find all elements whose text, label, or compiled list items contain the substring."""
+    """Find all elements whose text, label, compiled list items, or table captions contain the substring."""
     results: List[SomElement] = []
     lower = text.lower()
     for region in som.regions:
@@ -556,6 +556,8 @@ def _collect_by_text(element: SomElement, lower_text: str, results: List[SomElem
         parts.append(element.label)
     if element.attrs and element.attrs.items:
         parts.extend(item.text for item in element.attrs.items if item.text)
+    if element.attrs and element.attrs.caption:
+        parts.append(element.attrs.caption)
     if any(lower_text in part.lower() for part in parts):
         results.append(element)
     if element.children:

--- a/sdk/python/src/plasmate/types.py
+++ b/sdk/python/src/plasmate/types.py
@@ -122,6 +122,7 @@ class ElementAttrs(BaseModel):
     items: Optional[List[ListItem]] = None
     headers: Optional[List[str]] = None
     rows: Optional[List[List[str]]] = None
+    caption: Optional[str] = None
     section_label: Optional[str] = None
     legend: Optional[str] = None
     open: Optional[bool] = None

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -492,6 +492,45 @@ class TestFindByText:
         assert find_by_text(som, "Configure")[0].id == "e_list"
         assert find_by_text(som, "zzz_no_match") == []
 
+    def test_finds_compiled_table_captions(self) -> None:
+        som = Som(
+            som_version="1.0",
+            url="https://example.com/table",
+            title="Table Page",
+            lang="en",
+            regions=[
+                SomRegion(
+                    id="r_main",
+                    role=RegionRole.main,
+                    elements=[
+                        SomElement(
+                            id="e_table",
+                            role=ElementRole.table,
+                            attrs=ElementAttrs(
+                                caption="Plans",
+                                headers=["Plan", "Price"],
+                                rows=[
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+            meta=SomMeta(
+                html_bytes=100,
+                som_bytes=50,
+                element_count=1,
+                interactive_count=0,
+            ),
+        )
+
+        results = find_by_text(som, "plans")
+        assert [el.id for el in results] == ["e_table"]
+        assert find_by_text(som, "Plans")[0].id == "e_table"
+        assert find_by_text(som, "zzz_no_match") == []
+
 
 class TestFlatElements:
     def test_flattens_all_elements(self, sample_som: Som) -> None:


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. Python SDK `find_by_text` only searched text, labels, and list items, and `ElementAttrs` omitted `caption` (`extra=forbid`), so agents could not parse or locate tables by title.

This run accepts compiled captions and searches them, matching Node SDK `findByText`.

## Proof
Focused: `PYTHONPATH=src python3 -m pytest tests/test_query.py::TestFindByText -v` in `sdk/python` (9 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small Python SDK query delta. No security, cache, or protocol changes. Unique from open #141 (Python parser `to_markdown` captions), #142 (Node parser `toMarkdown` captions), #135 (Go SDK `FindByText` table rows), and #136 (Python SDK `find_by_text` table rows).