### PR TITLE
docs(automation): narrow hourly after #227

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,11 +33,11 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-08-27)
+## Active governor constraint (2026-08-28)
 
-- Window: `6d4b122` .. `236eeee`
+- Window: `9ccaa96` .. `ecf5a0c`
 - Decision: `NARROW`
-- Merged this run: #224, #225
+- Merged this run: #227
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -129,7 +129,10 @@ overwrite, reset, or absorb unrelated work.
   links or paragraphs. Do not copy #225 inspect compact control `name`
   onto fetch_page, CLI, CDP, or SDKs; do not invent missing or
   whitespace names, copy `name` onto paragraphs or unnamed links, or
-  add `id`/`for`.
+  add `id`/`for`. Do not copy #227 native element `lang` compile work
+  onto extract_text, CLI, CDP, extract_links, or adjacent attributes
+  (`xml:lang`, `dir`, `translate`); do not inherit `html lang`, invent
+  whitespace/absent lang, or copy `hreflang` into `lang`.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -145,8 +148,8 @@ overwrite, reset, or absorb unrelated work.
   role/level compile copy, img srcset compile copy, canvas
   width/height compile copy, inspect compact image src copy, inspect
   compact heading level copy, blockquote cite compile copy, area
-  shape/coords compile copy, autofocus compile copy, or inspect compact
-  control name copy.
+  shape/coords compile copy, autofocus compile copy, inspect compact
+  control name copy, or element lang compile copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Narrow the hourly builder after merging #227 (native element `lang` compile).
- Prohibit copying that one-surface compile onto extract_text, CLI, CDP, extract_links, or adjacent attributes.

## Proof
Docs-only governance constraint. Reviewed against `ecf5a0c` (merge of #227).

Plasmate MCP fetched: https://docs.plasmate.app