### PR TITLE
fix(sdk): fail closed on unparseable Python tool JSON

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -91,6 +91,18 @@ def _bounded_tool_error(text: str) -> str:
     return f"{text[: MAX_TOOL_ERROR_CHARS - 1]}…"
 
 
+def _parse_structured_tool_text(text: str) -> Any:
+    """Parse structured MCP tool text, failing closed when no JSON is present."""
+    if not text:
+        return None
+    parsed = _extract_last_json(text)
+    if parsed is not None:
+        return parsed
+    if text.strip() == "null":
+        return None
+    raise RuntimeError(_bounded_tool_error("Tool returned unparseable output"))
+
+
 class Plasmate:
     """
     Synchronous Plasmate client.
@@ -232,10 +244,7 @@ class Plasmate:
 
         if name == "extract_text":
             return text
-        if not text:
-            return None
-
-        return _extract_last_json(text)
+        return _parse_structured_tool_text(text)
 
     # ---- Stateless Tools ----
 
@@ -463,10 +472,7 @@ class AsyncPlasmate:
 
         if name == "extract_text":
             return text
-        if not text:
-            return None
-
-        return _extract_last_json(text)
+        return _parse_structured_tool_text(text)
 
     async def fetch_page(
         self,

--- a/sdk/python/tests/test_json_extract.py
+++ b/sdk/python/tests/test_json_extract.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from plasmate.client import _extract_last_json
+from plasmate.client import _extract_last_json, _parse_structured_tool_text
 
 
 class TestExtractLastJson:
@@ -69,3 +69,18 @@ class TestExtractLastJson:
         text = '{"ok": true}\nDone in 0.3s'
         result = _extract_last_json(text)
         assert result == {"ok": True}
+
+
+class TestParseStructuredToolText:
+    def test_empty_text_is_none(self):
+        assert _parse_structured_tool_text("") is None
+
+    def test_json_null_is_none(self):
+        assert _parse_structured_tool_text("null") is None
+
+    def test_valid_object(self):
+        assert _parse_structured_tool_text('{"ok": true}') == {"ok": True}
+
+    def test_unparseable_text_raises(self):
+        with pytest.raises(RuntimeError, match="Tool returned unparseable output"):
+            _parse_structured_tool_text("Fetching fixture...\nnot-json")

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -51,6 +51,16 @@ for line in sys.stdin:
                 },
             })
             continue
+        if tool_name == "unparseable_tool":
+            send({
+                "jsonrpc": "2.0",
+                "id": request.get("id"),
+                "result": {
+                    "content": [{"type": "text", "text": "Fetching fixture...\\nnot-json"}],
+                    "isError": False,
+                },
+            })
+            continue
         content = {
             "type": "text",
             "text": "Plain text fixture"
@@ -145,6 +155,27 @@ def test_async_oversized_tool_error_has_bounded_message(tmp_path: Path) -> None:
             with pytest.raises(RuntimeError) as error:
                 await client._call_tool("oversized_error", {})
             assert str(error.value) == f"{'x' * 199}…"
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_unparseable_tool_text_fails_closed(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        with pytest.raises(RuntimeError, match="Tool returned unparseable output"):
+            client._call_tool("unparseable_tool", {})
+    finally:
+        client.close()
+
+
+def test_async_unparseable_tool_text_fails_closed(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            with pytest.raises(RuntimeError, match="Tool returned unparseable output"):
+                await client._call_tool("unparseable_tool", {})
         finally:
             await client.close()
 


### PR DESCRIPTION
## Journey
Bounded error recovery for the Python SDK structured-tool path. `fetch_page` / `open_page` / `click` / `evaluate` used `_extract_last_json` and returned `None` when mixed progress/log text contained no JSON object.

## Hypothesis
Agents that receive a successful empty result after a mixed MCP payload treat the page as loaded and continue clicking or extracting against nothing.

## Delta
- `_parse_structured_tool_text` fails closed when tool text is present but not JSON.
- Empty text and JSON `null` still return `None`.
- `extract_text` still returns raw text.

## Proof
`cd sdk/python && PYTHONPATH=src python3 -m pytest tests/test_json_extract.py tests/test_protocol.py tests/test_client.py -v`

Before: unparseable tool text returned `None`.
After: `RuntimeError: Tool returned unparseable output`; 32 focused tests passed.

## Out of scope
Not an `attrs.*` extractor copy. Does not change `#` selector matching. Distinct from #160 (click DOM miss).

Governor: merge or reject on local proof. Do not require GitHub Actions.