### PR TITLE
fix(sdk): accept compiled time, meter, and hidden attrs

### DIFF
--- a/sdk/python/src/plasmate/types.py
+++ b/sdk/python/src/plasmate/types.py
@@ -170,6 +170,11 @@ class ElementAttrs(BaseModel):
     allow: Optional[str] = None
     width: Optional[str] = None
     height: Optional[str] = None
+    datetime: Optional[str] = None
+    hidden: Optional[Union[bool, str]] = None
+    low: Optional[str] = None
+    high: Optional[str] = None
+    optimum: Optional[str] = None
 
 
 class SomElement(BaseModel):

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -708,3 +708,63 @@ class TestPydanticModels:
     def test_select_option(self) -> None:
         opt = SelectOption(value="us", text="United States", selected=True)
         assert opt.selected is True
+
+    def test_model_validate_accepts_compiled_time_meter_and_hidden_attrs(self) -> None:
+        som = Som.model_validate(
+            {
+                "som_version": "1.0",
+                "url": "https://example.test/status",
+                "title": "Status",
+                "lang": "en",
+                "regions": [
+                    {
+                        "id": "r1",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e1",
+                                "role": "paragraph",
+                                "html_id": "published",
+                                "text": "Shipped",
+                                "attrs": {"datetime": "2026-08-25"},
+                            },
+                            {
+                                "id": "e2",
+                                "role": "group",
+                                "html_id": "quota",
+                                "text": "40",
+                                "attrs": {
+                                    "source_role": "meter",
+                                    "value": "40",
+                                    "low": "20",
+                                    "high": "80",
+                                    "optimum": "50",
+                                },
+                            },
+                            {
+                                "id": "e3",
+                                "role": "paragraph",
+                                "html_id": "note",
+                                "text": "Findable",
+                                "attrs": {"hidden": "until-found"},
+                            },
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 1,
+                    "som_bytes": 1,
+                    "element_count": 3,
+                    "interactive_count": 0,
+                },
+            }
+        )
+        published, quota, note = som.regions[0].elements
+        assert published.attrs is not None
+        assert published.attrs.datetime == "2026-08-25"
+        assert quota.attrs is not None
+        assert quota.attrs.low == "20"
+        assert quota.attrs.high == "80"
+        assert quota.attrs.optimum == "50"
+        assert note.attrs is not None
+        assert note.attrs.hidden == "until-found"


### PR DESCRIPTION
## Summary
Python `ElementAttrs` uses `extra="forbid"`, so `Som.model_validate` rejected current compiler output for `<time datetime>`, `hidden="until-found"`, and `<meter low/high/optimum>`.

This adds those compiled fields on the official Python SDK types only. Node/Go keep unknown JSON fields at runtime and are unchanged.

## Proof
`cd sdk/python && PYTHONPATH=src python3 -m pytest tests/test_query.py::TestPydanticModels::test_model_validate_accepts_compiled_time_meter_and_hidden_attrs tests/test_query.py::TestPydanticModels::test_rejects_extra_fields tests/test_query.py::TestPydanticModels::test_som_roundtrip -v`

3 passed.

## Governor notes
- Journey: Python typed SOM rejects shipped compiler attrs (SDK compatibility, not another compile-tag copy).
- Not a copy of #181/#185/#191 onto extract_text, CLI, CDP, extract_links, or adjacent tags.
- Did not add the same fields to Node, Go, parser packages, or docs.
- Focused local proof only; no full-repo verify.

Plasmate MCP reads this run: https://docs.plasmate.app and https://plasmate.app