### PR TITLE
fix(parser): include compiled select options in to_markdown

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -700,6 +700,10 @@ def _element_to_markdown(el: SomElement, lines: List[str]) -> None:
         lines.append(f"[Input: {label}{placeholder}]")
     elif role == ElementRole.SELECT:
         lines.append(f"[Select: {el.label or el.text or ''}]")
+        if el.attrs and el.attrs.options:
+            for option in el.attrs.options:
+                if option.text:
+                    lines.append(f"- {option.text}")
     elif role in (ElementRole.CHECKBOX, ElementRole.RADIO):
         checked = ""
         if el.attrs and el.attrs.checked:

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -1122,6 +1122,42 @@ class TestToMarkdown:
         assert "| Plan | Price |" in md
         assert "| Starter | $9 |" in md
 
+    def test_includes_compiled_select_options(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_select",
+                            "role": "select",
+                            "attrs": {
+                                "options": [
+                                    {"value": "us", "text": "United States"},
+                                    {"value": "ca", "text": "Canada"},
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        md = to_markdown(som)
+        assert "[Select: ]" in md
+        assert "- United States" in md
+        assert "- Canada" in md
+        assert md.index("[Select: ]") < md.index("- United States")
+        assert md.index("- United States") < md.index("- Canada")
+
 
 class TestFilterElements:
     def test_filter_by_actions(self, som: Som):


### PR DESCRIPTION
## Summary
- Python parser `to_markdown` now emits compiled `attrs.options[].text` under the select control, matching list-item markdown and the table-caption/row pattern.
- Adds a focused fixture that renders option labels when the select itself has no text/label.

## Proof
- `python3 -m pytest tests/test_parser.py::TestToMarkdown -v` in `packages/som-parser-python` — 13 passed, including `test_includes_compiled_select_options`.

## Notes
- Distinct from #149 (`find_by_text` select options).
- No network, cache, or protocol changes.