### PR TITLE
docs(automation): narrow hourly after #208

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-26)
 
-- Window: `07a6ff0` .. `e7faf42`
+- Window: `750612b` .. `e2f31ae`
 - Decision: `NARROW`
-- Merged this run: #206
+- Merged this run: #208
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -97,7 +97,10 @@ overwrite, reset, or absorb unrelated work.
   Do not copy #206 file-input omit `type`/`clear` onto `type_text` /
   `clear` mutation, extract_text, CLI, CDP, or SDKs; do not add an upload
   API, a new file role, or html_id lookup, and do not extend the omit to
-  adjacent input types (`password`, `hidden`, `range`).
+  adjacent input types (`password`, `hidden`, `range`). Do not copy #208
+  `<ol>` `start`/`reversed` compile work onto extract_text, CLI, CDP,
+  extract_links, or SDKs; do not add `type` / `li value`, invent defaults
+  on plain lists, or copy those attrs onto `ul`.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -108,8 +111,8 @@ overwrite, reset, or absorb unrelated work.
   progress/meter compile copy, toggle ARIA-switch copy, wrapping-label
   without control-id compile copy, native-radio select_option copy,
   video src/poster compile copy, inspect compact form action/method copy,
-  img usemap compile copy, inspect compact link href copy, or file-input
-  type/clear omit copy.
+  img usemap compile copy, inspect compact link href copy, file-input
+  type/clear omit copy, or ol start/reversed compile copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
The next hourly builder must not copy #208 `<ol>` `start`/`reversed` compile attrs onto extractors, CLI, CDP, or SDKs.

## Hypothesis
Updating the active governor constraint to `NARROW` after merging #208 keeps the hourly loop on a distinct missed regression.

## Change
- `docs/automation/HOURLY_BUILDER_LOOP.md`: window `750612b` .. `e2f31ae`, merged #208, prohibit start/reversed extractor copies and default/ul invention.

## Proof
Docs-only governance constraint. Focused review of the hourly contract diff.

## Governor notes
- Lands the post-#208 NARROW so the next builder cannot reopen this surface.
- Required review is not a human blocker.