### PR TITLE
docs(automation): narrow hourly after #255 and #256

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-08-30)
 
-- Window: `2af4b9a` .. `206bcaf`
+- Window: `6a40645` .. `61e35f7`
 - Decision: `NARROW`
-- Merged this run: `206bcaf` form `.elements` (already on master)
+- Merged this run: `81ec738` field `.maxLength` and `61e35f7` textarea `rows`/`cols` (already on master)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -191,6 +191,14 @@ overwrite, reset, or absorb unrelated work.
   RadioNodeList, form named getters, inspect compact fields, CLI, CDP, or
   SDKs; do not invent `elements` on non-form tags or compile the collection
   as an attribute.
+  Do not copy #255 input/textarea `.maxLength` IDL onto `select`,
+  `contenteditable`, paragraphs, `clear`/`type_text` handlers, or SDK
+  wrappers; do not invent maxlength on non-field tags, change
+  value/readonly IDL, add `minLength`, or add inspect compact `maxlength`.
+  Do not copy #256 textarea `rows`/`cols` compile onto extract_text, CLI,
+  CDP, extract_links, input, select, paragraphs, or SDKs; do not invent
+  HTML defaults (2/20), add JS `rows`/`cols` IDL, or change table
+  `attrs.rows`.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -214,7 +222,8 @@ overwrite, reset, or absorb unrelated work.
   IDL copy, table rowspan grid copy, input readOnly IDL copy,
   field required IDL copy, element hidden IDL copy, labelable
   control `.labels` copy, field placeholder IDL copy, field
-  setSelectionRange/select copy, or form `.elements` IDL copy.
+  setSelectionRange/select copy, form `.elements` IDL copy, field
+  maxLength IDL copy, or textarea rows/cols compile copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Merged #255 field `.maxLength` IDL and #256 textarea `rows`/`cols` compile onto master after focused local proof.
- Narrow the hourly builder: do not copy maxLength onto non-fields or textarea rows/cols onto extractors, input, select, or table grids.

## Proof
- Focused: #255 `cargo test --lib js::runtime::tests::input_maxlength_idl_updates_maxlength_attribute_for_som` (1 passed)
- Focused: #256 `cargo test --lib som::compiler::tests::test_textarea_rows_and_cols_are_compiled` (1 passed)
- Docs-only constraint update; no code change.

## Governor notes
- Decision: NARROW
- Window: `6a40645` .. `61e35f7`
- Plasmate MCP reads this run: `https://plasmate.app` (extract_text) and `https://docs.plasmate.app` (extract_text).