### PR TITLE
fix(mcp): include compiled iframe src in extract_links

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -702,7 +702,7 @@ struct ExtractLinksParams {
 pub fn extract_links_definition() -> ToolDefinition {
     ToolDefinition {
         name: "extract_links".to_string(),
-        description: "Fetch a web page and return all outbound URLs found in the page, one per line, deduplicated. Useful for crawling, sitemap discovery, and finding related pages.".to_string(),
+        description: "Fetch a web page and return outbound URLs found in the compiled SOM, one per line, deduplicated. Includes link hrefs and iframe src destinations. Useful for crawling, sitemap discovery, and finding related or framed pages.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -1334,15 +1334,22 @@ pub async fn handle_extract_links(
     tool_response(delivered_text)
 }
 
-/// Recursively collect link URLs from a SOM element tree.
+fn push_attr_url(attrs: &Value, key: &str, urls: &mut Vec<String>) {
+    if let Some(url) = attrs.get(key).and_then(|v| v.as_str()) {
+        if !url.is_empty() && url != "#" {
+            urls.push(url.to_string());
+        }
+    }
+}
+
+/// Recursively collect outbound URLs from a SOM element tree.
 fn collect_element_links(element: &crate::som::types::Element, urls: &mut Vec<String>) {
-    if element.role == crate::som::types::ElementRole::Link {
-        if let Some(ref attrs) = element.attrs {
-            if let Some(href) = attrs.get("href").and_then(|v| v.as_str()) {
-                if !href.is_empty() && href != "#" {
-                    urls.push(href.to_string());
-                }
-            }
+    if let Some(ref attrs) = element.attrs {
+        if element.role == crate::som::types::ElementRole::Link {
+            push_attr_url(attrs, "href", urls);
+        }
+        if element.role == crate::som::types::ElementRole::Iframe {
+            push_attr_url(attrs, "src", urls);
         }
     }
     if let Some(ref children) = element.children {
@@ -3931,6 +3938,38 @@ mod tests {
                 "https://example.com/shadow".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn collect_element_links_includes_compiled_iframe_src() {
+        let som = crate::som::compiler::compile(
+            r##"<html><head><title>Embed</title></head><body>
+<main>
+  <a href="https://example.test/docs">Docs</a>
+  <iframe src="https://example.test/embed" title="Help"></iframe>
+  <iframe src="#" title="Ignored"></iframe>
+</main>
+</body></html>"##,
+            "https://example.test/",
+        )
+        .expect("fixture HTML should compile");
+
+        let mut urls = Vec::new();
+        for region in &som.regions {
+            for element in &region.elements {
+                collect_element_links(element, &mut urls);
+            }
+        }
+
+        assert!(
+            urls.contains(&"https://example.test/docs".to_string()),
+            "{urls:?}"
+        );
+        assert!(
+            urls.contains(&"https://example.test/embed".to_string()),
+            "{urls:?}"
+        );
+        assert!(!urls.iter().any(|url| url == "#"), "{urls:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`extract_links` advertised outbound page URLs but only collected `a[href]`. Compiled iframe `src` destinations were dropped, so crawl/discovery agents never saw framed pages.

This run keeps the change on the MCP collector only (no CLI/CDP copy).

## Proof
Focused: `cargo test --bin plasmate collect_element_links`
- `collect_element_links_includes_compiled_iframe_src` compiles fixture HTML and asserts `https://example.test/embed` is returned beside the ordinary link, while `src="#"` is skipped.
- Existing shadow-DOM link collection still passes.

`cargo fmt --check -- src/mcp/tools.rs` passed. No full-suite or release build (fleet timebox).

## Governor notes
- Base: `3da02c6` (after #166 NARROW)
- Distinct journey: extract_links crawl discovery, not attrs.options/caption/items/rows, not `#` selectors, not fail-closed copies, not session_status counts.
- Plasmate MCP reads: `https://plasmate.app`, `https://docs.plasmate.app`, `https://docs.plasmate.app/changelog`, `https://docs.plasmate.app/som-spec`
- GitHub: no unused READY issues.