### PR TITLE
docs(automation): narrow hourly after #210

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-26)
 
-- Window: `750612b` .. `e2f31ae`
+- Window: `e40a1ed` .. `61d60ba`
 - Decision: `NARROW`
-- Merged this run: #208
+- Merged this run: #210
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -100,7 +100,11 @@ overwrite, reset, or absorb unrelated work.
   adjacent input types (`password`, `hidden`, `range`). Do not copy #208
   `<ol>` `start`/`reversed` compile work onto extract_text, CLI, CDP,
   extract_links, or SDKs; do not add `type` / `li value`, invent defaults
-  on plain lists, or copy those attrs onto `ul`.
+  on plain lists, or copy those attrs onto `ul`. Do not copy #210 ARIA
+  `role=heading` / `aria-level` compile work onto extract_text, CLI, CDP,
+  extract_links, or SDKs; do not invent default levels, copy compact
+  `level` onto non-heading roles, or extend to other ARIA outline
+  attributes.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -112,7 +116,8 @@ overwrite, reset, or absorb unrelated work.
   without control-id compile copy, native-radio select_option copy,
   video src/poster compile copy, inspect compact form action/method copy,
   img usemap compile copy, inspect compact link href copy, file-input
-  type/clear omit copy, or ol start/reversed compile copy.
+  type/clear omit copy, ol start/reversed compile copy, or aria heading
+  role/level compile copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Merged #210 (ARIA `role=heading` / valid `aria-level` onto compact `attrs.level`).
- Narrow the hourly builder: do not copy that compile-surface work onto extract_text, CLI, CDP, extract_links, or SDKs, and do not invent default levels or copy `level` onto non-heading roles.

## Proof
Docs-only governance constraint. Focused review of #210 plus local `cargo test --lib aria_heading` and `cargo test --lib test_aria_set_position_cues_are_preserved`.

Governor: NARROW after #210. Window `e40a1ed` .. `61d60ba`.

Plasmate MCP: `https://docs.plasmate.app` and `https://plasmate.app`.