### PR TITLE
fix(parser): include compiled select options in get_text/getText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -624,6 +624,11 @@ function visibleTextParts(el: SomElement): string[] {
       parts.push(item.text);
     }
   }
+  for (const option of el.attrs?.options ?? []) {
+    if (option.text) {
+      parts.push(option.text);
+    }
+  }
   const headers = el.attrs?.headers ?? [];
   if (headers.length) {
     parts.push(headers.join(' | '));

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -922,6 +922,46 @@ describe('getText', () => {
     expect(byRegion[0].text).toContain('Starter | $9');
     expect(byRegion[0].text).toContain('Pro | $29');
   });
+
+  it('includes compiled select options', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_select',
+              role: 'select',
+              attrs: {
+                options: [
+                  { value: 'us', text: 'United States' },
+                  { value: 'ca', text: 'Canada' },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const text = getText(som);
+    expect(text).toContain('United States');
+    expect(text).toContain('Canada');
+
+    const byRegion = getTextByRegion(som);
+    expect(byRegion).toHaveLength(1);
+    expect(byRegion[0].role).toBe('main');
+    expect(byRegion[0].text).toContain('United States');
+    expect(byRegion[0].text).toContain('Canada');
+  });
 });
 
 describe('getTextByRegion', () => {

--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -600,7 +600,7 @@ def get_headings(som: Som) -> List[Dict[str, object]]:
 
 
 def _visible_text_parts(el: SomElement) -> List[str]:
-    """Return element text plus compiled list items and table headers/rows."""
+    """Return element text plus compiled list items, select options, and table headers/rows."""
     parts: List[str] = []
     if el.text:
         parts.append(el.text)
@@ -611,6 +611,10 @@ def _visible_text_parts(el: SomElement) -> List[str]:
             for item in el.attrs.items:
                 if item.text:
                     parts.append(item.text)
+        if el.attrs.options:
+            for option in el.attrs.options:
+                if option.text:
+                    parts.append(option.text)
         if el.attrs.headers:
             parts.append(" | ".join(el.attrs.headers))
         if el.attrs.rows:

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -994,6 +994,44 @@ class TestGetText:
         assert "Starter | $9" in regions[0]["text"]
         assert "Pro | $29" in regions[0]["text"]
 
+    def test_includes_compiled_select_options(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_select",
+                            "role": "select",
+                            "attrs": {
+                                "options": [
+                                    {"value": "us", "text": "United States"},
+                                    {"value": "ca", "text": "Canada"},
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        text = get_text(som)
+        assert "United States" in text
+        assert "Canada" in text
+
+        regions = get_text_by_region(som)
+        assert regions[0]["role"] == "main"
+        assert "United States" in regions[0]["text"]
+        assert "Canada" in regions[0]["text"]
+
 
 class TestGetTextByRegion:
     def test_regions(self, som: Som):


### PR DESCRIPTION
## Summary
- Python `get_text` and Node `getText` now emit compiled `attrs.options[].text`, matching list items and table cells already in visible-text helpers.
- Adds focused fixtures that return option labels when the select itself has no text/label.

## Proof
- `python3 -m pytest tests/test_parser.py::TestGetText -v` in `packages/som-parser-python` — 4 passed, including `test_includes_compiled_select_options`.
- `npm test -- tests/parser.test.ts -t getText` in `packages/som-parser-node` — 5 passed, including `includes compiled select options`.

## Notes
- Distinct from #150/#151 (`to_markdown`/`toMarkdown` select options) and #149/#148 (`find_by_text`/`findByText` select options).
- No network, cache, or protocol changes.
- Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.