### PR TITLE
fix(sdk): include compiled table captions in FindByText

### DIFF
--- a/sdk/go/query.go
+++ b/sdk/go/query.go
@@ -102,8 +102,9 @@ func collectInteractive(elements []Element, result *[]Element) {
 }
 
 // FindByText returns all elements whose text contains the given substring
-// (case-insensitive). Labels and compiled list-item copy are searched as well
-// because lists keep item text in attrs.items and leave element.text empty.
+// (case-insensitive). Labels, compiled list-item copy, and table captions are
+// searched as well because lists keep item text in attrs.items and tables keep
+// titles in attrs.caption, leaving element.text empty.
 func FindByText(som *Som, text string) []Element {
 	lower := strings.ToLower(text)
 	var result []Element
@@ -137,6 +138,9 @@ func elementMatchesText(el Element, lowerText string) bool {
 			if strings.Contains(strings.ToLower(item.Text), lowerText) {
 				return true
 			}
+		}
+		if el.Attrs.Caption != nil && strings.Contains(strings.ToLower(*el.Attrs.Caption), lowerText) {
+			return true
 		}
 	}
 	return false

--- a/sdk/go/som.go
+++ b/sdk/go/som.go
@@ -75,6 +75,7 @@ type ElementAttrs struct {
 	Items           []ListItem     `json:"items,omitempty"`
 	Headers         []string       `json:"headers,omitempty"`
 	Rows            [][]string     `json:"rows,omitempty"`
+	Caption         *string        `json:"caption,omitempty"`
 	SectionLabel    *string        `json:"section_label,omitempty"`
 	Legend          *string        `json:"legend,omitempty"`
 	Open            *bool          `json:"open,omitempty"`

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -448,6 +448,57 @@ func TestFindByTextCompiledListItems(t *testing.T) {
 	}
 }
 
+func TestFindByTextCompiledTableCaptions(t *testing.T) {
+	caption := "Plans"
+	som := &Som{
+		SOMVersion: "1.0",
+		URL:        "https://example.com",
+		Title:      "Tables",
+		Lang:       "en",
+		Regions: []Region{
+			{
+				ID:   "r_main",
+				Role: "main",
+				Elements: []Element{
+					{
+						ID:   "e_table",
+						Role: "table",
+						Attrs: &ElementAttrs{
+							Caption: &caption,
+							Headers: []string{"Plan", "Price"},
+							Rows: [][]string{
+								{"Starter", "$9"},
+								{"Pro", "$29"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := FindByText(som, "plans")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(plans) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_table" {
+		t.Errorf("ID = %q, want e_table", results[0].ID)
+	}
+
+	results = FindByText(som, "Plans")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(Plans) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_table" {
+		t.Errorf("ID = %q, want e_table", results[0].ID)
+	}
+
+	empty := FindByText(som, "nonexistent")
+	if len(empty) != 0 {
+		t.Errorf("FindByText(nonexistent) = %d, want 0", len(empty))
+	}
+}
+
 func TestFlatElements(t *testing.T) {
 	som := mustParse(t)
 


### PR DESCRIPTION
## Summary
SOM tables compile caption copy into `attrs.caption` and leave `element.text` empty. Go SDK `FindByText` only searched text, labels, and list items, and `ElementAttrs` omitted `caption`, so agents could not parse or locate tables by title.

This run accepts compiled captions and searches them, matching Node SDK `findByText`.

## Proof
Focused: `go test -count=1 -run 'TestFindByText' .` in `sdk/go` (ok).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small Go SDK query delta. No security, cache, or protocol changes. Unique from open #141 (Python parser `to_markdown` captions), #142 (Node parser `toMarkdown` captions), #143 (Python SDK `find_by_text` captions), #135 (Go SDK `FindByText` table rows), and #136 (Python SDK `find_by_text` table rows).