### PR TITLE
fix(js): match querySelector :invalid

### DIFF
--- a/src/js/runtime.rs
+++ b/src/js/runtime.rs
@@ -2286,6 +2286,26 @@ function _isEnabledControl(el) {
     return true;
 }
 
+function _isInvalidControl(el) {
+    var tag = el.tagName;
+    if (tag !== 'INPUT' && tag !== 'SELECT' && tag !== 'TEXTAREA') {
+        return false;
+    }
+    if (!_isEnabledControl(el)) return false;
+    if ((tag === 'INPUT' || tag === 'TEXTAREA') && el.readOnly) return false;
+    if (tag === 'INPUT') {
+        var invalidType = String(el.type || '').toLowerCase();
+        if (invalidType === 'hidden' || invalidType === 'button' || invalidType === 'reset' ||
+            invalidType === 'submit' || invalidType === 'image' || invalidType === 'checkbox' ||
+            invalidType === 'radio' || invalidType === 'file' || invalidType === 'range' ||
+            invalidType === 'color') {
+            return false;
+        }
+    }
+    if (!el.required) return false;
+    return String(el.value || '') === '';
+}
+
 // CSS Selector matching (basic support)
 function _matchesSelector(el, selector) {
     if (!selector || el.nodeType !== Node.ELEMENT_NODE) return false;
@@ -2545,6 +2565,9 @@ function _matchesSimpleSelector(el, selector) {
                 break;
             case 'enabled':
                 if (!_isEnabledControl(el)) return false;
+                break;
+            case 'invalid':
+                if (!_isInvalidControl(el)) return false;
                 break;
             case 'root':
                 if (el !== document.documentElement) return false;
@@ -14423,6 +14446,114 @@ mod tests {
         assert_eq!(
             broken.attrs.as_ref().and_then(|attrs| attrs.get("value")),
             Some(&serde_json::json!("held"))
+        );
+        let pay = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("pay"))
+            .expect("pay button should compile");
+        assert_eq!(pay.role, crate::som::types::ElementRole::Button);
+        let note = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("note"))
+            .expect("note paragraph should compile");
+        assert_eq!(note.role, crate::som::types::ElementRole::Paragraph);
+        assert_eq!(note.text.as_deref(), Some("Just text"));
+        let notes = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("notes"))
+            .expect("notes textarea should compile");
+        assert_eq!(notes.role, crate::som::types::ElementRole::Textarea);
+        assert_eq!(notes.text.as_deref(), Some("draft"));
+    }
+
+    #[test]
+    fn query_selector_invalid_pseudo_compiles_required_empty_field_for_som() {
+        let mut rt = JsRuntime::new(RuntimeConfig {
+            inject_dom_shim: true,
+            execute_inline_scripts: false,
+            ..Default::default()
+        });
+        rt.bootstrap_dom(
+            r#"<html><body><form id="checkout"><input id="email" name="email" required value=""><input id="ok" name="ok" required value="ops@example.com"><input id="optional" name="optional" value=""><input id="blocked" name="blocked" required value="" disabled><input id="locked" name="locked" required value="" readonly><button id="pay">Pay</button><p id="note">Just text</p><textarea id="notes">draft</textarea></form></body></html>"#,
+            "https://example.test/invalid-pseudo",
+        );
+
+        let before = rt
+            .execute_in_context(
+                r#"[
+                    document.querySelector('input:invalid') ? document.querySelector('input:invalid').id : 'none',
+                    String(document.querySelectorAll('input:invalid').length),
+                    String(document.querySelector('#ok:invalid')),
+                    String(document.querySelector('#optional:invalid')),
+                    String(document.querySelector('#blocked:invalid')),
+                    String(document.querySelector('#locked:invalid')),
+                    String(document.querySelector('p:invalid')),
+                    String(document.querySelector('button:invalid')),
+                    String(document.querySelector('textarea:invalid')),
+                    String(document.querySelector('input:valid'))
+                ].join('|')"#,
+                "test.js",
+            )
+            .unwrap();
+        assert_eq!(before, "email|1|null|null|null|null|null|null|null|null");
+
+        rt.execute_in_context(
+            r#"
+            var field = document.querySelector('input:invalid');
+            if (field) field.value = 'ready@example.com';
+            var ok = document.querySelector('#ok:invalid');
+            if (ok) ok.value = 'should-not-write';
+            var optional = document.querySelector('#optional:invalid');
+            if (optional) optional.value = 'should-not-write';
+            var blocked = document.querySelector('#blocked:invalid');
+            if (blocked) blocked.value = 'should-not-write';
+            var locked = document.querySelector('#locked:invalid');
+            if (locked) locked.value = 'should-not-write';
+            "#,
+            "test.js",
+        )
+        .unwrap();
+
+        let serialized = rt.serialize_dom().unwrap();
+        assert!(
+            serialized.contains("id=\"email\"")
+                && serialized.contains("value=\"ready@example.com\""),
+            "checkout JS must persist the :invalid input value: {serialized}"
+        );
+        assert!(
+            serialized.contains("id=\"ok\"")
+                && serialized.contains("value=\"ops@example.com\"")
+                && serialized.contains("id=\"optional\"")
+                && serialized.contains("id=\"blocked\"")
+                && serialized.contains("id=\"locked\"")
+                && serialized.contains("Just text")
+                && serialized.contains(">draft</textarea>"),
+            "valid, optional, barred fields, paragraphs, and textareas must stay intact: {serialized}"
+        );
+
+        let som = crate::som::compiler::compile(&serialized, "https://example.test/invalid-pseudo")
+            .unwrap();
+        let elements: Vec<_> = som
+            .regions
+            .iter()
+            .flat_map(|region| region.elements.iter())
+            .collect();
+        let email = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("email"))
+            .expect("email input should compile");
+        assert_eq!(email.role, crate::som::types::ElementRole::TextInput);
+        assert_eq!(
+            email.attrs.as_ref().and_then(|attrs| attrs.get("value")),
+            Some(&serde_json::json!("ready@example.com"))
+        );
+        let ok = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("ok"))
+            .expect("ok input should compile");
+        assert_eq!(
+            ok.attrs.as_ref().and_then(|attrs| attrs.get("value")),
+            Some(&serde_json::json!("ops@example.com"))
         );
         let pay = elements
             .iter()


### PR DESCRIPTION
## Summary
- Checkout pages copy a required empty field through `input:invalid`; that pseudo failed closed, so the corrected value never reached SOM.
- Match `:invalid` only for enabled, non-readonly text-like required INPUT/SELECT/TEXTAREA controls with an empty value. Paragraphs, buttons, optional/filled/disabled/readonly fields, and `:valid` stay unmatched.

## Proof
- Focused: cargo test --lib query_selector_invalid_pseudo_compiles_required_empty_field_for_som
- Plasmate MCP: https://docs.plasmate.app, https://plasmate.app, and https://docs.plasmate.app/coverage-js

## Governor notes
Distinct from `:enabled`, `:required`, `:optional`, `:checked`, `:default`, and `:placeholder-shown` copies. Does not implement `:valid`, pattern/type mismatch, or checkbox/radio/file invalidity.