### PR TITLE
fix(js): resolve labelable control labels

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,11 +33,11 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-08-29)
+## Active governor constraint (2026-08-30)
 
-- Window: `189a11c` .. `9e60fbf`
+- Window: `b44d06e` .. `02b6078`
 - Decision: `NARROW`
-- Merged this run: #245 #246 (already on master)
+- Merged this run: `02b6078` labelable `.labels` (already on master)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -175,6 +175,10 @@ overwrite, reset, or absorb unrelated work.
   (`aria-hidden`, `style=display:none`); do not change `hidden="until-found"`
   compile behavior, invent hidden on untouched elements, or add inspect
   compact `hidden`.
+  Do not copy labelable control `.labels` onto `button`, `meter`,
+  `progress`, `output`, `click`/`clear`/`toggle` handlers, SDKs, or
+  inspect compact fields; do not add `htmlFor` IDL or invent labels on
+  paragraphs.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -196,7 +200,8 @@ overwrite, reset, or absorb unrelated work.
   compact disabled copy, inspect compact checked copy, inspect
   compact value copy, details open IDL copy, select selectedIndex
   IDL copy, table rowspan grid copy, input readOnly IDL copy,
-  field required IDL copy, or element hidden IDL copy.
+  field required IDL copy, element hidden IDL copy, or labelable
+  control `.labels` copy.
 
 ## Preferred lanes
 

--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -1293,6 +1293,35 @@ Object.defineProperty(PlasElement.prototype, 'name', {
     set: function(v) { this._attrs.name = v; }
 });
 
+Object.defineProperty(PlasElement.prototype, 'labels', {
+    get: function() {
+        if (this.tagName !== 'INPUT' && this.tagName !== 'TEXTAREA' && this.tagName !== 'SELECT') {
+            return undefined;
+        }
+        var results = [];
+        var id = this.id;
+        if (id) {
+            var all = document.getElementsByTagName('label');
+            for (var i = 0; i < all.length; i++) {
+                if (all[i].getAttribute('for') === id) {
+                    results.push(all[i]);
+                }
+            }
+        }
+        var ancestor = this.parentNode;
+        while (ancestor && ancestor.nodeType === Node.ELEMENT_NODE) {
+            if (ancestor.tagName === 'LABEL') {
+                if (!ancestor.getAttribute('for')) {
+                    results.push(ancestor);
+                }
+                break;
+            }
+            ancestor = ancestor.parentNode;
+        }
+        return results;
+    }
+});
+
 Object.defineProperty(PlasElement.prototype, 'href', {
     get: function() { return this._attrs.href || ''; },
     set: function(v) { this._attrs.href = v; }
@@ -6815,6 +6844,118 @@ mod tests {
                 .is_none_or(|attrs| attrs.get("hidden").is_none()),
             "untouched button must not compile hidden: {go:?}"
         );
+    }
+
+    #[test]
+    fn labelable_control_labels_include_for_and_wrapping_labels() {
+        let mut rt = JsRuntime::new(RuntimeConfig {
+            inject_dom_shim: true,
+            execute_inline_scripts: false,
+            ..Default::default()
+        });
+        rt.bootstrap_dom(
+            r#"<html><body><label for="plan">Billing plan</label><input id="plan" type="radio" name="plan" value="pro"><label><input id="email" type="radio" name="contact" value="email"> Email</label><p id="note">Just text</p><button id="go">Go</button></body></html>"#,
+            "https://example.test/labels",
+        );
+
+        let plan_count = rt
+            .execute_in_context(
+                "String(document.getElementById('plan').labels.length)",
+                "test.js",
+            )
+            .unwrap();
+        let plan_text = rt
+            .execute_in_context(
+                "document.getElementById('plan').labels[0].textContent.replace(/\\s+/g, ' ').trim()",
+                "test.js",
+            )
+            .unwrap();
+        let email_count = rt
+            .execute_in_context(
+                "String(document.getElementById('email').labels.length)",
+                "test.js",
+            )
+            .unwrap();
+        let email_text = rt
+            .execute_in_context(
+                "document.getElementById('email').labels[0].textContent.replace(/\\s+/g, ' ').trim()",
+                "test.js",
+            )
+            .unwrap();
+        let note_labels = rt
+            .execute_in_context("String(document.getElementById('note').labels)", "test.js")
+            .unwrap();
+        let go_labels = rt
+            .execute_in_context("String(document.getElementById('go').labels)", "test.js")
+            .unwrap();
+        assert_eq!(plan_count, "1");
+        assert_eq!(plan_text, "Billing plan");
+        assert_eq!(email_count, "1");
+        assert_eq!(email_text, "Email");
+        assert_eq!(note_labels, "undefined");
+        assert_eq!(go_labels, "undefined");
+
+        rt.execute_in_context(
+            r#"
+            (function() {
+                var el = document.getElementById('email');
+                var wanted = 'Email';
+                var labelText = '';
+                if (el.labels && el.labels.length) {
+                    labelText = (el.labels[0].textContent || '').replace(/\s+/g, ' ').trim();
+                }
+                if (el.value !== wanted && labelText !== wanted) {
+                    throw new Error('Option not found: ' + wanted);
+                }
+                var radios = document.getElementsByTagName('input');
+                for (var j = 0; j < radios.length; j++) {
+                    if (radios[j].type === 'radio' && radios[j].name === el.name) {
+                        radios[j].checked = false;
+                    }
+                }
+                el.checked = true;
+            })();
+            "#,
+            "test.js",
+        )
+        .unwrap();
+
+        let serialized = rt.serialize_dom().unwrap();
+        let som =
+            crate::som::compiler::compile(&serialized, "https://example.test/labels").unwrap();
+        let elements: Vec<_> = som
+            .regions
+            .iter()
+            .flat_map(|region| region.elements.iter())
+            .collect();
+        let email = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("email"))
+            .expect("email radio should compile");
+        assert_eq!(
+            email.attrs.as_ref().and_then(|attrs| attrs.get("checked")),
+            Some(&serde_json::json!(true))
+        );
+        let plan = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("plan"))
+            .expect("plan radio should compile");
+        assert!(
+            plan.attrs
+                .as_ref()
+                .is_none_or(|attrs| attrs.get("checked").is_none()),
+            "unrelated radio must stay independent: {plan:?}"
+        );
+        let note = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("note"))
+            .expect("note paragraph should compile");
+        assert_eq!(note.role, crate::som::types::ElementRole::Paragraph);
+        let go = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("go"))
+            .expect("go button should compile");
+        assert_eq!(go.role, crate::som::types::ElementRole::Button);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Expose INPUT/TEXTAREA/SELECT `.labels` from `for=` and wrapping `<label>` so `select_option` can match radios by visible label text.
- Narrow the hourly builder away from copying `.labels` onto adjacent tags, handlers, SDKs, or inspect compact fields.

## Proof
- `cargo test --lib labelable_control_labels_include_for_and_wrapping_labels`

## Governor
No open PRs targeted master. This lands the focused correction on default.