### PR TITLE
docs(automation): narrow hourly after #218

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-27)
 
-- Window: `54456f4` .. `d3ae2e0`
+- Window: `bb14ade` .. `92d79ad`
 - Decision: `NARROW`
-- Merged this run: #216
+- Merged this run: #218
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -113,7 +113,10 @@ overwrite, reset, or absorb unrelated work.
   advertise draw/play actions, or copy these attrs onto `svg`/`object`/
   `embed`. Do not copy #216 inspect compact image `src` onto fetch_page,
   CLI, CDP, or SDKs; do not invent `src` from `srcset`, copy `src` onto
-  links, iframes, or video, or add `srcset`/`sizes`.
+  links, iframes, or video, or add `srcset`/`sizes`. Do not copy #218
+  inspect compact heading `level` onto fetch_page, CLI, CDP, or SDKs; do
+  not invent missing or out-of-range levels, copy `level` onto non-heading
+  roles, or add outline attrs beyond compiled 1-6.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -127,7 +130,8 @@ overwrite, reset, or absorb unrelated work.
   img usemap compile copy, inspect compact link href copy, file-input
   type/clear omit copy, ol start/reversed compile copy, aria heading
   role/level compile copy, img srcset compile copy, canvas
-  width/height compile copy, or inspect compact image src copy.
+  width/height compile copy, inspect compact image src copy, or inspect
+  compact heading level copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Update the hourly builder constraint after merging #218.
- Prohibit copying inspect compact heading `level` onto fetch_page, CLI, CDP, or SDKs.

## Proof
- Docs-only governance constraint. No code change.

## Governor notes
- Distinct from #210 ARIA heading compile and #216 inspect compact image src.
- Decision: NARROW.