### PR TITLE
fix(sdk): keep Python SOM parse when compiler attrs outpace the typed model

### DIFF
--- a/sdk/python/src/plasmate/types.py
+++ b/sdk/python/src/plasmate/types.py
@@ -93,7 +93,7 @@ class ListItem(BaseModel):
 class ElementAttrs(BaseModel):
     """Role-specific attributes for an element."""
 
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "allow"}
 
     href: Optional[str] = None
     target: Optional[str] = None

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -686,6 +686,47 @@ class TestPydanticModels:
                 unknown_field="oops",
             )
 
+    def test_element_attrs_preserve_unmodeled_compiled_fields(self) -> None:
+        som = Som.model_validate(
+            {
+                "som_version": "0.1",
+                "url": "https://example.test/fr",
+                "title": "Accueil",
+                "lang": "fr",
+                "regions": [
+                    {
+                        "id": "r_main",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e1",
+                                "role": "link",
+                                "text": "Accueil",
+                                "actions": ["click"],
+                                "attrs": {
+                                    "href": "/fr",
+                                    "lang": "fr",
+                                    "autofocus": True,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 32,
+                    "som_bytes": 16,
+                    "element_count": 1,
+                    "interactive_count": 1,
+                },
+            }
+        )
+        attrs = som.regions[0].elements[0].attrs
+        assert attrs is not None
+        dumped = attrs.model_dump(exclude_none=True)
+        assert dumped["href"] == "/fr"
+        assert dumped["lang"] == "fr"
+        assert dumped["autofocus"] is True
+
     def test_validates_level_range(self) -> None:
         attrs = ElementAttrs(level=3)
         assert attrs.level == 3


### PR DESCRIPTION
## Summary
Python `ElementAttrs` used `extra=forbid`, so `Som.model_validate` failed on compiled element attrs the typed model does not yet name (including `lang` and `autofocus` after #227/#224). Allow unknown fields on `ElementAttrs` only. Structural models stay fail-closed.

## Proof
`cd sdk/python && PYTHONPATH=src python3 -m pytest tests/ -v` — 83 passed.

## Governor notes
Not a lang/autofocus compile copy onto extract_text, CLI, CDP, or extract_links. One SDK parse-compat fix so agents can load current compiler output.

Plasmate MCP: https://plasmate.app and https://docs.plasmate.app