### PR TITLE
docs(automation): narrow hourly after #243

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-29)
 
-- Window: `0929266` .. `a12bc22`
+- Window: `2eadf9d` .. `67f4eb2`
 - Decision: `NARROW`
-- Merged this run: #239
+- Merged this run: #243
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -155,6 +155,17 @@ overwrite, reset, or absorb unrelated work.
   `contenteditable`, `clear` handler changes, or SDK wrappers; do not
   invent an `open` content attribute on non-details tags, change checkbox
   `checked` or textarea value persistence, or add inspect compact `open`.
+  Do not copy #241 select `.options` / `.selectedIndex` IDL onto `input`,
+  `textarea`, `contenteditable`, `clear` handler changes, or SDK wrappers;
+  do not invent `selected` on non-option tags, change textarea value or
+  details open persistence, or add inspect compact `selectedIndex`.
+  Do not copy #242 table `rowspan` grid fill onto extract_text, CLI, CDP,
+  SDKs, or adjacent tags (`ul`, `ol`, `dl`); do not invent a compiled
+  `rowspan` attr, change `colspan`, or copy table headers onto lists.
+  Do not copy #243 input/textarea `.readOnly` IDL onto `select`,
+  `contenteditable`, `dialog`, paragraphs, `clear`/`toggle`/`select_option`
+  handlers, or SDK wrappers; do not invent readonly on non-field tags,
+  change disabled IDL, or add inspect compact `readonly`.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -174,7 +185,8 @@ overwrite, reset, or absorb unrelated work.
   control name copy, element lang compile copy, Python ElementAttrs
   extra=allow copy, textarea value IDL child-text copy, inspect
   compact disabled copy, inspect compact checked copy, inspect
-  compact value copy, or details open IDL copy.
+  compact value copy, details open IDL copy, select selectedIndex
+  IDL copy, table rowspan grid copy, or input readOnly IDL copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Governor NARROW after #241, #242, and #243. Hourly must not copy select selectedIndex, table rowspan grid fill, or input readOnly IDL onto adjacent tags or inspect compact.

## Hypothesis
Recording the prohibitions in the active governor constraint is safer than letting the next hourly run clone those surfaces.

## Before
- Constraint still named #239 and allowed select-selectedIndex, rowspan-grid, and input-readOnly follow-ons

## After
- Window `2eadf9d` .. `67f4eb2`, merged #243
- Prohibits #241 copies onto input/textarea/contenteditable/clear/SDK wrappers and inspect compact selectedIndex
- Prohibits #242 copies onto extract_text/CLI/CDP/SDKs and lists
- Prohibits #243 copies onto select/contenteditable/dialog/paragraphs/clear/toggle/select_option/SDK wrappers and inspect compact readonly

## Proof
Docs-only constraint update. Focused review of `docs/automation/HOURLY_BUILDER_LOOP.md`. No runtime change.

Plasmate MCP: https://docs.plasmate.app and https://plasmate.app

Governor: merge on local proof.