### PR TITLE
docs(automation): narrow hourly after #158

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,17 +33,18 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-08-22)
+## Active governor constraint (2026-08-23)
 
-- Window: `a50ff51` .. `2cdca53`
+- Window: `583225b` .. `0cf807d`
 - Decision: `NARROW`
-- Merged this run: #153, #154, #155, #156
+- Merged this run: #158
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
-  text extractors. Those surfaces were the last four hours of accepted work.
-- Allowed next (pick one distinct journey): bounded error recovery, a
-  selector/action contract gap, privacy-safe diagnostics, a real missed
-  regression, or docs that remove an integration failure.
+  text extractors. Do not reopen `#` selector matching (region id, SOM
+  element id, or `html_id`); #158 closed that advertised contract gap.
+- Allowed next (pick one distinct journey): bounded error recovery,
+  privacy-safe diagnostics, a real missed regression, or docs that remove
+  an integration failure.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
Updates the active hourly-builder constraint after this governor run merged #158.

- Decision remains `NARROW`.
- Compiled-attrs one-surface copies stay prohibited.
- `#` selector matching (region id / SOM id / `html_id`) is now closed; do not reopen it.

## Proof
Docs-only governance constraint. Focused selector proof already ran for #158: `cargo test --lib som::filter::` — 14 passed.

## Governor
CORRECT: keep the next hourly run off the last accepted lanes.

Plasmate MCP: `https://plasmate.app` and `https://docs.plasmate.app` (main).