### PR TITLE
docs(automation): narrow hourly after #282

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-01)
 
-- Window: `f82b7e9` .. `9324ce0`
+- Window: `688d58b` .. `7db8cf6`
 - Decision: `NARROW`
-- Merged this run: `0ebcc44` input.accept IDL (`9324ce0`)
+- Merged this run: `155b7b8` inspect compact expanded (`7db8cf6`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -253,6 +253,10 @@ overwrite, reset, or absorb unrelated work.
   `contenteditable`, paragraphs, `clear`/`type_text` handlers, or SDK
   wrappers; do not invent accept on non-input tags, change pattern/
   min/max IDL, add inspect compact `accept`, or add upload APIs.
+  Do not copy #282 inspect compact `expanded` onto fetch_page, CLI, CDP,
+  or SDKs; do not invent missing expanded, copy it onto paragraphs or
+  checkboxes, read non-boolean compiled aria-expanded, or add
+  `aria-pressed` / `aria-selected` compact fields.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -283,8 +287,8 @@ overwrite, reset, or absorb unrelated work.
   insertRow/insertCell copy, select.add copy, toggleAttribute copy,
   ARIA alert/status live-region compile copy, form.reset copy,
   figcaption paragraph compile copy, input min/max IDL copy,
-  input pattern IDL copy, select value IDL copy, or input accept
-  IDL copy.
+  input pattern IDL copy, select value IDL copy, input accept
+  IDL copy, or inspect compact expanded copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
Governor NARROW after merging #282. Stop the next hourly from copying inspect compact `expanded` onto fetch_page, CLI, CDP, SDKs, or adjacent aria-pressed/selected fields.

## Proof
Docs-only constraint update. Focused inspect proof already passed on #282: `cargo test --lib compact_som_preserves_expanded`.

## Plasmate MCP
Fetched live `https://docs.plasmate.app`, `https://docs.plasmate.app/changelog`, and `https://plasmate.app` before merge.