### PR TITLE
fix(parser): include compiled table captions in get_text

### DIFF
--- a/packages/som-parser-python/som_parser/query.py
+++ b/packages/som-parser-python/som_parser/query.py
@@ -600,7 +600,7 @@ def get_headings(som: Som) -> List[Dict[str, object]]:
 
 
 def _visible_text_parts(el: SomElement) -> List[str]:
-    """Return element text plus compiled list items, select options, and table headers/rows."""
+    """Return element text plus compiled list items, select options, table captions, and table headers/rows."""
     parts: List[str] = []
     if el.text:
         parts.append(el.text)
@@ -615,6 +615,8 @@ def _visible_text_parts(el: SomElement) -> List[str]:
             for option in el.attrs.options:
                 if option.text:
                     parts.append(option.text)
+        if el.attrs.caption:
+            parts.append(el.attrs.caption)
         if el.attrs.headers:
             parts.append(" | ".join(el.attrs.headers))
         if el.attrs.rows:

--- a/packages/som-parser-python/tests/test_parser.py
+++ b/packages/som-parser-python/tests/test_parser.py
@@ -1032,6 +1032,50 @@ class TestGetText:
         assert "United States" in regions[0]["text"]
         assert "Canada" in regions[0]["text"]
 
+    def test_includes_compiled_table_captions(self):
+        som = parse_som({
+            **FIXTURE_SOM,
+            "regions": [
+                {
+                    "id": "r_main",
+                    "role": "main",
+                    "elements": [
+                        {
+                            "id": "e_table",
+                            "role": "table",
+                            "attrs": {
+                                "caption": "Plans",
+                                "headers": ["Plan", "Price"],
+                                "rows": [
+                                    ["Starter", "$9"],
+                                    ["Pro", "$29"],
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+            "meta": {
+                "html_bytes": 100,
+                "som_bytes": 50,
+                "element_count": 1,
+                "interactive_count": 0,
+            },
+        })
+
+        text = get_text(som)
+        assert "Plans" in text
+        assert text.index("Plans") < text.index("Plan | Price")
+        assert "Plan | Price" in text
+        assert "Starter | $9" in text
+
+        regions = get_text_by_region(som)
+        assert regions[0]["role"] == "main"
+        assert "Plans" in regions[0]["text"]
+        assert regions[0]["text"].index("Plans") < regions[0]["text"].index("Plan | Price")
+        assert "Plan | Price" in regions[0]["text"]
+        assert "Starter | $9" in regions[0]["text"]
+
 
 class TestGetTextByRegion:
     def test_regions(self, som: Som):


### PR DESCRIPTION
## Summary
- Python `get_text` / `get_text_by_region` now emit compiled `attrs.caption`, matching `find_by_text` and `to_markdown`.
- Adds a focused fixture that returns the table title when the table itself has no text/label.

## Proof
- `python3 -m pytest tests/test_parser.py::TestGetText -v` in `packages/som-parser-python` — 5 passed, including `test_includes_compiled_table_captions`.

## Notes
- Distinct from #152 (`get_text`/`getText` select options) and #141 (`to_markdown` table captions).
- No network, cache, or protocol changes.
- Plasmate MCP: `https://plasmate.app` (fetch_page) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.