### PR TITLE
docs(som): align published reference with compiled fields

### DIFF
--- a/scripts/test_public_claim_surfaces.py
+++ b/scripts/test_public_claim_surfaces.py
@@ -1,4 +1,7 @@
+from html import unescape
 from pathlib import Path
+import json
+import re
 import unittest
 
 
@@ -24,6 +27,22 @@ GO_SDK_SURFACES = (
 )
 
 
+SOM_REFERENCE_SURFACES = (
+    "website/docs/src/som.md",
+    "website/docs/som.html",
+)
+
+
+def first_json_example(text: str) -> dict:
+    markdown = re.search(r"```json\n(\{.*?\n\})\n```", text, re.S)
+    if markdown:
+        return json.loads(markdown.group(1))
+    html = re.search(r'<code class="language-json">(.*?)</code>', text, re.S)
+    if not html:
+        raise AssertionError("published SOM reference is missing a JSON example")
+    return json.loads(unescape(html.group(1)))
+
+
 class PublicClaimSurfaceTests(unittest.TestCase):
     def test_public_guidance_uses_evidence_aligned_wording(self) -> None:
         for paths, stale_wording, aligned_wording in SURFACES:
@@ -41,6 +60,25 @@ class PublicClaimSurfaceTests(unittest.TestCase):
                 self.assertIn("FetchPageOptions", text)
                 self.assertNotIn("github.com/nickel-org/plasmate-go", text)
                 self.assertNotIn("plasmate.FetchOptions{", text)
+
+    def test_som_reference_example_matches_compiled_contract(self) -> None:
+        for relative_path in SOM_REFERENCE_SURFACES:
+            with self.subTest(path=relative_path):
+                text = (ROOT / relative_path).read_text(encoding="utf-8")
+                self.assertNotIn('"compression_ratio"', text)
+                self.assertNotIn('"version": "0.1"', text)
+                self.assertNotIn("&quot;version&quot;: &quot;0.1&quot;", text)
+                self.assertNotIn('"role": "Navigation"', text)
+                self.assertNotIn("r_aside_0", text)
+                self.assertIn("text_input", text)
+                example = first_json_example(text)
+                self.assertEqual(example["som_version"], "0.1")
+                self.assertEqual(example["lang"], "en")
+                self.assertEqual(example["meta"]["interactive_count"], 20)
+                self.assertNotIn("compression_ratio", example["meta"])
+                self.assertEqual(example["regions"][0]["role"], "navigation")
+                self.assertIn("open_graph", example["structured_data"])
+                self.assertIn("twitter_card", example["structured_data"])
 
 
 if __name__ == "__main__":

--- a/website/docs/som.html
+++ b/website/docs/som.html
@@ -472,31 +472,32 @@ that the retained representation is sufficient for the target task.</p>
 </li>
 </ol>
 <h2 id="structure">Structure</h2><pre><code class="language-json">{
-  &quot;version&quot;: &quot;0.1&quot;,
+  &quot;som_version&quot;: &quot;0.1&quot;,
   &quot;url&quot;: &quot;https://example.com&quot;,
   &quot;title&quot;: &quot;Page Title&quot;,
+  &quot;lang&quot;: &quot;en&quot;,
   &quot;meta&quot;: {
     &quot;html_bytes&quot;: 589546,
     &quot;som_bytes&quot;: 56625,
     &quot;element_count&quot;: 325,
-    &quot;compression_ratio&quot;: 10.4
+    &quot;interactive_count&quot;: 20
   },
   &quot;structured_data&quot;: {
-    &quot;json_ld&quot;: [...],
-    &quot;opengraph&quot;: {...},
-    &quot;twitter_cards&quot;: {...},
-    &quot;meta_tags&quot;: [...]
+    &quot;json_ld&quot;: [],
+    &quot;open_graph&quot;: {},
+    &quot;twitter_card&quot;: {},
+    &quot;meta&quot;: {}
   },
   &quot;regions&quot;: [
     {
       &quot;id&quot;: &quot;r_navigation&quot;,
-      &quot;role&quot;: &quot;Navigation&quot;,
-      &quot;elements&quot;: [...]
+      &quot;role&quot;: &quot;navigation&quot;,
+      &quot;elements&quot;: []
     },
     {
       &quot;id&quot;: &quot;r_main&quot;,
-      &quot;role&quot;: &quot;Main&quot;,
-      &quot;elements&quot;: [...]
+      &quot;role&quot;: &quot;main&quot;,
+      &quot;elements&quot;: []
     }
   ]
 }
@@ -510,35 +511,35 @@ that the retained representation is sufficient for the target task.</p>
 </tr>
 </thead>
 <tbody><tr>
-<td><strong>Navigation</strong></td>
-<td><code>&lt;nav&gt;</code>, class/ID containing &quot;nav&quot;, &quot;menu&quot;, &quot;header-links&quot;</td>
-</tr>
-<tr>
-<td><strong>Main</strong></td>
-<td><code>&lt;main&gt;</code>, <code>&lt;article&gt;</code>, class/ID containing &quot;content&quot;, &quot;main&quot;, &quot;post&quot;</td>
-</tr>
-<tr>
-<td><strong>Header</strong></td>
-<td><code>&lt;header&gt;</code>, class/ID containing &quot;header&quot;, &quot;masthead&quot;, &quot;banner&quot;</td>
-</tr>
-<tr>
-<td><strong>Footer</strong></td>
-<td><code>&lt;footer&gt;</code>, class/ID containing &quot;footer&quot;, &quot;colophon&quot;</td>
-</tr>
-<tr>
-<td><strong>Aside</strong></td>
-<td><code>&lt;aside&gt;</code>, class/ID containing &quot;sidebar&quot;, &quot;aside&quot;, &quot;widget&quot;</td>
-</tr>
-<tr>
-<td><strong>Form</strong></td>
-<td><code>&lt;form&gt;</code>, class/ID containing &quot;form&quot;, &quot;login&quot;, &quot;signup&quot;</td>
-</tr>
-<tr>
-<td><strong>Dialog</strong></td>
-<td><code>&lt;dialog&gt;</code>, role=&quot;dialog&quot;, class containing &quot;modal&quot;, &quot;popup&quot;</td>
-</tr>
-<tr>
-<td><strong>Content</strong></td>
+<td><code>navigation</code></td>
+        <td><code>&lt;nav&gt;</code>, class/ID containing &quot;nav&quot;, &quot;menu&quot;, &quot;header-links&quot;</td>
+      </tr>
+      <tr>
+        <td><code>main</code></td>
+        <td><code>&lt;main&gt;</code>, <code>&lt;article&gt;</code>, class/ID containing &quot;content&quot;, &quot;main&quot;, &quot;post&quot;</td>
+      </tr>
+      <tr>
+        <td><code>header</code></td>
+        <td><code>&lt;header&gt;</code>, class/ID containing &quot;header&quot;, &quot;masthead&quot;, &quot;banner&quot;</td>
+      </tr>
+      <tr>
+        <td><code>footer</code></td>
+        <td><code>&lt;footer&gt;</code>, class/ID containing &quot;footer&quot;, &quot;colophon&quot;</td>
+      </tr>
+      <tr>
+        <td><code>aside</code></td>
+        <td><code>&lt;aside&gt;</code>, class/ID containing &quot;sidebar&quot;, &quot;aside&quot;, &quot;widget&quot;</td>
+      </tr>
+      <tr>
+        <td><code>form</code></td>
+        <td><code>&lt;form&gt;</code>, class/ID containing &quot;form&quot;, &quot;login&quot;, &quot;signup&quot;</td>
+      </tr>
+      <tr>
+        <td><code>dialog</code></td>
+        <td><code>&lt;dialog&gt;</code>, role=&quot;dialog&quot;, class containing &quot;modal&quot;, &quot;popup&quot;</td>
+      </tr>
+      <tr>
+        <td><code>content</code></td>
 <td>Fallback for regions that do not match other roles</td>
 </tr>
 </tbody></table>
@@ -547,7 +548,7 @@ that the retained representation is sufficient for the target task.</p>
 <li><code>r_navigation</code> (primary nav)</li>
 <li><code>r_main</code> (primary content)</li>
 <li><code>r_footer</code> (page footer)</li>
-<li><code>r_aside_0</code>, <code>r_aside_1</code> (multiple sidebars)</li>
+<li><code>r_aside</code>, <code>r_aside_1</code> (multiple sidebars)</li>
 </ul>
 <h2 id="elements">Elements</h2><p>Each element in a region has:</p>
 <table>
@@ -565,36 +566,36 @@ that the retained representation is sufficient for the target task.</p>
 </tr>
 <tr>
 <td><code>role</code></td>
-<td>string</td>
-<td>Semantic role: link, button, input, select, textarea, heading, paragraph, image, list, table</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td>string</td>
-<td>Accessible name from aria-label, label[for], placeholder, alt, or visible text</td>
-</tr>
-<tr>
-<td><code>text</code></td>
-<td>string</td>
-<td>Summarized text content (budget-limited)</td>
-</tr>
-<tr>
-<td><code>href</code></td>
-<td>string</td>
-<td>For links: the target URL</td>
-</tr>
-<tr>
-<td><code>type</code></td>
-<td>string</td>
-<td>For inputs: the input type (text, email, password, etc.)</td>
-</tr>
-<tr>
-<td><code>value</code></td>
-<td>string</td>
-<td>Current value for form elements</td>
-</tr>
-<tr>
-<td><code>hints</code></td>
+        <td>string</td>
+        <td>Semantic role: link, button, text_input, select, textarea, checkbox, radio, heading, paragraph, image, list, table, section, group, separator, details, iframe</td>
+      </tr>
+      <tr>
+        <td><code>html_id</code></td>
+        <td>string</td>
+        <td>Original HTML <code>id</code> when present</td>
+      </tr>
+      <tr>
+        <td><code>label</code></td>
+        <td>string</td>
+        <td>Accessible name from aria-label, label[for], placeholder, alt, or visible text</td>
+      </tr>
+      <tr>
+        <td><code>text</code></td>
+        <td>string</td>
+        <td>Summarized text content (budget-limited)</td>
+      </tr>
+      <tr>
+        <td><code>actions</code></td>
+        <td>array</td>
+        <td>Compact operations such as click, type, clear, select, toggle</td>
+      </tr>
+      <tr>
+        <td><code>attrs</code></td>
+        <td>object</td>
+        <td>Role-specific attributes such as href, type, value, and src</td>
+      </tr>
+      <tr>
+        <td><code>hints</code></td>
 <td>array</td>
 <td>CSS class-inferred hints: primary, secondary, danger, disabled, active, etc.</td>
 </tr>

--- a/website/docs/src/som.md
+++ b/website/docs/src/som.md
@@ -22,31 +22,32 @@ Where the DOM is a faithful representation of every tag, attribute, and style in
 
 ```json
 {
-  "version": "0.1",
+  "som_version": "0.1",
   "url": "https://example.com",
   "title": "Page Title",
+  "lang": "en",
   "meta": {
     "html_bytes": 589546,
     "som_bytes": 56625,
     "element_count": 325,
-    "compression_ratio": 10.4
+    "interactive_count": 20
   },
   "structured_data": {
-    "json_ld": [...],
-    "opengraph": {...},
-    "twitter_cards": {...},
-    "meta_tags": [...]
+    "json_ld": [],
+    "open_graph": {},
+    "twitter_card": {},
+    "meta": {}
   },
   "regions": [
     {
       "id": "r_navigation",
-      "role": "Navigation",
-      "elements": [...]
+      "role": "navigation",
+      "elements": []
     },
     {
       "id": "r_main",
-      "role": "Main",
-      "elements": [...]
+      "role": "main",
+      "elements": []
     }
   ]
 }
@@ -58,14 +59,14 @@ SOM organizes page content into semantic regions. Region detection uses HTML5 la
 
 | Role | Detection |
 |------|-----------|
-| **Navigation** | `<nav>`, class/ID containing "nav", "menu", "header-links" |
-| **Main** | `<main>`, `<article>`, class/ID containing "content", "main", "post" |
-| **Header** | `<header>`, class/ID containing "header", "masthead", "banner" |
-| **Footer** | `<footer>`, class/ID containing "footer", "colophon" |
-| **Aside** | `<aside>`, class/ID containing "sidebar", "aside", "widget" |
-| **Form** | `<form>`, class/ID containing "form", "login", "signup" |
-| **Dialog** | `<dialog>`, role="dialog", class containing "modal", "popup" |
-| **Content** | Fallback for regions that do not match other roles |
+| `navigation` | `<nav>`, class/ID containing "nav", "menu", "header-links" |
+| `main` | `<main>`, `<article>`, class/ID containing "content", "main", "post" |
+| `header` | `<header>`, class/ID containing "header", "masthead", "banner" |
+| `footer` | `<footer>`, class/ID containing "footer", "colophon" |
+| `aside` | `<aside>`, class/ID containing "sidebar", "aside", "widget" |
+| `form` | `<form>`, class/ID containing "form", "login", "signup" |
+| `dialog` | `<dialog>`, role="dialog", class containing "modal", "popup" |
+| `content` | Fallback for regions that do not match other roles |
 
 ### Region ID Format
 
@@ -74,7 +75,7 @@ Region IDs use the format `r_` + a descriptor derived from the region's role and
 - `r_navigation` (primary nav)
 - `r_main` (primary content)
 - `r_footer` (page footer)
-- `r_aside_0`, `r_aside_1` (multiple sidebars)
+- `r_aside`, `r_aside_1` (multiple sidebars)
 
 ## Elements
 
@@ -83,12 +84,12 @@ Each element in a region has:
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Deterministic ID: `e_` + hex(sha256(origin\|role\|name\|dom_path))[0..12] |
-| `role` | string | Semantic role: link, button, input, select, textarea, heading, paragraph, image, list, table |
-| `name` | string | Accessible name from aria-label, label[for], placeholder, alt, or visible text |
+| `role` | string | Semantic role: link, button, text_input, select, textarea, checkbox, radio, heading, paragraph, image, list, table, section, group, separator, details, iframe |
+| `html_id` | string | Original HTML `id` when present |
+| `label` | string | Accessible name from aria-label, label[for], placeholder, alt, or visible text |
 | `text` | string | Summarized text content (budget-limited) |
-| `href` | string | For links: the target URL |
-| `type` | string | For inputs: the input type (text, email, password, etc.) |
-| `value` | string | Current value for form elements |
+| `actions` | array | Compact operations such as click, type, clear, select, toggle |
+| `attrs` | object | Role-specific attributes such as href, type, value, and src |
 | `hints` | array | CSS class-inferred hints: primary, secondary, danger, disabled, active, etc. |
 
 ### Element ID Stability


### PR DESCRIPTION
## Summary
Published SOM reference at docs.plasmate.app/som still documented a stale document (`version`, `compression_ratio`, capitalized region roles, top-level `name`/`href`/`type`/`value`). Agents following that page cannot parse live `fetch_page` output.

This run aligns `website/docs/src/som.md` and `website/docs/som.html` with the compiled contract (`som_version`, `lang`, `interactive_count`, lowercase roles, `label`/`actions`/`attrs`) and proves the example JSON parses.

## Proof
- Live Plasmate MCP: `https://plasmate.app` (fetch_page), `https://docs.plasmate.app` / `https://docs.plasmate.app/som` (extract_text)
- GitHub: no open PRs; no unused READY issues
- Focused: `python3 -m unittest scripts.test_public_claim_surfaces -v`

## Governor notes
Allowed lane: published-docs integration failure (not an SDK install-path rewrite). Does not copy prohibited attrs/extractor/fail-closed/iframe/extract_links/Go-module work.