### PR TITLE
docs(automation): narrow hourly after #231

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-28)
 
-- Window: `2db3ca9` .. `80dd27f`
+- Window: `4c9a9a5` .. `1d96eac`
 - Decision: `NARROW`
-- Merged this run: #229
+- Merged this run: #231
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -136,7 +136,11 @@ overwrite, reset, or absorb unrelated work.
   #229 Python `ElementAttrs` extra=allow onto Node or Go SDKs, CLI,
   CDP, parsers, or other Python models (`Som`, `Region`, `Element`);
   structural models stay fail-closed. Do not add named `lang` /
-  `autofocus` fields to Python `ElementAttrs` as a follow-on.
+  `autofocus` fields to Python `ElementAttrs` as a follow-on. Do not
+  copy #231 textarea `.value` IDL child-text mapping onto `select`,
+  `contenteditable`, `clear` handler changes, or SDK wrappers; do not
+  invent a textarea `value` content attribute or change input attribute
+  persistence.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -153,8 +157,8 @@ overwrite, reset, or absorb unrelated work.
   width/height compile copy, inspect compact image src copy, inspect
   compact heading level copy, blockquote cite compile copy, area
   shape/coords compile copy, autofocus compile copy, inspect compact
-  control name copy, element lang compile copy, or Python ElementAttrs
-  extra=allow copy.
+  control name copy, element lang compile copy, Python ElementAttrs
+  extra=allow copy, or textarea value IDL child-text copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Governor NARROW after merging #231.

## Hypothesis
The next hourly run will otherwise copy textarea `.value` IDL child-text mapping onto `select`, `contenteditable`, `clear`, or SDK wrappers.

## Before
Hourly constraint still named #229 and allowed textarea IDL copies.

## After
Window `4c9a9a5` .. `1d96eac`; prohibited #231 copies; allowed-next excludes textarea value IDL child-text copy.

## Proof
Docs-only governance constraint. Focused product proof for #231 already landed: `cargo test --lib textarea_value_idl_updates_child_text_for_som` and `cargo test --lib js::runtime::tests::test_dom_` (19 pass).

Governor: merge on local proof. Do not leave this PR open.