### PR TITLE
fix(parser): include compiled table captions in getText

### DIFF
--- a/packages/som-parser-node/src/query.ts
+++ b/packages/som-parser-node/src/query.ts
@@ -629,6 +629,9 @@ function visibleTextParts(el: SomElement): string[] {
       parts.push(option.text);
     }
   }
+  if (el.attrs?.caption) {
+    parts.push(el.attrs.caption);
+  }
   const headers = el.attrs?.headers ?? [];
   if (headers.length) {
     parts.push(headers.join(' | '));

--- a/packages/som-parser-node/tests/parser.test.ts
+++ b/packages/som-parser-node/tests/parser.test.ts
@@ -962,6 +962,54 @@ describe('getText', () => {
     expect(byRegion[0].text).toContain('United States');
     expect(byRegion[0].text).toContain('Canada');
   });
+
+  it('includes compiled table captions', () => {
+    const som: Som = {
+      ...FIXTURE,
+      regions: [
+        {
+          id: 'r_main',
+          role: 'main',
+          elements: [
+            {
+              id: 'e_table',
+              role: 'table',
+              attrs: {
+                caption: 'Plans',
+                headers: ['Plan', 'Price'],
+                rows: [
+                  ['Starter', '$9'],
+                  ['Pro', '$29'],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      meta: {
+        html_bytes: 100,
+        som_bytes: 50,
+        element_count: 1,
+        interactive_count: 0,
+      },
+    };
+
+    const text = getText(som);
+    expect(text).toContain('Plans');
+    expect(text.indexOf('Plans')).toBeLessThan(text.indexOf('Plan | Price'));
+    expect(text).toContain('Plan | Price');
+    expect(text).toContain('Starter | $9');
+
+    const byRegion = getTextByRegion(som);
+    expect(byRegion).toHaveLength(1);
+    expect(byRegion[0].role).toBe('main');
+    expect(byRegion[0].text).toContain('Plans');
+    expect(byRegion[0].text.indexOf('Plans')).toBeLessThan(
+      byRegion[0].text.indexOf('Plan | Price'),
+    );
+    expect(byRegion[0].text).toContain('Plan | Price');
+    expect(byRegion[0].text).toContain('Starter | $9');
+  });
 });
 
 describe('getTextByRegion', () => {


### PR DESCRIPTION
## Summary
- Node `getText` / `getTextByRegion` now emit compiled `attrs.caption`, matching `findByText` and `toMarkdown`.
- Adds a focused fixture that returns the table title when the table itself has no text/label.

## Proof
- `npx vitest run tests/parser.test.ts -t "getText"` in `packages/som-parser-node` — 6 passed, including `includes compiled table captions`.

## Notes
- Distinct from #153 (`get_text` table captions) and #152 (`get_text`/`getText` select options).
- No network, cache, or protocol changes.
- Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.