### PR TITLE
fix(mcp): name close_page and live session ids on capacity errors

### DIFF
--- a/src/mcp/sessions.rs
+++ b/src/mcp/sessions.rs
@@ -128,9 +128,26 @@ impl SessionManager {
         let mut sessions = self.sessions.write().await;
 
         if sessions.len() >= MAX_SESSIONS {
+            let now = Instant::now();
+            let mut occupied: Vec<(u128, String)> = sessions
+                .iter()
+                .map(|(id, session)| {
+                    (
+                        now.saturating_duration_since(session.last_accessed)
+                            .as_millis(),
+                        id.clone(),
+                    )
+                })
+                .collect();
+            occupied.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+            let ids = occupied
+                .into_iter()
+                .map(|(_, id)| id)
+                .collect::<Vec<_>>()
+                .join(", ");
             return Err(format!(
-                "Maximum sessions ({}) reached. Close a session first.",
-                MAX_SESSIONS
+                "Maximum sessions ({}) reached. Call close_page on a live session_id: {}.",
+                MAX_SESSIONS, ids
             ));
         }
 
@@ -467,9 +484,18 @@ mod tests {
             session_ids.push(id);
         }
 
-        // Next one should fail
         let result = manager.create_session().await;
-        assert!(result.is_err());
+        let err = result.expect_err("capacity should reject the extra session");
+        assert!(err.contains("close_page"), "{err}");
+        assert!(
+            err.contains(&format!("Maximum sessions ({MAX_SESSIONS}) reached")),
+            "{err}"
+        );
+        for id in &session_ids {
+            assert!(err.contains(id), "missing {id} in {err}");
+        }
+        assert!(!err.contains("http"), "{err}");
+        assert!(!err.contains('/'), "{err}");
 
         // Close one and try again
         manager.close_session(&session_ids[0]).await;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1709,7 +1709,7 @@ pub fn click_definition() -> ToolDefinition {
 pub fn close_page_definition() -> ToolDefinition {
     ToolDefinition {
         name: "close_page".to_string(),
-        description: "Close a browser session and free resources.".to_string(),
+        description: "Close a browser session and free its slot. Use this when open_page reports maximum sessions reached; pass one live session_id from that error or from session_status.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -4425,6 +4425,37 @@ mod tests {
         assert_eq!(snapshot["effective_html_entries"], 1);
         assert_eq!(snapshot["total_effective_html_bytes"], 31);
         assert_eq!(snapshot["max_hot_entries"], 1000);
+    }
+
+    #[tokio::test]
+    async fn open_page_capacity_error_names_close_page_and_live_session_ids() {
+        let sessions = Arc::new(SessionManager::new());
+        let mut ids = Vec::new();
+        for _ in 0..crate::mcp::sessions::MAX_SESSIONS {
+            ids.push(sessions.create_session().await.unwrap());
+        }
+        let client = reqwest::Client::new();
+        let cache = Arc::new(SomCache::new(CacheConfig::default()));
+        let result = handle_open_page(
+            &json!({"url": "https://example.com/checkout"}),
+            &client,
+            &sessions,
+            &cache,
+        )
+        .await;
+
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("close_page"), "{text}");
+        for id in &ids {
+            assert!(text.contains(id), "missing {id} in {text}");
+        }
+        assert!(!text.contains("https://example.com/checkout"), "{text}");
+        assert!(!text.contains("http"), "{text}");
+
+        for id in ids {
+            assert!(sessions.close_session(&id).await);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Journey
Bounded agent-task recovery when MCP `open_page` hits the 10-session cap.

## Hypothesis
Capacity errors said “Close a session first” without naming `close_page` or listing live `session_id` values, so an agent could not free a slot without guessing.

## Change
- `create_session` lists live session IDs (longest-idle first) and names `close_page`
- IDs only — no URLs, titles, or page content
- `close_page` description tells agents to use those IDs when capacity is reached

## Proof
Focused, no network:
- `cargo test --bin plasmate mcp::sessions::tests::test_max_sessions`
- `cargo test --bin plasmate open_page_capacity_error_names_close_page`

Governor lane: not an IDL getter, querySelector pseudo, inspect-compact field, or compile-attr copy.

Plasmate MCP: `https://docs.plasmate.app` (extract_text).