### PR TITLE
docs(automation): narrow hourly after #253

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-30)
 
-- Window: `03c2ef5` .. `9f9815e`
+- Window: `2af4b9a` .. `206bcaf`
 - Decision: `NARROW`
-- Merged this run: `9f9815e` field `setSelectionRange`/`select` (already on master)
+- Merged this run: `206bcaf` form `.elements` (already on master)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -187,6 +187,10 @@ overwrite, reset, or absorb unrelated work.
   tags, `selectionStart`/`selectionEnd`/`setRangeText`, handlers, or SDK
   wrappers; do not invent compiled caret/selection attrs or inspect
   compact selection fields.
+  Do not copy #253 form `.elements` IDL onto fieldset, `document.forms`,
+  RadioNodeList, form named getters, inspect compact fields, CLI, CDP, or
+  SDKs; do not invent `elements` on non-form tags or compile the collection
+  as an attribute.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -209,8 +213,8 @@ overwrite, reset, or absorb unrelated work.
   compact value copy, details open IDL copy, select selectedIndex
   IDL copy, table rowspan grid copy, input readOnly IDL copy,
   field required IDL copy, element hidden IDL copy, labelable
-  control `.labels` copy, field placeholder IDL copy, or field
-  setSelectionRange/select copy.
+  control `.labels` copy, field placeholder IDL copy, field
+  setSelectionRange/select copy, or form `.elements` IDL copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Hourly JS IDL copies keep stacking adjacent form APIs. #253 already landed `form.elements` so listed control updates persist.

## Hypothesis
NARROW the next hourly run away from fieldset, `document.forms`, RadioNodeList, form named getters, inspect compact fields, CLI, CDP, and SDKs.

## Proof
Docs-only constraint update. Product proof for this window is the already-merged focused test `form_elements_idl_updates_listed_controls_for_som`.

## Scope
`docs/automation/HOURLY_BUILDER_LOOP.md` only.

Fetched via Plasmate MCP: `https://plasmate.app`.