### PR TITLE
fix(sdk): include compiled select options in FindByText

### DIFF
--- a/sdk/go/query.go
+++ b/sdk/go/query.go
@@ -102,10 +102,11 @@ func collectInteractive(elements []Element, result *[]Element) {
 }
 
 // FindByText returns all elements whose text contains the given substring
-// (case-insensitive). Labels, compiled list-item copy, table captions, and
-// table header/cell copy are searched as well because lists keep item text
-// in attrs.items and tables keep titles and cells in attrs.caption /
-// attrs.headers / attrs.rows, leaving element.text empty.
+// (case-insensitive). Labels, compiled list-item copy, select options, table
+// captions, and table header/cell copy are searched as well because lists keep
+// item text in attrs.items, selects keep option labels in attrs.options, and
+// tables keep titles and cells in attrs.caption / attrs.headers / attrs.rows,
+// leaving element.text empty.
 func FindByText(som *Som, text string) []Element {
 	lower := strings.ToLower(text)
 	var result []Element
@@ -142,6 +143,11 @@ func elementMatchesText(el Element, lowerText string) bool {
 		}
 		if el.Attrs.Caption != nil && strings.Contains(strings.ToLower(*el.Attrs.Caption), lowerText) {
 			return true
+		}
+		for _, option := range el.Attrs.Options {
+			if strings.Contains(strings.ToLower(option.Text), lowerText) {
+				return true
+			}
 		}
 		for _, header := range el.Attrs.Headers {
 			if strings.Contains(strings.ToLower(header), lowerText) {

--- a/sdk/go/som_test.go
+++ b/sdk/go/som_test.go
@@ -548,6 +548,54 @@ func TestFindByTextCompiledTableRows(t *testing.T) {
 	}
 }
 
+func TestFindByTextCompiledSelectOptions(t *testing.T) {
+	som := &Som{
+		SOMVersion: "1.0",
+		URL:        "https://example.com/form",
+		Title:      "Form Page",
+		Lang:       "en",
+		Regions: []Region{
+			{
+				ID:   "r_main",
+				Role: "main",
+				Elements: []Element{
+					{
+						ID:   "e_select",
+						Role: "select",
+						Attrs: &ElementAttrs{
+							Options: []SelectOption{
+								{Value: "us", Text: "United States"},
+								{Value: "ca", Text: "Canada"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := FindByText(som, "united states")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(united states) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_select" {
+		t.Errorf("ID = %q, want e_select", results[0].ID)
+	}
+
+	results = FindByText(som, "Canada")
+	if len(results) != 1 {
+		t.Fatalf("FindByText(Canada) = %d, want 1", len(results))
+	}
+	if results[0].ID != "e_select" {
+		t.Errorf("ID = %q, want e_select", results[0].ID)
+	}
+
+	empty := FindByText(som, "nonexistent")
+	if len(empty) != 0 {
+		t.Errorf("FindByText(nonexistent) = %d, want 0", len(empty))
+	}
+}
+
 func TestFlatElements(t *testing.T) {
 	som := mustParse(t)
 


### PR DESCRIPTION
## Summary
SOM selects compile option labels into `attrs.options` and leave `element.text` empty. Go SDK `FindByText` already searched text, labels, compiled list items, captions, and table cells, so agents still could not locate dropdowns by option copy.

This run matches compiled select option text for case-insensitive substring lookup.

## Proof
Focused: `go test -count=1 -run 'TestFindByText' .` in `sdk/go` (ok).

Plasmate MCP: `https://plasmate.app` (fetch_page, selector=main).

## Governor
One small SDK query delta. No security, cache, or protocol changes. Unique from merged #145 (Python SDK select options) and #135 (Go SDK table rows).