### PR TITLE
fix(mcp): toggle compiled ARIA switch targets

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2254,7 +2254,7 @@ pub fn scroll_definition() -> ToolDefinition {
 pub fn toggle_definition() -> ToolDefinition {
     ToolDefinition {
         name: "toggle".to_string(),
-        description: "Toggle a checkbox, radio button, or details/summary widget by its SOM element ID. Returns the updated page SOM.".to_string(),
+        description: "Toggle a checkbox, radio button, details/summary widget, or ARIA switch/checkbox by its SOM element ID. Returns the updated page SOM.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -2825,6 +2825,7 @@ pub async fn handle_toggle(
                     return JSON.stringify({{ error: 'Element not found in DOM' }});
                 }}
                 var tag = el.tagName.toUpperCase();
+                var role = (el.getAttribute('role') || '').toLowerCase();
                 if (tag === 'INPUT' && (el.type === 'checkbox' || el.type === 'radio')) {{
                     el.checked = !el.checked;
                     var changeEvt = new Event('change', {{ bubbles: true }});
@@ -2835,8 +2836,15 @@ pub async fn handle_toggle(
                     var toggleEvt = new Event('toggle', {{ bubbles: true }});
                     el.dispatchEvent(toggleEvt);
                     return JSON.stringify({{ toggled: true, open: el.open }});
+                }} else if (role === 'switch' || role === 'checkbox' || role === 'menuitemcheckbox' || role === 'radio' || role === 'menuitemradio') {{
+                    var checked = (el.getAttribute('aria-checked') || '').toLowerCase() === 'true';
+                    el.setAttribute('aria-checked', checked ? 'false' : 'true');
+                    el.dispatchEvent(new Event('click', {{ bubbles: true }}));
+                    el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                    return JSON.stringify({{ toggled: true, checked: !checked }});
                 }} else {{
-                    return JSON.stringify({{ error: 'Element is not a checkbox, radio button, or details element' }});
+                    return JSON.stringify({{ error: 'Element is not a checkbox, radio button, details, or ARIA switch' }});
                 }}
             }})()
             "#,
@@ -3641,6 +3649,62 @@ mod tests {
         let payload = tool_payload(&clicked);
         assert_eq!(payload["title"], "Pay");
         assert!(payload["regions"].is_array(), "{payload}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn toggle_flips_compiled_aria_switch() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Alerts</title></head><body><main><!-- __fixture_aria_switch__ --><button role='switch' id='alerts' aria-checked='true'>Email alerts</button></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_url = Some("https://example.test/alerts".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/alerts").unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        let element_id = sessions
+            .with_session(&session_id, |session| {
+                let som = session.target.current_som.as_ref().unwrap();
+                som.regions
+                    .iter()
+                    .flat_map(|region| region.elements.iter())
+                    .find(|element| {
+                        element.role == ElementRole::Checkbox
+                            && element.html_id.as_deref() == Some("alerts")
+                    })
+                    .map(|element| element.id.clone())
+                    .expect("seeded page must expose the ARIA switch")
+            })
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let toggled = handle_toggle(
+            &json!({"session_id": session_id, "element_id": element_id}),
+            &client,
+            &sessions,
+        )
+        .await;
+        assert!(toggled.get("isError").is_none(), "{toggled}");
+        let payload = tool_payload(&toggled);
+        assert_eq!(payload["title"], "Alerts");
+        let switch = payload["regions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .flat_map(|region| region["elements"].as_array().into_iter().flatten())
+            .find(|element| element["html_id"] == "alerts")
+            .expect("toggled SOM must keep the ARIA switch");
+        assert_eq!(switch["role"], "checkbox", "{switch}");
+        assert_eq!(switch["attrs"]["aria"]["checked"], false, "{switch}");
     }
 
     #[tokio::test]

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -39,5 +39,17 @@ fn main() {
         }
         return;
     }
+    if input.contains("__fixture_aria_switch__") {
+        if input.contains("role") && input.contains("switch") && input.contains("aria-checked") {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"toggled\":true,\"checked\":false}}","effective_html":"<html><head><title>Alerts</title></head><body><main><!-- __fixture_aria_switch__ --><button role='switch' id='alerts' aria-checked='false'>Email alerts</button></main></body></html>"}}}}"#
+            );
+        } else {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"error\":\"Element is not a checkbox, radio button, or details element\"}}","effective_html":"<html><body><p>mutated</p></body></html>"}}}}"#
+            );
+        }
+        return;
+    }
     println!(r#"{{"status":"evaluation","value":{{"result":"ok"}}}}"#);
 }


### PR DESCRIPTION
## Summary
- Compiler already maps `role=switch` / `role=checkbox` / `role=menuitemcheckbox` to SOM checkbox targets with `toggle`.
- MCP `toggle` only mutated native `<input type=checkbox|radio>` and `<details>`, so agents following the action plan failed on ARIA switches.
- Flip `aria-checked` and dispatch click/input/change on those compiled widgets. Native input and details paths are unchanged.

## Proof
- Focused: `cargo test --bin plasmate toggle_flips_compiled_aria_switch`
- `cargo fmt --check` on the two changed files
- Did not run the full suite (hourly builder timebox)

## Governor
Distinct from recent compiler attr copies and from click/`type_text` fail-closed copies. Does not add html_id lookup or disabled/readonly fail-closed to toggle.