### PR TITLE
docs(automation): narrow hourly after #303

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,11 +33,11 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-09-02)
+## Active governor constraint (2026-09-03)
 
-- Window: `4942f9c` .. `c8510a8`
+- Window: `46f7346` .. `8929c23`
 - Decision: `NARROW`
-- Merged this run: `220e3d9` querySelector `:empty` (`c8510a8`)
+- Merged this run: `d1e52ea` document.getElementsByName (`8929c23`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -298,6 +298,9 @@ overwrite, reset, or absorb unrelated work.
   Do not copy #301 querySelector `:empty` onto other pseudos
   (`:disabled`, `:required`, `:nth-child`, `:blank`), later-sibling
   (`~`), extract_text, CLI, CDP, SDKs, or inspect compact fields.
+  Do not copy #303 document.getElementsByName onto form.elements,
+  document.forms, RadioNodeList, form named getters, extract_text, CLI,
+  CDP, SDKs, or inspect compact fields.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -335,7 +338,8 @@ overwrite, reset, or absorb unrelated work.
   querySelector :checked copy, listed-control form owner IDL copy,
   optgroup.label IDL copy, input/select multiple IDL copy,
   querySelector adjacent-sibling combinator copy,
-  HTMLElement tabIndex IDL copy, or querySelector :empty copy.
+  HTMLElement tabIndex IDL copy, querySelector :empty copy, or
+  document.getElementsByName copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
Hourly builder must not copy #303 `document.getElementsByName` onto form collections, extractors, or SDKs.

## Proof
Docs-only NARROW after merge of #303 (`d1e52ea` / `8929c23`). Focused lib test `get_elements_by_name_fills_named_control_for_som` already passed on this machine.

Plasmate MCP: `https://plasmate.app`.