### PR TITLE
fix(parser): include compiled select options in toMarkdown

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -705,6 +705,16 @@ export function toMarkdown(som: Som): string {
           lines.push(`![${el.attrs?.alt ?? ''}](${el.attrs?.src ?? ''})`);
           lines.push('');
           break;
+        case 'select': {
+          lines.push(`[Select: ${el.label ?? el.text ?? ''}]`);
+          for (const option of el.attrs?.options ?? []) {
+            if (option.text) {
+              lines.push(`- ${option.text}`);
+            }
+          }
+          lines.push('');
+          break;
+        }
         case 'list': {
           const items = el.attrs?.items ?? [];
           for (const item of items) {

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -1088,6 +1088,43 @@ describe('toMarkdown', () => {
     expect(md).toContain('| Plan | Price |');
     expect(md).toContain('| Starter | $9 |');
   });
+
+  it('includes compiled select options', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_select',
+              role: 'select',
+              attrs: {
+                options: [
+                  { value: 'us', text: 'United States' },
+                  { value: 'ca', text: 'Canada' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const md = toMarkdown(som);
+    expect(md).toContain('[Select: ]');
+    expect(md).toContain('- United States');
+    expect(md).toContain('- Canada');
+    expect(md.indexOf('[Select: ]')).toBeLessThan(md.indexOf('- United States'));
+    expect(md.indexOf('- United States')).toBeLessThan(md.indexOf('- Canada'));
+  });
 });
 
 describe('filter', () => {


### PR DESCRIPTION
## Summary
- Node parser `toMarkdown` now emits compiled `attrs.options[].text` under the select control, matching list-item markdown and the table-caption/row pattern.
- Adds a focused fixture that renders option labels when the select itself has no text/label.

## Proof
- `npm test -- tests/parser.test.ts -t "includes compiled select options"` in `packages/som-parser-node` — 1 passed.
- `npm test -- tests/parser.test.ts -t toMarkdown` — 10 passed.

## Notes
- Distinct from #150 (Python `to_markdown` select options) and #149 (`find_by_text` select options).
- No network, cache, or protocol changes.