### PR TITLE
feat(mcp): count disabled and readonly interactives in session_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This exposes Plasmate over stdio as MCP tools:
 - `crawl_policy` - evaluate RFC 9309 robots.txt policy without changing fetch behavior
 - `inspect_page` - return bounded SOM first, with deterministic optional visual fallback
 - `cache_status` - inspect MCP SOM cache reuse and restorable page-state entries
-- `session_status` - inspect active sessions, loaded URLs, HTML/SOM/node inventory
+- `session_status` - inspect active sessions, loaded URLs, HTML/SOM/node inventory, and disabled/readonly interactive counts
 - `trace_status` - inspect bounded action-trace retention for one session
 - `trace_export` - export privacy-safe `plasmate.trace.v1` events
 - `trace_clear` - discard retained events without resetting their sequence
@@ -224,7 +224,8 @@ Use `cache_status` after repeated fetches to inspect local MCP SOM cache hits,
 misses, selector entries, effective-HTML entries, and avoided HTML work.
 Use `session_status` before long interactive runs to inspect active browser
 session count, capacity, loaded URLs, raw/effective HTML sizes, SOM sizes,
-node-map counts, structured data presence, age, and idle time. Stateful
+node-map counts, structured data presence, disabled/readonly interactive
+counts, age, and idle time. Stateful
 `open_page` and `navigate_to` return `cache_restored=true` when they reuse a
 content-hash-validated cache entry with both SOM and effective HTML.
 Set `trace=true` on `open_page` to opt into bounded, memory-only action tracing,

--- a/docs/claude-desktop-config.md
+++ b/docs/claude-desktop-config.md
@@ -41,7 +41,7 @@ Claude now has access to these tools:
 | `extract_text` | Get clean, readable text from any web page |
 | `extract_links` | Get all outbound URLs from a page (deduplicated) |
 | `cache_status` | Inspect MCP SOM cache hits, misses, selector/effective-HTML entries, and avoided HTML work |
-| `session_status` | Inspect active MCP browser sessions, loaded URLs, raw/effective HTML, SOM/node inventory, capacity, age, and idle time |
+| `session_status` | Inspect active MCP browser sessions, loaded URLs, raw/effective HTML, SOM/node inventory, disabled/readonly interactive counts, capacity, age, and idle time |
 | `trace_status` | Inspect whether a session's bounded, memory-only action trace is enabled and retained |
 | `trace_export` | Export redacted `plasmate.trace.v1` events for one live session |
 | `trace_clear` | Clear retained trace events while preserving the monotonic sequence |

--- a/src/mcp/sessions.rs
+++ b/src/mcp/sessions.rs
@@ -48,6 +48,8 @@ pub struct SessionSummary {
     pub som_bytes: Option<usize>,
     pub element_count: Option<usize>,
     pub interactive_count: Option<usize>,
+    pub disabled_count: Option<usize>,
+    pub readonly_count: Option<usize>,
 }
 
 /// State for a single MCP browser session.
@@ -357,18 +359,16 @@ impl SessionManager {
         let mut session_summaries: Vec<SessionSummary> = sessions
             .iter()
             .map(|(session_id, session)| {
-                let som_meta = session.target.current_som.as_ref().map(|som| &som.meta);
+                let som = session.target.current_som.as_ref();
+                let som_meta = som.map(|som| &som.meta);
+                let blocked = som.map(blocked_interactive_counts);
                 SessionSummary {
                     session_id: session_id.clone(),
                     url: session.target.current_url.clone(),
-                    title: session
-                        .target
-                        .current_som
-                        .as_ref()
-                        .map(|som| som.title.clone()),
+                    title: som.map(|som| som.title.clone()),
                     age_ms: now.duration_since(session.created_at).as_millis(),
                     idle_ms: now.duration_since(session.last_accessed).as_millis(),
-                    has_page: session.target.current_som.is_some(),
+                    has_page: som.is_some(),
                     has_structured_data: session.target.current_structured_data.is_some(),
                     has_effective_html: session.target.effective_html.is_some(),
                     node_count: session.target.node_map.len(),
@@ -377,6 +377,8 @@ impl SessionManager {
                     som_bytes: som_meta.map(|meta| meta.som_bytes),
                     element_count: som_meta.map(|meta| meta.element_count),
                     interactive_count: som_meta.map(|meta| meta.interactive_count),
+                    disabled_count: blocked.map(|(disabled, _)| disabled),
+                    readonly_count: blocked.map(|(_, readonly)| readonly),
                 }
             })
             .collect();
@@ -391,6 +393,50 @@ impl SessionManager {
             longest_idle_ms,
             sessions: session_summaries,
         }
+    }
+}
+
+fn blocked_interactive_counts(som: &crate::som::types::Som) -> (usize, usize) {
+    let mut disabled = 0;
+    let mut readonly = 0;
+    for region in &som.regions {
+        count_blocked_interactives(&region.elements, &mut disabled, &mut readonly);
+    }
+    (disabled, readonly)
+}
+
+fn count_blocked_interactives(
+    elements: &[crate::som::types::Element],
+    disabled: &mut usize,
+    readonly: &mut usize,
+) {
+    for element in elements {
+        if element.role.is_interactive() {
+            if let Some(attrs) = &element.attrs {
+                if attr_flag_true(attrs, "disabled") {
+                    *disabled += 1;
+                }
+                if attr_flag_true(attrs, "readonly") {
+                    *readonly += 1;
+                }
+            }
+        }
+        if let Some(children) = &element.children {
+            count_blocked_interactives(children, disabled, readonly);
+        }
+        if let Some(shadow) = &element.shadow {
+            count_blocked_interactives(&shadow.elements, disabled, readonly);
+        }
+    }
+}
+
+fn attr_flag_true(attrs: &serde_json::Value, key: &str) -> bool {
+    match attrs.get(key) {
+        Some(serde_json::Value::Bool(true)) => true,
+        Some(serde_json::Value::String(value)) => {
+            value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case(key)
+        }
+        _ => false,
     }
 }
 
@@ -454,6 +500,32 @@ mod tests {
         assert!(snapshot.sessions[0].has_effective_html);
         assert_eq!(snapshot.sessions[0].html_bytes, Some(13));
         assert_eq!(snapshot.sessions[0].effective_html_bytes, Some(31));
+        assert_eq!(snapshot.sessions[0].disabled_count, None);
+        assert_eq!(snapshot.sessions[0].readonly_count, None);
+        assert!(manager.close_session(&id).await);
+    }
+
+    #[tokio::test]
+    async fn snapshot_counts_disabled_and_readonly_interactives() {
+        let manager = SessionManager::new();
+        let id = manager.create_session().await.unwrap();
+        let html = "<html><head><title>Locked fields</title></head><body><main><input id='coupon' disabled value='SAVE'><textarea id='notes' readonly>Draft</textarea><button>Ok</button></main></body></html>";
+        manager
+            .with_session(&id, |session| {
+                session.target.current_url = Some("https://example.test/locked".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    crate::som::compiler::compile(html, "https://example.test/locked").unwrap(),
+                );
+            })
+            .await
+            .unwrap();
+
+        let snapshot = manager.snapshot().await;
+        assert_eq!(snapshot.sessions[0].interactive_count, Some(3));
+        assert_eq!(snapshot.sessions[0].disabled_count, Some(1));
+        assert_eq!(snapshot.sessions[0].readonly_count, Some(1));
         assert!(manager.close_session(&id).await);
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1117,7 +1117,7 @@ pub fn cache_status_definition() -> ToolDefinition {
 pub fn session_status_definition() -> ToolDefinition {
     ToolDefinition {
         name: "session_status".to_string(),
-        description: "Return Plasmate's MCP browser-session inventory: capacity, age/idle timing, loaded URLs, raw/effective HTML sizes, SOM sizes, node-map counts, and structured-data presence. Use this to inspect stateful open_page/navigate_to workflows before creating more sessions or debugging repeated actions.".to_string(),
+        description: "Return Plasmate's MCP browser-session inventory: capacity, age/idle timing, loaded URLs, raw/effective HTML sizes, SOM sizes, node-map counts, structured-data presence, and compiled disabled/readonly interactive counts. Use this to inspect stateful open_page/navigate_to workflows before creating more sessions or retrying type_text on locked fields.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {}
@@ -4159,6 +4159,31 @@ mod tests {
             snapshot["sessions"].as_array().unwrap()[0]["has_effective_html"].as_bool(),
             Some(false)
         );
+        assert!(snapshot["sessions"].as_array().unwrap()[0]["disabled_count"].is_null());
+        assert!(snapshot["sessions"].as_array().unwrap()[0]["readonly_count"].is_null());
+        assert!(sessions.close_session(&session_id).await);
+    }
+
+    #[tokio::test]
+    async fn test_session_status_reports_disabled_and_readonly_counts() {
+        let sessions = Arc::new(SessionManager::new());
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Locked fields</title></head><body><main><input id='coupon' disabled value='SAVE'><textarea id='notes' readonly>Draft</textarea></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/locked").unwrap(),
+                );
+            })
+            .await
+            .unwrap();
+
+        let result = handle_session_status(&sessions).await;
+        let text = result["content"][0]["text"].as_str().unwrap();
+        let snapshot: serde_json::Value = serde_json::from_str(text).unwrap();
+        let summary = &snapshot["sessions"].as_array().unwrap()[0];
+        assert_eq!(summary["disabled_count"], 1);
+        assert_eq!(summary["readonly_count"], 1);
         assert!(sessions.close_session(&session_id).await);
     }
 


### PR DESCRIPTION
## Why
#163 made type_text fail closed on compiled disabled/readonly fields, but session_status still only reported interactive_count. Agents had to retry a mutation to learn the page was locked.

This is the allowed privacy-safe diagnostics lane after the 2026-08-23 NARROW governor window. It does not copy fail-closed onto clear, toggle, or select_option.

## Change
session_status now includes per-session disabled_count and readonly_count from the compiled SOM (interactive roles only, including nested/shadow children). Counts are absent when no SOM is loaded. No IDs, values, or page content are added.

## Proof
Focused local tests (not full suite):
- cargo test --bin plasmate snapshot_counts_disabled
- cargo test --bin plasmate test_session_status
- cargo test --bin plasmate test_snapshot_reports_session_inventory
- cargo fmt -- --check src/mcp/sessions.rs src/mcp/tools.rs

Before: empty-session snapshot has no blocked counts; locked fixture is invisible.
After: locked fixture reports disabled_count=1, readonly_count=1 beside interactive_count.

Plasmate MCP fetch: https://docs.plasmate.app (main). https://plasmate.dev returned 404.
GitHub had no open READY issues and no open automation PR.