### PR TITLE
fix(parser): include compiled select options in findByText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -59,6 +59,11 @@ function searchableTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  for (const option of el.attrs?.options ?? []) {
+    if (option.text) {
+      parts.push(option.text);
+    }
+  }
   if (el.attrs?.caption) {
     parts.push(el.attrs.caption);
   }

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -495,6 +495,43 @@ describe('findByText', () => {
     ]);
     expect(findByText(som, 'plans', { exact: true })).toEqual([]);
   });
+
+  it('finds compiled select options', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_select',
+              role: 'select',
+              attrs: {
+                options: [
+                  { value: 'us', text: 'United States' },
+                  { value: 'ca', text: 'Canada' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    expect(findByText(som, 'united states').map((el) => el.id)).toEqual(['e_select']);
+    expect(findByText(som, 'Canada', { exact: true }).map((el) => el.id)).toEqual([
+      'e_select',
+    ]);
+    expect(findByText(som, 'canada', { exact: true })).toEqual([]);
+    expect(findByText(som, 'nonexistent')).toEqual([]);
+  });
 });
 
 describe('getInteractiveElements', () => {


### PR DESCRIPTION
## Summary
- Node parser `findByText` now searches compiled `attrs.options[].text`, matching the Node/Python/Go SDKs.
- Agents can locate a select by option labels even when the element itself has no `text`/`label`.

## Proof
- Focused: `npm test -- tests/parser.test.ts` in `packages/som-parser-node` — 73 passed, including `finds compiled select options`.

## Notes
- One outcome: Node parser query only. Python parser still omits options; that is a later increment.
- Fetched live page: https://plasmate.app