### PR TITLE
fix(sdk): include compiled select options in find_by_text

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -469,7 +469,7 @@ def find_action_target_by_label(
 
 
 def find_by_text(som: Som, text: str) -> List[SomElement]:
-    """Find all elements whose text, label, compiled list items, table captions, or table cells contain the substring."""
+    """Find all elements whose text, label, compiled list items, select options, table captions, or table cells contain the substring."""
     results: List[SomElement] = []
     lower = text.lower()
     for region in som.regions:
@@ -556,6 +556,8 @@ def _collect_by_text(element: SomElement, lower_text: str, results: List[SomElem
         parts.append(element.label)
     if element.attrs and element.attrs.items:
         parts.extend(item.text for item in element.attrs.items if item.text)
+    if element.attrs and element.attrs.options:
+        parts.extend(option.text for option in element.attrs.options if option.text)
     if element.attrs and element.attrs.caption:
         parts.append(element.attrs.caption)
     if element.attrs and element.attrs.headers:

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -531,6 +531,43 @@ class TestFindByText:
         assert find_by_text(som, "Plans")[0].id == "e_table"
         assert find_by_text(som, "zzz_no_match") == []
 
+    def test_finds_compiled_select_options(self) -> None:
+        som = Som(
+            som_version="1.0",
+            url="https://example.com/form",
+            title="Form Page",
+            lang="en",
+            regions=[
+                SomRegion(
+                    id="r_main",
+                    role=RegionRole.main,
+                    elements=[
+                        SomElement(
+                            id="e_select",
+                            role=ElementRole.select,
+                            attrs=ElementAttrs(
+                                options=[
+                                    SelectOption(value="us", text="United States"),
+                                    SelectOption(value="ca", text="Canada"),
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+            meta=SomMeta(
+                html_bytes=100,
+                som_bytes=50,
+                element_count=1,
+                interactive_count=1,
+            ),
+        )
+
+        results = find_by_text(som, "united states")
+        assert [el.id for el in results] == ["e_select"]
+        assert find_by_text(som, "Canada")[0].id == "e_select"
+        assert find_by_text(som, "zzz_no_match") == []
+
     def test_finds_compiled_table_rows(self) -> None:
         som = Som(
             som_version="1.0",


### PR DESCRIPTION
## Summary
SOM selects compile option labels into `attrs.options` and leave `element.text` empty. Python SDK `find_by_text` already searched text, labels, compiled list items, captions, and table cells, so agents still could not locate dropdowns by option copy.

This run matches compiled select option text for case-insensitive substring lookup.

## Proof
Focused: `PYTHONPATH=src python3 -m pytest tests/test_query.py::TestFindByText -v` in `sdk/python` (11 passed).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main) and `https://docs.plasmate.app` (extract_text).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from open #135 (Go SDK table rows) and merged table/list/caption FindByText work.