### PR TITLE
docs(automation): narrow hourly after #308

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-03)
 
-- Window: `5a189dc` .. `f262508`
+- Window: `a773e09` .. `6fc9bdf`
 - Decision: `NARROW`
-- Merged this run: `e4be6af` autocomplete IDL (`d30f5e2`) and `51a0638` HTMLElement.title IDL (`f262508`)
+- Merged this run: `95d111b` HTMLElement.contentEditable IDL (`6fc9bdf`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -307,6 +307,10 @@ overwrite, reset, or absorb unrelated work.
   Do not copy #306 HTMLElement.title IDL onto extract_text, CLI, CDP,
   SDKs, inspect compact fields, or adjacent attributes (`alt`, `lang`,
   `accesskey`, `tabIndex`).
+  Do not copy #308 HTMLElement.contentEditable IDL onto type_text /
+  clear mutation, extract_text, CLI, CDP, extract_links, SDKs, inspect
+  compact fields, or adjacent attributes (`spellcheck`, `inputmode`,
+  `enterkeyhint`).
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -346,7 +350,8 @@ overwrite, reset, or absorb unrelated work.
   querySelector adjacent-sibling combinator copy,
   HTMLElement tabIndex IDL copy, querySelector :empty copy,
   document.getElementsByName copy, form/listed-control autocomplete
-  IDL copy, or HTMLElement title IDL copy.
+  IDL copy, HTMLElement title IDL copy, or HTMLElement contentEditable
+  IDL copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
Governor NARROW after merging #308. Stops the next hourly from copying HTMLElement.contentEditable IDL onto type_text/clear mutation, extractors, SDKs, inspect compact fields, or adjacent attributes.

## Proof
Docs-only constraint update. Focused proof for #308 already ran: `cargo test content_editable_idl_compiles_type_target_for_som --lib`

Plasmate MCP fetch: `https://plasmate.app`

## Governor
Decision: NARROW. Window `a773e09` .. `6fc9bdf`. One governance correction, no product lane copy.