### PR TITLE
fix(mcp): include compiled select options in extract_text

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -639,6 +639,15 @@ fn extract_element_text(element: &crate::som::types::Element, parts: &mut Vec<St
                 }
             }
         }
+        if let Some(options) = attrs.get("options").and_then(|value| value.as_array()) {
+            for option in options {
+                if let Some(text) = option.get("text").and_then(|v| v.as_str()) {
+                    if !text.is_empty() {
+                        parts.push(text.to_string());
+                    }
+                }
+            }
+        }
         if let Some(caption) = attrs.get("caption").and_then(|v| v.as_str()) {
             if !caption.is_empty() {
                 parts.push(caption.to_string());
@@ -3701,6 +3710,25 @@ mod tests {
                 "Starter | $9".to_string(),
                 "Pro | $29".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn test_extract_element_text_includes_compiled_select_options() {
+        let mut select = test_element("country", ElementRole::Select, None, None);
+        select.attrs = Some(json!({
+            "options": [
+                {"value": "us", "text": "United States"},
+                {"value": "ca", "text": "Canada"}
+            ]
+        }));
+
+        let mut parts = Vec::new();
+        extract_element_text(&select, &mut parts);
+
+        assert_eq!(
+            parts,
+            vec!["United States".to_string(), "Canada".to_string()]
         );
     }
 


### PR DESCRIPTION
## Summary
- MCP `extract_text` now emits compiled `attrs.options` labels, matching parser `get_text`/`getText`.
- Selects often leave `element.text` empty; option copy lives in `attrs.options`.

## Proof
- `cargo test --bin plasmate test_extract_element_text_includes_compiled -- --nocapture` — 2 passed, including `test_extract_element_text_includes_compiled_select_options`.

## Notes
- Distinct from #153/#154 (parser `get_text`/`getText` table captions) and #152 (parser select options).
- No network, cache, or protocol changes.
- Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text). GitHub issues: no open READY items; no open issues.