### PR TITLE
docs(automation): narrow hourly after #163

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,18 +35,18 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-23)
 
-- Window: `9348eac` .. `7971625`
+- Window: `457915d` .. `8286203`
 - Decision: `NARROW`
-- Merged this run: #160, #161
+- Merged this run: #163
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
   element id, or `html_id`); #158 closed that advertised contract gap.
-  Do not copy #160 click DOM-miss fail-closed or #161 unparseable Python
-  tool-JSON fail-closed onto adjacent handlers or SDKs.
-- Allowed next (pick one distinct journey): a different bounded error
-  recovery, privacy-safe diagnostics, a real missed regression, or docs
-  that remove an integration failure.
+  Do not copy #160 click DOM-miss fail-closed, #161 unparseable Python
+  tool-JSON fail-closed, or #163 `type_text` disabled/readonly fail-closed
+  onto adjacent handlers (`clear`, `toggle`, `select_option`) or SDKs.
+- Allowed next (pick one distinct journey): privacy-safe diagnostics, a
+  real missed regression, or docs that remove an integration failure.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Governor NARROW after merging #163.

## Hypothesis
Without an updated constraint, the next hourly run will copy type_text disabled/readonly fail-closed onto clear, toggle, select_option, or an adjacent SDK.

## Delta
- Record window `457915d` .. `8286203`.
- Prohibit copies of #163 onto adjacent handlers/SDKs.
- Keep compiled-attrs copies, `#` selector matching, and #160/#161 copies prohibited.

## Proof
Docs-only. Confirmed merged SHA: #163=`8286203`. Focused local proof already passed on #163: `cargo test --bin plasmate type_text_disabled_or_readonly_fails_closed_and_preserves_session`.

## Out of scope
No product code. Does not reopen #163 behavior.

Fetched via Plasmate MCP: https://plasmate.app and https://docs.plasmate.app.

Governor: merge immediately. Do not require GitHub Actions.