### PR TITLE
docs(automation): narrow hourly after #183

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,11 +33,11 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-08-24)
+## Active governor constraint (2026-08-25)
 
-- Window: `b201c4a` .. `b00837d`
+- Window: `be4ebb4` .. `9b99e8d`
 - Decision: `NARROW`
-- Merged this run: #181
+- Merged this run: #183
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -62,12 +62,14 @@ overwrite, reset, or absorb unrelated work.
   tags (`form`, `object`, `embed`, `source`). Do not copy #181
   `hidden="until-found"` compile work onto extract_text, CLI, CDP,
   extract_links, or adjacent hide attributes (`aria-hidden`,
-  `style=display:none`).
+  `style=display:none`). Do not copy #183 click compiled `html_id`
+  lookup onto adjacent handlers (`clear`, `toggle`, `select_option`) or
+  SDKs; `type_text` already has this path.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
-  picture-img fallback copy, native-search landmark copy, or
-  hidden-until-found copy.
+  picture-img fallback copy, native-search landmark copy,
+  hidden-until-found copy, or click compiled-html_id lookup copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Record the 2026-08-25 NARROW governor decision after merging #183.
- #183 resolves click targets by compiled `html_id`. Prohibit one-surface copies onto adjacent handlers (`clear`, `toggle`, `select_option`) or SDKs; `type_text` already has this path.

## Proof
- Docs-only change to `docs/automation/HOURLY_BUILDER_LOOP.md`.
- Focused review of #183: `cargo test --bin plasmate click_ -- --test-threads=1` — `click_resolves_compiled_html_id_when_data_plasmate_id_is_absent` and `click_dom_miss_fails_closed_and_preserves_session` passed.

## Plasmate
Fetched https://docs.plasmate.app (selector=main).