### PR TITLE
fix(sdk): include compiled select options in findByText

### DIFF
--- a/sdk/node/src/query.test.ts
+++ b/sdk/node/src/query.test.ts
@@ -362,6 +362,39 @@ describe('findByText', () => {
     );
     assert.deepEqual(findByText(som, 'nonexistent'), []);
   });
+
+  it('finds compiled select options', () => {
+    const som: Som = {
+      ...fixture,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_select',
+              role: 'select',
+              attrs: {
+                options: [
+                  { value: 'us', text: 'United States' },
+                  { value: 'ca', text: 'Canada' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const results = findByText(som, 'united states');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, 'e_select');
+    assert.deepEqual(
+      findByText(som, 'Canada').map((el) => el.id),
+      ['e_select'],
+    );
+    assert.deepEqual(findByText(som, 'nonexistent'), []);
+  });
 });
 
 describe('getActionPlan', () => {

--- a/sdk/node/src/query.ts
+++ b/sdk/node/src/query.ts
@@ -516,6 +516,11 @@ function searchableTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  for (const option of el.attrs?.options ?? []) {
+    if (option.text) {
+      parts.push(option.text);
+    }
+  }
   if (el.attrs?.caption) {
     parts.push(el.attrs.caption);
   }


### PR DESCRIPTION
## Summary
- Node `findByText` now searches compiled `attrs.options[].text`, matching Python and Go SDKs.
- Agents can locate a select by option labels even when the element itself has no `text`/`label`.

## Proof
- Focused: `npm run build && node --test dist/query.test.js` in `sdk/node` — 33 passed, including `finds compiled select options`.

## Notes
- One outcome: Node SDK query only. Parsers still omit options; that is a later increment.
- Fetched live page: https://plasmate.app