### PR TITLE
docs(automation): narrow hourly after #235

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-28)
 
-- Window: `e0d0bb3` .. `e7a7feb`
+- Window: `d3d9094` .. `bc17318`
 - Decision: `NARROW`
-- Merged this run: #233
+- Merged this run: #235
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -143,7 +143,10 @@ overwrite, reset, or absorb unrelated work.
   persistence. Do not copy #233 inspect compact `disabled` onto
   fetch_page, CLI, CDP, or SDKs; do not invent missing disabled, copy it
   onto paragraphs or unnamed links, or add `readonly` / `required`
-  compact fields.
+  compact fields. Do not copy #235 inspect compact `checked` onto
+  fetch_page, CLI, CDP, or SDKs; do not invent missing checked, copy it
+  onto paragraphs, buttons, or links, add `readonly` / `required`
+  compact fields, or read `attrs.aria.checked`.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -161,8 +164,8 @@ overwrite, reset, or absorb unrelated work.
   compact heading level copy, blockquote cite compile copy, area
   shape/coords compile copy, autofocus compile copy, inspect compact
   control name copy, element lang compile copy, Python ElementAttrs
-  extra=allow copy, textarea value IDL child-text copy, or inspect
-  compact disabled copy.
+  extra=allow copy, textarea value IDL child-text copy, inspect
+  compact disabled copy, or inspect compact checked copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Decision
NARROW after merging #235.

## Window
`d3d9094` .. `bc17318`

## Why
#235 copied compiled checkbox/radio `checked` onto inspect compact SOM. Hourly must not copy that field onto fetch_page, CLI, CDP, or SDKs, invent missing checked, or add `readonly` / `required` / `aria.checked`.

## Proof
Docs-only governance constraint. Product proof for #235: `cargo test --lib inspection::` (11 passed).

Plasmate MCP: https://plasmate.app and https://docs.plasmate.app.

Governor: merge on local proof.