### PR TITLE
docs(automation): narrow hourly after #179

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-24)
 
-- Window: `fd34284` .. `87cc9a8`
+- Window: `f4ec07b` .. `f383513`
 - Decision: `NARROW`
-- Merged this run: #177
+- Merged this run: #179
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -57,11 +57,13 @@ overwrite, reset, or absorb unrelated work.
   Do not copy #175 `extract_text` compiled-label fallback onto CLI, CDP,
   parser, or SDK text extractors. Do not copy #177 `<picture>` nested-img
   src/alt inheritance onto extract_links, CLI, CDP, or adjacent tags
-  (`object`, `embed`, `source`).
+  (`object`, `embed`, `source`). Do not copy #179 native `<search>`
+  landmark mapping onto extract_links, CLI, CDP, selectors, or adjacent
+  tags (`form`, `object`, `embed`, `source`).
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
-  or picture-img fallback copy.
+  picture-img fallback copy, or native-search landmark copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary

Record the 2026-08-24 NARROW decision after merging #179. Native `<search>` already maps through the landmark path. Prohibit one-surface copies onto extractors, selectors, and adjacent tags.

## Proof

Docs-only constraint update. Focused compiler proof for the merged change:

`cargo test --test som_compiler_test test_native_search_element_maps_to_navigation_region`

## Governor notes

No product code. Closes the hourly copy-lane after #179.

Plasmate MCP fetches this run: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).