### PR TITLE
docs(automation): narrow hourly after #336

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-06)
 
-- Window: `ee3d76d` .. `8ba73e6`
+- Window: `94d66e8` .. `1898abb`
 - Decision: `NARROW`
-- Merged this run: `8d4b401` querySelector `:root` (`8ba73e6`)
+- Merged this run: `71bd522` querySelector unknown-pseudo fail-closed (`1898abb`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -364,6 +364,10 @@ overwrite, reset, or absorb unrelated work.
   (`:scope`, `:defined`, `:has`, `:is`, `:host`), extract_text, CLI, CDP,
   SDKs, or the native DOM bridge; do not invent `:root` on body, paragraphs,
   inputs, buttons, or textareas.
+  Do not copy #336 querySelector unknown-pseudo fail-closed onto
+  implementing `:hover`, `:nth-child`, `:disabled`, `:scope`, `:defined`,
+  `:has`, or `:is`; do not copy the switch default onto extract_text, CLI,
+  CDP, SDKs, or the native DOM bridge.
 - Allowed next (pick one distinct journey): a real missed regression, or
   a published-docs integration failure that is not another SDK install-path
   rewrite, SOM-reference field rewrite, extract_text label fallback copy,
@@ -411,7 +415,8 @@ overwrite, reset, or absorb unrelated work.
   copy, HTMLElement popover IDL copy, querySelector :only-child
   copy, querySelector :default copy, input/button type IDL copy,
   a/area hash IDL copy, querySelector :placeholder-shown copy,
-  or querySelector :root copy.
+  querySelector :root copy, or querySelector unknown-pseudo
+  fail-closed copy.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Governor NARROW after merging #336. Hourly must not copy unknown-pseudo fail-closed onto implementing `:hover`, `:nth-child`, `:disabled`, or adjacent extractors.

## Hypothesis
Updating the active constraint is safer than letting the next hourly implement those pseudos or copy the switch default onto CLI/CDP/SDKs.

## Proof
Docs-only. Reviewed `docs/automation/HOURLY_BUILDER_LOOP.md`. Window `94d66e8` .. `1898abb`. Merged `71bd522` via #336 after focused `cargo test --lib query_selector_unknown_pseudo` and `query_selector_root_pseudo`.

## Scope
- `docs/automation/HOURLY_BUILDER_LOOP.md` only

Plasmate MCP reads this run: `https://plasmate.app` and `https://docs.plasmate.app`