### PR TITLE
fix(langchain): call MCP type_text from PlasmateBrowser

### DIFF
--- a/integrations/langchain/langchain_plasmate/tools.py
+++ b/integrations/langchain/langchain_plasmate/tools.py
@@ -60,7 +60,7 @@ class PlasmateBrowser:
         """Type *text* into an element in the current session."""
         self._require_session()
         return self.client._call_tool(
-            "type",
+            "type_text",
             {
                 "session_id": self.session_id,
                 "element_id": element_id,

--- a/integrations/langchain/tests/test_tools.py
+++ b/integrations/langchain/tests/test_tools.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from langchain_plasmate import (
+    PlasmateBrowser,
     PlasmateClickTool,
     PlasmateFetchTool,
     PlasmateNavigateTool,
@@ -136,3 +137,22 @@ def test_fetch_tool_async_forwards_fetch_options() -> None:
         javascript=False,
         selector="main",
     )
+
+
+def test_browser_type_text_calls_mcp_type_text() -> None:
+    client = Mock()
+    client._call_tool.return_value = _som()
+    browser = PlasmateBrowser(client=client)
+    browser.session_id = "sess-1"
+
+    result = browser.type_text("e1", "hello")
+
+    client._call_tool.assert_called_once_with(
+        "type_text",
+        {
+            "session_id": "sess-1",
+            "element_id": "e1",
+            "text": "hello",
+        },
+    )
+    assert result == _som()


### PR DESCRIPTION
## Summary
LangChain `PlasmateBrowser.type_text` called the MCP tool `"type"`, which does not exist. The live tool is `"type_text"`, so advertised form-fill through `get_plasmate_tools()` failed with `Unknown tool: type`.

This routes the existing wrapper to `"type_text"`. No Python SDK method add.

## Proof
Focused LangChain tests (`integrations/langchain`): 8 passed, including `test_browser_type_text_calls_mcp_type_text`.

## Governor notes
- Distinct from #160–#187 compiler/attr/fail-closed/docs copies and from open #189 Node `openPage` flat SOM.
- One surface: LangChain `PlasmateBrowser.type_text` MCP tool name only.
- Plasmate MCP fetch: `https://plasmate.app`, `https://docs.plasmate.app`, `https://docs.plasmate.app/som-spec`, `https://docs.plasmate.app/changelog`.