### PR TITLE
fix(sdk): parse compiled description-list items in Python ListItem

### DIFF
--- a/sdk/python/src/plasmate/query.py
+++ b/sdk/python/src/plasmate/query.py
@@ -469,7 +469,7 @@ def find_action_target_by_label(
 
 
 def find_by_text(som: Som, text: str) -> List[SomElement]:
-    """Find all elements whose text, label, compiled list items, select options, table captions, or table cells contain the substring."""
+    """Find all elements whose text, label, compiled list items, description-list terms/descriptions, select options, table captions, or table cells contain the substring."""
     results: List[SomElement] = []
     lower = text.lower()
     for region in som.regions:
@@ -556,6 +556,10 @@ def _collect_by_text(element: SomElement, lower_text: str, results: List[SomElem
         parts.append(element.label)
     if element.attrs and element.attrs.items:
         parts.extend(item.text for item in element.attrs.items if item.text)
+        parts.extend(item.term for item in element.attrs.items if item.term)
+        parts.extend(
+            item.description for item in element.attrs.items if item.description
+        )
     if element.attrs and element.attrs.options:
         parts.extend(option.text for option in element.attrs.options if option.text)
     if element.attrs and element.attrs.caption:

--- a/sdk/python/src/plasmate/types.py
+++ b/sdk/python/src/plasmate/types.py
@@ -87,7 +87,9 @@ class ListItem(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    text: str
+    text: Optional[str] = None
+    term: Optional[str] = None
+    description: Optional[str] = None
 
 
 class ElementAttrs(BaseModel):

--- a/sdk/python/tests/test_query.py
+++ b/sdk/python/tests/test_query.py
@@ -492,6 +492,64 @@ class TestFindByText:
         assert find_by_text(som, "Configure")[0].id == "e_list"
         assert find_by_text(som, "zzz_no_match") == []
 
+    def test_finds_compiled_description_list_items(self) -> None:
+        som = Som.model_validate(
+            {
+                "som_version": "1.0",
+                "url": "https://example.test/glossary",
+                "title": "Glossary",
+                "lang": "en",
+                "regions": [
+                    {
+                        "id": "r_main",
+                        "role": "main",
+                        "elements": [
+                            {
+                                "id": "e_glossary",
+                                "role": "list",
+                                "html_id": "glossary",
+                                "attrs": {
+                                    "items": [
+                                        {
+                                            "term": "SOM",
+                                            "description": "Semantic Object Model",
+                                        },
+                                        {
+                                            "term": "AWP",
+                                            "description": "Agent Web Protocol",
+                                        },
+                                    ]
+                                },
+                            },
+                            {
+                                "id": "e_bullets",
+                                "role": "list",
+                                "html_id": "bullets",
+                                "attrs": {"items": [{"text": "Dot"}]},
+                            },
+                        ],
+                    }
+                ],
+                "meta": {
+                    "html_bytes": 100,
+                    "som_bytes": 50,
+                    "element_count": 2,
+                    "interactive_count": 0,
+                },
+            }
+        )
+
+        glossary = som.regions[0].elements[0]
+        items = glossary.attrs.items if glossary.attrs else None
+        assert items is not None
+        assert items[0].term == "SOM"
+        assert items[0].description == "Semantic Object Model"
+        assert items[0].text is None
+        assert find_by_text(som, "SOM")[0].id == "e_glossary"
+        assert find_by_text(som, "Semantic Object Model")[0].id == "e_glossary"
+        assert find_by_text(som, "Dot")[0].id == "e_bullets"
+        assert find_by_text(som, "zzz_no_match") == []
+
     def test_finds_compiled_table_captions(self) -> None:
         som = Som(
             som_version="1.0",
@@ -749,3 +807,17 @@ class TestPydanticModels:
     def test_select_option(self) -> None:
         opt = SelectOption(value="us", text="United States", selected=True)
         assert opt.selected is True
+
+    def test_list_item_accepts_compiled_description_list_fields(self) -> None:
+        item = ListItem.model_validate(
+            {"term": "SOM", "description": "Semantic Object Model"}
+        )
+        assert item.term == "SOM"
+        assert item.description == "Semantic Object Model"
+        assert item.text is None
+        bullet = ListItem.model_validate({"text": "Dot"})
+        assert bullet.text == "Dot"
+        assert bullet.term is None
+        assert bullet.description is None
+        with pytest.raises(Exception):
+            ListItem.model_validate({"text": "Dot", "unknown_field": "oops"})


### PR DESCRIPTION
## Summary
- Compiled `<dl>` items from #286 use `term`/`description` and omit `text`.
- Python `ListItem` was fail-closed with required `text`, so `Som.model_validate` rejected glossary SOMs and `find_by_text` could not search those terms.
- Keep `ListItem` fail-closed; add optional `term`/`description`; search them in `find_by_text`. Unordered-list `text` items are unchanged.

## Proof
- Before: `ListItem.model_validate({"term":"SOM","description":"Semantic Object Model"})` failed (3 validation errors).
- After: `PYTHONPATH=src python3 -m pytest tests/test_query.py -v` — 51 passed, including the new description-list parse and search tests.

## Governor notes
- Distinct from copying #286 compile work onto extract_text, CLI, CDP, or other SDKs.
- Node/Go types are untouched.
- Focused Python SDK proof only; no full-repo verify.