### PR TITLE
fix(sdk): expose type_text on the Python client

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -78,6 +78,7 @@ with Plasmate() as browser:
 - **`open_page(url)`** - Returns dict with `session_id` and `som`
 - **`evaluate(session_id, expression)`** - Run JS, get result
 - **`click(session_id, element_id)`** - Click element, get updated SOM
+- **`type_text(session_id, element_id, text, *, append=False)`** - Type into an input or textarea, get updated SOM
 - **`close_page(session_id)`** - Close session
 
 ### Lifecycle

--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -369,6 +369,35 @@ class Plasmate:
             "element_id": element_id,
         })
 
+    def type_text(
+        self,
+        session_id: str,
+        element_id: str,
+        text: str,
+        *,
+        append: bool = False,
+    ) -> dict:
+        """
+        Type text into a form input or textarea by its SOM element ID.
+
+        Args:
+            session_id: Session ID from open_page
+            element_id: Element ID from SOM (e.g. 'e5')
+            text: Text to type into the element
+            append: If true, append instead of replacing. Default: false
+
+        Returns:
+            Updated SOM after typing
+        """
+        args: dict[str, Any] = {
+            "session_id": session_id,
+            "element_id": element_id,
+            "text": text,
+        }
+        if append:
+            args["append"] = True
+        return self._call_tool("type_text", args)
+
     def close_page(self, session_id: str) -> None:
         """
         Close a browser session and free resources.
@@ -557,6 +586,24 @@ class AsyncPlasmate:
             "session_id": session_id,
             "element_id": element_id,
         })
+
+    async def type_text(
+        self,
+        session_id: str,
+        element_id: str,
+        text: str,
+        *,
+        append: bool = False,
+    ) -> dict:
+        """Type text into a form input or textarea by its SOM element ID."""
+        args: dict[str, Any] = {
+            "session_id": session_id,
+            "element_id": element_id,
+            "text": text,
+        }
+        if append:
+            args["append"] = True
+        return await self._call_tool("type_text", args)
 
     async def close_page(self, session_id: str) -> None:
         """Close a browser session and free resources."""

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -39,3 +39,40 @@ def test_async_read_methods_forward_selector() -> None:
         ]
 
     asyncio.run(exercise())
+
+
+def test_sync_type_text_forwards_session_target_and_append() -> None:
+    browser = Plasmate()
+    calls = Mock(side_effect=[{}, {}])
+    browser._call_tool = calls  # type: ignore[method-assign]
+
+    assert browser.type_text("s1", "e5", "hello") == {}
+    assert browser.type_text("s1", "e5", "!", append=True) == {}
+
+    assert calls.call_args_list == [
+        call("type_text", {"session_id": "s1", "element_id": "e5", "text": "hello"}),
+        call(
+            "type_text",
+            {"session_id": "s1", "element_id": "e5", "text": "!", "append": True},
+        ),
+    ]
+
+
+def test_async_type_text_forwards_session_target_and_append() -> None:
+    async def exercise() -> None:
+        browser = AsyncPlasmate()
+        calls = AsyncMock(side_effect=[{}, {}])
+        browser._call_tool = calls  # type: ignore[method-assign]
+
+        assert await browser.type_text("s1", "e5", "hello") == {}
+        assert await browser.type_text("s1", "e5", "!", append=True) == {}
+
+        assert calls.call_args_list == [
+            call("type_text", {"session_id": "s1", "element_id": "e5", "text": "hello"}),
+            call(
+                "type_text",
+                {"session_id": "s1", "element_id": "e5", "text": "!", "append": True},
+            ),
+        ]
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Summary
- Python `open_page`/`click` could not fill forms: sync and async clients had no `type_text` wrapper.
- Forward `type_text` with optional `append` to the existing MCP tool. Node/Go clients, handlers, and other integrations are untouched.

## Proof
- Before: `Plasmate.type_text` / `AsyncPlasmate.type_text` were missing.
- After: `cd sdk/python && PYTHONPATH=src python3 -m pytest tests/test_client.py -v` — 4 passed, including the new forward/append tests.

## Governor notes
- Distinct from #190 LangChain `type_text` tool-name rename.
- Distinct from copying #286 description-list compile work onto SDKs (#288).
- Does not add `clear`/`toggle`/`select_option`, html_id lookup, or disabled fail-closed copies.
- Focused Python SDK proof only; no full-repo verify.

Plasmate MCP: fetched https://plasmate.app and https://docs.plasmate.app/sdk-python.