### PR TITLE
fix(sdk): map Node openPage from flat MCP SOM

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -33,6 +33,34 @@ describe('read selectors', () => {
   });
 });
 
+describe('openPage payload', () => {
+  it('builds session.som from the flat MCP open_page fields', async () => {
+    const browser = new Plasmate({ binary: 'unused' });
+    const client = browser as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+    client.callTool = async (name, args) => {
+      assert.equal(name, 'open_page');
+      assert.deepEqual(args, { url: 'fixture' });
+      return {
+        session_id: 's1',
+        title: 'Example',
+        url: 'https://example.test/',
+        cache_restored: false,
+        regions: [{ id: 'r_main', role: 'main', elements: [] }],
+      };
+    };
+
+    const session = await browser.openPage('fixture');
+    assert.equal(session.sessionId, 's1');
+    assert.equal(session.som.title, 'Example');
+    assert.equal(session.som.url, 'https://example.test/');
+    assert.equal(session.som.regions.length, 1);
+    assert.equal(session.som.regions[0]?.id, 'r_main');
+    browser.close();
+  });
+});
+
 describe('protocol lifecycle', () => {
   it('uses a true notification for initialized', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'plasmate-node-sdk-'));

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -83,6 +83,42 @@ export interface PageSession {
   som: Som;
 }
 
+interface OpenPagePayload {
+  session_id?: string;
+  som?: Som;
+  title?: string;
+  url?: string;
+  lang?: string;
+  som_version?: string;
+  regions?: Som['regions'];
+  meta?: Som['meta'];
+  structured_data?: Som['structured_data'];
+}
+
+function emptySomMeta(): Som['meta'] {
+  return {
+    html_bytes: 0,
+    som_bytes: 0,
+    element_count: 0,
+    interactive_count: 0,
+  };
+}
+
+function somFromOpenPage(result: OpenPagePayload): Som {
+  if (result.som && typeof result.som === 'object') {
+    return result.som;
+  }
+  return {
+    som_version: result.som_version ?? '1.0',
+    url: result.url ?? '',
+    title: result.title ?? '',
+    lang: result.lang ?? '',
+    regions: Array.isArray(result.regions) ? result.regions : [],
+    meta: result.meta ?? emptySomMeta(),
+    ...(result.structured_data ? { structured_data: result.structured_data } : {}),
+  };
+}
+
 export interface PlasmateOptions {
   /** Path to the plasmate binary. Default: "plasmate" (found in PATH) */
   binary?: string;
@@ -329,11 +365,11 @@ export class Plasmate extends EventEmitter {
    * @param url - URL to open
    */
   async openPage(url: string): Promise<PageSession> {
-    const result = await this.callTool('open_page', { url }) as {
-      session_id: string;
-      som: Som;
+    const result = await this.callTool('open_page', { url }) as OpenPagePayload;
+    return {
+      sessionId: result.session_id ?? '',
+      som: somFromOpenPage(result),
     };
-    return { sessionId: result.session_id, som: result.som };
   }
 
   /**


### PR DESCRIPTION
## Summary
Node `openPage` treated the MCP `open_page` result as `{ session_id, som }`. The live tool returns a flat payload (`session_id`, `title`, `url`, `regions`), so `session.som` was undefined and agents could not read click/type targets after opening a page.

This maps those top-level fields into the advertised `{ sessionId, som }` session object.

## Proof
Focused `sdk/node` tests (`npm test`): 39 passed, including `builds session.som from the flat MCP open_page fields`.

## Governor notes
- Distinct from #160–#187 compiler/attr/fail-closed/docs copies.
- One surface: Node `openPage` only. No MCP wire change, no Python/Go copy.
- Plasmate MCP fetch: `https://docs.plasmate.app` (and changelog/SOM spec/MCP integration pages).