### PR TITLE
fix(sdk): add Python extract_links as plain text

### DIFF
--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -242,7 +242,7 @@ class Plasmate:
         if result and result.get("isError"):
             raise RuntimeError(_bounded_tool_error(text))
 
-        if name == "extract_text":
+        if name in ("extract_text", "extract_links"):
             return text
         return _parse_structured_tool_text(text)
 
@@ -301,6 +301,27 @@ class Plasmate:
         if selector is not None:
             args["selector"] = selector
         return self._call_tool("extract_text", args)
+
+    def extract_links(
+        self,
+        url: str,
+        *,
+        selector: Optional[str] = None,
+    ) -> str:
+        """
+        Fetch a page and return deduplicated outbound URLs, one per line.
+
+        Args:
+            url: URL to fetch
+            selector: Optional SOM region, role, action, or element-id filter
+
+        Returns:
+            Newline-separated URLs (plain text, not JSON)
+        """
+        args: dict[str, Any] = {"url": url}
+        if selector is not None:
+            args["selector"] = selector
+        return self._call_tool("extract_links", args)
 
     # ---- Stateful Tools ----
 
@@ -470,7 +491,7 @@ class AsyncPlasmate:
         if result and result.get("isError"):
             raise RuntimeError(_bounded_tool_error(text))
 
-        if name == "extract_text":
+        if name in ("extract_text", "extract_links"):
             return text
         return _parse_structured_tool_text(text)
 
@@ -506,6 +527,18 @@ class AsyncPlasmate:
         if selector is not None:
             args["selector"] = selector
         return await self._call_tool("extract_text", args)
+
+    async def extract_links(
+        self,
+        url: str,
+        *,
+        selector: Optional[str] = None,
+    ) -> str:
+        """Fetch a page and return deduplicated outbound URLs, one per line."""
+        args: dict[str, Any] = {"url": url}
+        if selector is not None:
+            args["selector"] = selector
+        return await self._call_tool("extract_links", args)
 
     async def open_page(self, url: str) -> dict:
         """Open a page in a persistent browser session."""

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -8,30 +8,34 @@ from plasmate.client import AsyncPlasmate, Plasmate
 
 def test_sync_read_methods_forward_selector() -> None:
     browser = Plasmate()
-    calls = Mock(side_effect=[{}, "text"])
+    calls = Mock(side_effect=[{}, "text", "https://example.test/a"])
     browser._call_tool = calls  # type: ignore[method-assign]
 
     assert browser.fetch_page("fixture", selector="main") == {}
     assert browser.extract_text("fixture", selector="content") == "text"
+    assert browser.extract_links("fixture", selector="nav") == "https://example.test/a"
 
     assert calls.call_args_list == [
         call("fetch_page", {"url": "fixture", "selector": "main"}),
         call("extract_text", {"url": "fixture", "selector": "content"}),
+        call("extract_links", {"url": "fixture", "selector": "nav"}),
     ]
 
 
 def test_async_read_methods_forward_selector() -> None:
     async def exercise() -> None:
         browser = AsyncPlasmate()
-        calls = AsyncMock(side_effect=[{}, "text"])
+        calls = AsyncMock(side_effect=[{}, "text", "https://example.test/a"])
         browser._call_tool = calls  # type: ignore[method-assign]
 
         assert await browser.fetch_page("fixture", selector="main") == {}
         assert await browser.extract_text("fixture", selector="content") == "text"
+        assert await browser.extract_links("fixture", selector="nav") == "https://example.test/a"
 
         assert calls.call_args_list == [
             call("fetch_page", {"url": "fixture", "selector": "main"}),
             call("extract_text", {"url": "fixture", "selector": "content"}),
+            call("extract_links", {"url": "fixture", "selector": "nav"}),
         ]
 
     asyncio.run(exercise())

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -61,11 +61,15 @@ for line in sys.stdin:
                 },
             })
             continue
+        if tool_name == "extract_text":
+            payload = "Plain text fixture"
+        elif tool_name == "extract_links":
+            payload = "https://example.test/a\\nhttps://example.test/b"
+        else:
+            payload = json.dumps({"ok": True})
         content = {
             "type": "text",
-            "text": "Plain text fixture"
-            if tool_name == "extract_text"
-            else json.dumps({"ok": True}),
+            "text": payload,
         }
         send({
             "jsonrpc": "2.0",
@@ -111,6 +115,29 @@ def test_async_extract_text_preserves_plain_text(tmp_path: Path) -> None:
         client = AsyncPlasmate(binary=_fixture(tmp_path))
         try:
             assert await client.extract_text("fixture") == "Plain text fixture"
+        finally:
+            await client.close()
+
+    asyncio.run(exercise())
+
+
+def test_sync_extract_links_preserves_plain_text(tmp_path: Path) -> None:
+    client = Plasmate(binary=_fixture(tmp_path))
+    try:
+        assert client.extract_links("fixture") == (
+            "https://example.test/a\nhttps://example.test/b"
+        )
+    finally:
+        client.close()
+
+
+def test_async_extract_links_preserves_plain_text(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        client = AsyncPlasmate(binary=_fixture(tmp_path))
+        try:
+            assert await client.extract_links("fixture") == (
+                "https://example.test/a\nhttps://example.test/b"
+            )
         finally:
             await client.close()
 

--- a/website/docs/src/sdk-python.md
+++ b/website/docs/src/sdk-python.md
@@ -223,6 +223,9 @@ som = client.fetch_page("https://example.com")
 # Extract plain text
 text = client.extract_text("https://example.com")
 
+# Extract deduplicated outbound URLs (plain text, one per line)
+links = client.extract_links("https://example.com", selector="nav")
+
 # Stateful sessions
 session = client.open_page("https://example.com")
 session_id = session["session_id"]
@@ -251,6 +254,7 @@ from plasmate import AsyncPlasmate
 async with AsyncPlasmate() as client:
     som = await client.fetch_page("https://example.com")
     text = await client.extract_text("https://example.com")
+    links = await client.extract_links("https://example.com", selector="nav")
 
     session = await client.open_page("https://example.com")
     session_id = session["session_id"]


### PR DESCRIPTION
## Summary
The official Python SDK advertised `fetch_page` and `extract_text` but had no `extract_links` method. MCP already returns deduplicated outbound URLs as plain text (one per line). Calling that tool through the generic JSON path would fail closed after #161.

This run adds sync/async `extract_links`, keeps the payload as text, and documents the method on the Python SDK page.

## Proof
Focused: `cd sdk/python && PYTHONPATH=src python3 -m pytest tests/test_client.py tests/test_protocol.py -v`
- `test_sync_extract_links_preserves_plain_text` / async counterpart return newline-separated fixture URLs instead of raising unparseable JSON.
- Selector forwarding covers `extract_links` beside the existing read methods.
- Existing extract_text and unparseable-JSON fail-closed tests still pass (16 passed).

No full-suite or release build (fleet timebox).

## Governor notes
- Base: `3da02c6` (after #166 NARROW)
- Distinct journey: Python SDK crawl discovery, not attrs.options/caption/items/rows, not `#` selectors, not fail-closed copies onto clear/toggle/select_option, not session_status counts.
- Sibling open automation PR #167 is MCP `extract_links` iframe src; this PR does not touch that collector.
- Plasmate MCP reads: `https://plasmate.app`, `https://docs.plasmate.app`, `https://docs.plasmate.app/changelog`, `https://docs.plasmate.app/integration-mcp`, `https://docs.plasmate.app/sdk-python`
- GitHub: no unused READY issues.