### PR TITLE
docs(automation): narrow hourly compiled-attrs copies

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,6 +33,18 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
+## Active governor constraint (2026-08-22)
+
+- Window: `a50ff51` .. `2cdca53`
+- Decision: `NARROW`
+- Merged this run: #153, #154, #155, #156
+- Prohibited next: another compiled `attrs.options` / `attrs.caption` /
+  `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
+  text extractors. Those surfaces were the last four hours of accepted work.
+- Allowed next (pick one distinct journey): bounded error recovery, a
+  selector/action contract gap, privacy-safe diagnostics, a real missed
+  regression, or docs that remove an integration failure.
+
 ## Preferred lanes
 
 Select one demonstrated gap from current code and evidence:


### PR DESCRIPTION
## Summary
- Records the 2026-08-22 governor NARROW decision after merging #153–#156.
- Prohibits another compiled attrs one-surface copy in parser/SDK/CLI/MCP text extractors.
- Names allowed next journeys so the hourly builder does not continue the last four-hour series.

## Proof
- Focused review of `docs/automation/HOURLY_BUILDER_LOOP.md` against merged SHAs `a50ff51`..`2cdca53`.
- Doc-only; no runtime change.

## Notes
- Plasmate MCP: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).