### PR TITLE
fix(js): persist field placeholder through placeholder

### DIFF
--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -1293,6 +1293,21 @@ Object.defineProperty(PlasElement.prototype, 'name', {
     set: function(v) { this._attrs.name = v; }
 });
 
+Object.defineProperty(PlasElement.prototype, 'placeholder', {
+    get: function() {
+        if (this.tagName !== 'INPUT' && this.tagName !== 'TEXTAREA') {
+            return '';
+        }
+        return this.getAttribute('placeholder') || '';
+    },
+    set: function(v) {
+        if (this.tagName !== 'INPUT' && this.tagName !== 'TEXTAREA') {
+            return;
+        }
+        this.setAttribute('placeholder', String(v));
+    }
+});
+
 Object.defineProperty(PlasElement.prototype, 'labels', {
     get: function() {
         if (this.tagName !== 'INPUT' && this.tagName !== 'TEXTAREA' && this.tagName !== 'SELECT') {
@@ -6956,6 +6971,173 @@ mod tests {
             .find(|element| element.html_id.as_deref() == Some("go"))
             .expect("go button should compile");
         assert_eq!(go.role, crate::som::types::ElementRole::Button);
+    }
+
+    #[test]
+    fn input_placeholder_idl_updates_placeholder_attribute_for_som() {
+        let mut rt = JsRuntime::new(RuntimeConfig {
+            inject_dom_shim: true,
+            execute_inline_scripts: false,
+            ..Default::default()
+        });
+        rt.bootstrap_dom(
+            r#"<html><body><input id="name" value="a"><textarea id="notes" placeholder="Old hint">Draft</textarea><p id="note">Just text</p><select id="plan"><option value="free" selected>Free</option></select><div id="editor" contenteditable="true">Edit me</div></body></html>"#,
+            "https://example.test/hint",
+        );
+
+        let before_name = rt
+            .execute_in_context(
+                "String(document.getElementById('name').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let before_notes = rt
+            .execute_in_context(
+                "String(document.getElementById('notes').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let before_note = rt
+            .execute_in_context(
+                "String(document.getElementById('note').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let before_plan = rt
+            .execute_in_context(
+                "String(document.getElementById('plan').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let before_editor = rt
+            .execute_in_context(
+                "String(document.getElementById('editor').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        assert_eq!(before_name, "");
+        assert_eq!(before_notes, "Old hint");
+        assert_eq!(before_note, "");
+        assert_eq!(before_plan, "");
+        assert_eq!(before_editor, "");
+
+        rt.execute_in_context(
+            "document.getElementById('name').placeholder = 'Full name'; document.getElementById('notes').placeholder = 'Updated notes'; document.getElementById('note').placeholder = 'Invented'; document.getElementById('plan').placeholder = 'Invented'; document.getElementById('editor').placeholder = 'Invented';",
+            "test.js",
+        )
+        .unwrap();
+
+        let after_name = rt
+            .execute_in_context(
+                "String(document.getElementById('name').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let after_notes = rt
+            .execute_in_context(
+                "String(document.getElementById('notes').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let after_note = rt
+            .execute_in_context(
+                "String(document.getElementById('note').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let after_plan = rt
+            .execute_in_context(
+                "String(document.getElementById('plan').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        let after_editor = rt
+            .execute_in_context(
+                "String(document.getElementById('editor').placeholder)",
+                "test.js",
+            )
+            .unwrap();
+        assert_eq!(after_name, "Full name");
+        assert_eq!(after_notes, "Updated notes");
+        assert_eq!(after_note, "");
+        assert_eq!(after_plan, "");
+        assert_eq!(after_editor, "");
+
+        let serialized = rt.serialize_dom().unwrap();
+        assert!(
+            serialized.contains("id=\"name\"") && serialized.contains("placeholder=\"Full name\""),
+            "named input must persist placeholder: {serialized}"
+        );
+        assert!(
+            serialized.contains("id=\"notes\"")
+                && serialized.contains("placeholder=\"Updated notes\""),
+            "textarea must persist placeholder: {serialized}"
+        );
+        assert!(
+            !serialized.contains("id=\"note\" placeholder")
+                && !serialized.contains("placeholder=\"Invented\""),
+            "paragraphs, selects, and contenteditable must not invent placeholder: {serialized}"
+        );
+
+        let som = crate::som::compiler::compile(&serialized, "https://example.test/hint").unwrap();
+        let elements: Vec<_> = som
+            .regions
+            .iter()
+            .flat_map(|region| region.elements.iter())
+            .collect();
+        let name = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("name"))
+            .expect("name input should compile");
+        assert_eq!(
+            name.attrs
+                .as_ref()
+                .and_then(|attrs| attrs.get("placeholder")),
+            Some(&serde_json::json!("Full name"))
+        );
+        let notes = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("notes"))
+            .expect("notes textarea should compile");
+        assert_eq!(
+            notes
+                .attrs
+                .as_ref()
+                .and_then(|attrs| attrs.get("placeholder")),
+            Some(&serde_json::json!("Updated notes"))
+        );
+        let note = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("note"))
+            .expect("note paragraph should compile");
+        assert_eq!(note.role, crate::som::types::ElementRole::Paragraph);
+        assert!(
+            note.attrs
+                .as_ref()
+                .is_none_or(|attrs| attrs.get("placeholder").is_none()),
+            "paragraphs must not compile placeholder: {note:?}"
+        );
+        let plan = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("plan"))
+            .expect("plan select should compile");
+        assert!(
+            plan.attrs
+                .as_ref()
+                .is_none_or(|attrs| attrs.get("placeholder").is_none()),
+            "selects must not compile placeholder: {plan:?}"
+        );
+        let editor = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("editor"))
+            .expect("editor should compile");
+        assert!(
+            editor
+                .attrs
+                .as_ref()
+                .is_none_or(|attrs| attrs.get("placeholder").is_none()),
+            "contenteditable must not compile placeholder: {editor:?}"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## Journey
JS-assigned `input.placeholder` / `textarea.placeholder` hints were own properties, so post-JS SOM dropped the typing hint the compiler already knows how to surface.

## Hypothesis
Reflecting `placeholder` only on `INPUT` and `TEXTAREA` onto the content attribute lets serialization keep the hint without inventing it on select, contenteditable, or paragraphs.

## Proof
Focused: `cargo test --lib input_placeholder_idl`
- 1 passed; 492 filtered out

## Scope
- One IDL reflector in `src/js/runtime.rs`
- No extract_text / CLI / CDP / SDK / inspect-compact copy
- No `type_text` / `clear` mutation change

Plasmate MCP: `https://plasmate.app` and `https://docs.plasmate.app` (extract_text).