### PR TITLE
fix(parser): include compiled select options in find_by_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -73,6 +73,8 @@ def _searchable_text_parts(el: SomElement) -> List[str]:
     if el.attrs:
         if el.attrs.items:
             parts.extend(item.text for item in el.attrs.items if item.text)
+        if el.attrs.options:
+            parts.extend(option.text for option in el.attrs.options if option.text)
         if el.attrs.caption:
             parts.append(el.attrs.caption)
         if el.attrs.headers:

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -587,6 +587,42 @@ class TestFindByText:
         assert [el.id for el in find_by_text(som, "Plans", exact=True)] == ["e_table"]
         assert find_by_text(som, "plans", exact=True) == []
 
+    def test_finds_compiled_select_options(self):
+        som = parse_som(
+            {
+                **FIXTURE_SOM,
+                "regions": [
+                    {
+                        "id": "r_main",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e_select",
+                                "role": "select",
+                                "attrs": {
+                                    "options": [
+                                        {"value": "us", "text": "United States"},
+                                        {"value": "ca", "text": "Canada"},
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 100,
+                    "som_bytes": 50,
+                    "element_count": 1,
+                    "interactive_count": 0,
+                },
+            }
+        )
+
+        assert [el.id for el in find_by_text(som, "united states")] == ["e_select"]
+        assert [el.id for el in find_by_text(som, "Canada", exact=True)] == ["e_select"]
+        assert find_by_text(som, "canada", exact=True) == []
+        assert find_by_text(som, "nonexistent") == []
+
 
 class TestGetInteractiveElements:
     def test_count(self, som: Som):


### PR DESCRIPTION
## Summary
- Python `find_by_text` now searches compiled `attrs.options[].text`, matching the Node parser and the Python/Node/Go SDKs.
- Adds a focused fixture that finds a select by option label when the control itself has no text/label.

## Proof
- `python3 -m pytest tests/test_parser.py::TestFindByText -v` in `packages/som-parser-python` — 11 passed, including `test_finds_compiled_select_options`.

## Notes
- Leftover sibling of #148 (Node parser `findByText` already includes options).
- No network, cache, or protocol changes.