### PR TITLE
fix(som): treat native search element as a landmark

### DIFF
--- a/src/som/heuristics.rs
+++ b/src/som/heuristics.rs
@@ -246,6 +246,7 @@ pub fn landmark_role(tag: &str, attrs: &[(String, String)]) -> Option<&'static s
         "header" => Some("header"),
         "footer" => Some("footer"),
         "dialog" => Some("dialog"),
+        "search" => Some("search"),
         _ => None,
     }
 }

--- a/tests/som_compiler_test.rs
+++ b/tests/som_compiler_test.rs
@@ -373,6 +373,31 @@ fn test_aria_search_landmark_maps_to_navigation_region() {
 }
 
 #[test]
+fn test_native_search_element_maps_to_navigation_region() {
+    let html = r#"<!DOCTYPE html>
+<html><head><title>Native Search</title></head>
+<body>
+    <search aria-label="Site search">
+        <input type="search" aria-label="Query">
+        <button>Search</button>
+    </search>
+    <main><p>Visible content</p></main>
+</body></html>"#;
+
+    let som = compiler::compile(html, "https://example.com").unwrap();
+    let search_region = som
+        .regions
+        .iter()
+        .find(|r| r.role == RegionRole::Navigation && r.label.as_deref() == Some("Site search"))
+        .expect("native search element should compile as a labelled navigation region");
+
+    assert!(search_region
+        .elements
+        .iter()
+        .any(|e| e.role == ElementRole::TextInput));
+}
+
+#[test]
 fn test_action_semantics_conformance_fixture() {
     let html = std::fs::read_to_string("specs/conformance/016-action-semantics.html")
         .expect("action semantics fixture should load");


### PR DESCRIPTION
## Summary

ARIA `role="search"` already compiled as a labelled navigation region. The native HTML `<search>` landmark did not, so agents lost the query surface on pages that use the element.

This maps `<search>` through the existing landmark path (`search` → navigation). One compiler surface, one fixture.

## Proof

Focused: `cargo test --test som_compiler_test test_native_search_element_maps_to_navigation_region`

## Governor notes

Distinct from #177 picture-img fallback and the prohibited extract_text / area / SDK copies. Does not reopen selector matching.

Plasmate MCP fetches this run: `https://docs.plasmate.app` (extract_text, extract_links) and `https://plasmate.app` (fetch_page).