### PR TITLE
docs(automation): narrow hourly after #177

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-24)
 
-- Window: `3b81e84` .. `8ae98f2`
+- Window: `fd34284` .. `87cc9a8`
 - Decision: `NARROW`
-- Merged this run: #175
+- Merged this run: #177
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -55,10 +55,13 @@ overwrite, reset, or absorb unrelated work.
   SDK READMEs. Do not copy #173 `<area href>` compile work onto
   extract_links, CLI, CDP, or adjacent tags (`object`, `embed`, `source`).
   Do not copy #175 `extract_text` compiled-label fallback onto CLI, CDP,
-  parser, or SDK text extractors.
+  parser, or SDK text extractors. Do not copy #177 `<picture>` nested-img
+  src/alt inheritance onto extract_links, CLI, CDP, or adjacent tags
+  (`object`, `embed`, `source`).
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
-  rewrite, SOM-reference field rewrite, or extract_text label fallback copy.
+  rewrite, SOM-reference field rewrite, extract_text label fallback copy,
+  or picture-img fallback copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary

Record the 2026-08-24 NARROW decision after merging #177. Prohibit copying picture nested-img src/alt inheritance onto extract_links, CLI, CDP, or adjacent tags.

## Proof

Docs-only governance constraint. No code change.

## Governor notes

Focused local proof for #177 already passed: `cargo test --lib som::compiler::tests::test_picture_inherits_nested_img_src_and_alt`.

Plasmate MCP fetches this run: `https://plasmate.app` (fetch_page) and `https://docs.plasmate.app` (extract_text).