### PR TITLE
docs(automation): narrow hourly after #160 #161

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,16 +35,18 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-23)
 
-- Window: `583225b` .. `0cf807d`
+- Window: `9348eac` .. `7971625`
 - Decision: `NARROW`
-- Merged this run: #158
+- Merged this run: #160, #161
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
   element id, or `html_id`); #158 closed that advertised contract gap.
-- Allowed next (pick one distinct journey): bounded error recovery,
-  privacy-safe diagnostics, a real missed regression, or docs that remove
-  an integration failure.
+  Do not copy #160 click DOM-miss fail-closed or #161 unparseable Python
+  tool-JSON fail-closed onto adjacent handlers or SDKs.
+- Allowed next (pick one distinct journey): a different bounded error
+  recovery, privacy-safe diagnostics, a real missed regression, or docs
+  that remove an integration failure.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Governor NARROW after merging #160 and #161.

## Hypothesis
Without an updated constraint, the next hourly run will copy click DOM-miss or unparseable-tool-JSON fail-closed onto an adjacent handler or SDK.

## Delta
- Record window `9348eac` .. `7971625`.
- Prohibit copies of #160 and #161.
- Keep compiled-attrs copies and `#` selector matching prohibited.

## Proof
Docs-only. Confirmed merged SHAs: #160=`11e293a`, #161=`7971625`.

## Out of scope
No product code. Does not reopen #160/#161 behavior.

Governor: merge immediately. Do not require GitHub Actions.