### PR TITLE
docs(sdk): point Go install at the published module

### DIFF
--- a/scripts/test_public_claim_surfaces.py
+++ b/scripts/test_public_claim_surfaces.py
@@ -18,6 +18,12 @@ SURFACES = (
 )
 
 
+GO_SDK_SURFACES = (
+    "website/docs/src/sdk-go.md",
+    "website/docs/sdk-go.html",
+)
+
+
 class PublicClaimSurfaceTests(unittest.TestCase):
     def test_public_guidance_uses_evidence_aligned_wording(self) -> None:
         for paths, stale_wording, aligned_wording in SURFACES:
@@ -26,6 +32,15 @@ class PublicClaimSurfaceTests(unittest.TestCase):
                     text = (ROOT / relative_path).read_text(encoding="utf-8")
                     self.assertNotIn(stale_wording, text)
                     self.assertIn(aligned_wording, text)
+
+    def test_go_sdk_docs_use_published_module_and_options_type(self) -> None:
+        for relative_path in GO_SDK_SURFACES:
+            with self.subTest(path=relative_path):
+                text = (ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertIn("github.com/plasmate-labs/plasmate/sdk/go", text)
+                self.assertIn("FetchPageOptions", text)
+                self.assertNotIn("github.com/nickel-org/plasmate-go", text)
+                self.assertNotIn("plasmate.FetchOptions{", text)
 
 
 if __name__ == "__main__":

--- a/website/docs/sdk-go.html
+++ b/website/docs/sdk-go.html
@@ -458,7 +458,7 @@
     </nav>
     <main class="content">
       <h1 id="go-sdk">Go SDK</h1><p>The official Go SDK for Plasmate, with typed structs and SOM query functions.</p>
-<h2 id="installation">Installation</h2><pre><code class="language-sh">go get github.com/nickel-org/plasmate-go
+<h2 id="installation">Installation</h2><pre><code class="language-sh">go get github.com/plasmate-labs/plasmate/sdk/go
 </code></pre>
 <p>Requires Go 1.21+ and the <code>plasmate</code> binary on your PATH.</p>
 <h2 id="quick-start">Quick Start</h2><pre><code class="language-go">package main
@@ -467,7 +467,7 @@ import (
     &quot;fmt&quot;
     &quot;log&quot;
 
-    plasmate &quot;github.com/nickel-org/plasmate-go&quot;
+    plasmate &quot;github.com/plasmate-labs/plasmate/sdk/go&quot;
 )
 
 func main() {
@@ -579,9 +579,11 @@ client := plasmate.NewClient(plasmate.WithBinary(&quot;/usr/local/bin/plasmate&q
 som, err := client.FetchPage(&quot;https://example.com&quot;)
 
 // Fetch with options
-som, err := client.FetchPageWithOptions(&quot;https://example.com&quot;, plasmate.FetchOptions{
-    Budget:     8000,
-    JavaScript: true,
+budget := 8000
+javascript := true
+som, err := client.FetchPageWithOptions(&quot;https://example.com&quot;, plasmate.FetchPageOptions{
+    Budget:     &amp;budget,
+    JavaScript: &amp;javascript,
 })
 
 // Extract plain text

--- a/website/docs/src/sdk-go.md
+++ b/website/docs/src/sdk-go.md
@@ -5,7 +5,7 @@ The official Go SDK for Plasmate, with typed structs and SOM query functions.
 ## Installation
 
 ```sh
-go get github.com/nickel-org/plasmate-go
+go get github.com/plasmate-labs/plasmate/sdk/go
 ```
 
 Requires Go 1.21+ and the `plasmate` binary on your PATH.
@@ -19,7 +19,7 @@ import (
     "fmt"
     "log"
 
-    plasmate "github.com/nickel-org/plasmate-go"
+    plasmate "github.com/plasmate-labs/plasmate/sdk/go"
 )
 
 func main() {
@@ -221,9 +221,11 @@ client := plasmate.NewClient(plasmate.WithBinary("/usr/local/bin/plasmate"))
 som, err := client.FetchPage("https://example.com")
 
 // Fetch with options
-som, err := client.FetchPageWithOptions("https://example.com", plasmate.FetchOptions{
-    Budget:     8000,
-    JavaScript: true,
+budget := 8000
+javascript := true
+som, err := client.FetchPageWithOptions("https://example.com", plasmate.FetchPageOptions{
+    Budget:     &budget,
+    JavaScript: &javascript,
 })
 
 // Extract plain text


### PR DESCRIPTION
## Why
Live https://docs.plasmate.app/sdk-go still tells integrators to `go get github.com/nickel-org/plasmate-go` and compile `plasmate.FetchOptions{Budget: 8000, JavaScript: true}`. That module does not exist, and the published type is `FetchPageOptions` with pointer fields (`sdk/go/client.go`, `sdk/go/README.md`). Copy-paste install/compile fails.

Governor NARROW (2026-08-23) allows docs that remove an integration failure. This is not an extractor/SDK method copy.

## Change
- Replace the stale module path and options type on both published Go SDK surfaces
- Show pointer field construction matching the real `FetchPageOptions` API

## Proof
`python3 -m unittest scripts.test_public_claim_surfaces -v`

- `test_go_sdk_docs_use_published_module_and_options_type` now requires `github.com/plasmate-labs/plasmate/sdk/go` and `FetchPageOptions`, and rejects the stale module path / `plasmate.FetchOptions{`
- Existing claim-surface wording test still passes

No full-repo verify (hourly builder timebox). Plasmate MCP fetched https://plasmate.app, https://docs.plasmate.app, and https://docs.plasmate.app/sdk-go.