### PR TITLE
docs(openclaw): discover MCP tools and drop missing in-tree copies

### DIFF
--- a/src/release_manifest.rs
+++ b/src/release_manifest.rs
@@ -1114,6 +1114,34 @@ mod tests {
     }
 
     #[test]
+    fn openclaw_docs_do_not_point_at_missing_in_tree_files_or_a_closed_tool_list() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for rel in [
+            "website/docs/src/integration-openclaw.md",
+            "website/docs/integration-openclaw.html",
+        ] {
+            let content = fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|error| panic!("read OpenClaw docs {rel}: {error}"));
+            assert!(
+                !content.contains("integrations/openclaw/"),
+                "{rel} still points at missing in-tree OpenClaw files"
+            );
+            assert!(
+                !content.contains("Available MCP tools:"),
+                "{rel} still hard-codes a closed MCP tool list"
+            );
+            assert!(
+                content.contains("tools/list"),
+                "{rel} should tell agents to discover MCP tools"
+            );
+            assert!(
+                content.contains("inspect") && content.contains("ARD"),
+                "{rel} should name inspection and ARD instead of omitting them"
+            );
+        }
+    }
+
+    #[test]
     fn public_claim_registry_matches_retained_coverage_evidence() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let registry: serde_json::Value = serde_json::from_str(

--- a/website/docs/integration-openclaw.html
+++ b/website/docs/integration-openclaw.html
@@ -461,12 +461,11 @@
 <p>Skill repo: <a href="https://github.com/plasmate-labs/skill-openclaw"><code>plasmate-labs/skill-openclaw</code></a></p>
 <h2 id="installation">Installation</h2><h3 id="install-plasmate">1. Install Plasmate</h3><pre><code class="language-bash">curl -fsSL https://plasmate.app/install.sh | sh
 </code></pre>
-<h3 id="install-the-skill">2. Install the skill</h3><pre><code class="language-bash">clawhub install plasmate
+<h3 id="install-the-skill-and-pf-wrapper">2. Install the skill and `pf` wrapper</h3><pre><code class="language-bash">clawhub install plasmate
 </code></pre>
-<p>Or manually copy <code>integrations/openclaw/SKILL.md</code> to <code>~/.openclaw/skills/plasmate/SKILL.md</code>.</p>
-<h3 id="install-the-pf-wrapper">3. Install the `pf` wrapper</h3><pre><code class="language-bash">cp integrations/openclaw/scripts/pf /usr/local/bin/pf
-chmod +x /usr/local/bin/pf
-</code></pre>
+<p>The skill and optional <code>pf</code> wrapper live in
+<a href="https://github.com/plasmate-labs/skill-openclaw"><code>plasmate-labs/skill-openclaw</code></a>.
+This repository does not ship those OpenClaw skill files.</p>
 <h2 id="quick-start">Quick Start</h2><p>Replace <code>web_fetch</code> calls with <code>pf</code>:</p>
 <pre><code class="language-bash"># Before
 web_fetch https://docs.stripe.com/api
@@ -495,7 +494,12 @@ estimates; use your model&#39;s tokenizer when evaluating an OpenClaw workflow.<
   }
 }
 </code></pre>
-<p>Available MCP tools: <code>fetch_page</code>, <code>extract_text</code>, <code>extract_links</code>, <code>cache_status</code>, <code>session_status</code>, <code>screenshot_page</code>, <code>open_page</code>, <code>navigate_to</code>, <code>click</code>, <code>type_text</code>, <code>select_option</code>, <code>scroll</code>, <code>toggle</code>, <code>clear</code>, <code>evaluate</code>, <code>close_page</code>, <code>get_cookies</code>, <code>set_cookies</code>, <code>clear_cookies</code>.</p>
+<p>The native server advertises its current tools through MCP <code>tools/list</code>; clients
+should discover them rather than depend on a hard-coded list. The surface
+includes stateless fetch, text/link extraction, ARD discovery, crawl-policy, and
+page inspection; cache, session, trace, and validation-only replay; screenshots
+and persistent page sessions; navigation and click/type/select/scroll/toggle/clear
+interactions; and cookie read, write, and clear operations.</p>
 <h2 id="cdp-mode-puppeteer-compatible">CDP Mode (Puppeteer-compatible)</h2><p>Run Plasmate&#39;s CDP compatibility server for workflows that use its documented
 supported Puppeteer/CDP subset:</p>
 <pre><code class="language-bash">plasmate serve --protocol cdp --port 9222

--- a/website/docs/src/integration-openclaw.md
+++ b/website/docs/src/integration-openclaw.md
@@ -12,20 +12,15 @@ Skill repo: [`plasmate-labs/skill-openclaw`](https://github.com/plasmate-labs/sk
 curl -fsSL https://plasmate.app/install.sh | sh
 ```
 
-### 2. Install the skill
+### 2. Install the skill and `pf` wrapper
 
 ```bash
 clawhub install plasmate
 ```
 
-Or manually copy `integrations/openclaw/SKILL.md` to `~/.openclaw/skills/plasmate/SKILL.md`.
-
-### 3. Install the `pf` wrapper
-
-```bash
-cp integrations/openclaw/scripts/pf /usr/local/bin/pf
-chmod +x /usr/local/bin/pf
-```
+The skill and optional `pf` wrapper live in
+[`plasmate-labs/skill-openclaw`](https://github.com/plasmate-labs/skill-openclaw).
+This repository does not ship those OpenClaw skill files.
 
 ## Quick Start
 
@@ -72,7 +67,12 @@ Add to your agent's MCP config:
 }
 ```
 
-Available MCP tools: `fetch_page`, `extract_text`, `extract_links`, `cache_status`, `session_status`, `screenshot_page`, `open_page`, `navigate_to`, `click`, `type_text`, `select_option`, `scroll`, `toggle`, `clear`, `evaluate`, `close_page`, `get_cookies`, `set_cookies`, `clear_cookies`.
+The native server advertises its current tools through MCP `tools/list`; clients
+should discover them rather than depend on a hard-coded list. The surface
+includes stateless fetch, text/link extraction, ARD discovery, crawl-policy, and
+page inspection; cache, session, trace, and validation-only replay; screenshots
+and persistent page sessions; navigation and click/type/select/scroll/toggle/clear
+interactions; and cookie read, write, and clear operations.
 
 ## CDP Mode (Puppeteer-compatible)
 


### PR DESCRIPTION
## Journey
Published-docs integration failure on the live OpenClaw guide.

## Hypothesis
https://docs.plasmate.app/integration-openclaw told agents to copy `integrations/openclaw/SKILL.md` and `scripts/pf` from this tree (those files are not shipped) and listed a closed MCP tool set that omitted inspect, ARD, crawl-policy, and traces.

## Change
- Point skill/`pf` install at ClawHub and `plasmate-labs/skill-openclaw`
- Replace the hard-coded MCP tool list with `tools/list` discovery
- Do not copy this onto Pi or other integration pages

## Proof
Focused, no network:
- `cargo test --lib openclaw_docs_do_not_point_at_missing_in_tree_files_or_a_closed_tool_list`

Governor lane: published-docs integration failure; not an SDK install-path, SOM-reference rewrite, IDL getter, querySelector pseudo, inspect-compact field, or compile-attr copy.

Plasmate MCP: `https://docs.plasmate.app` (fetch_page) and `https://docs.plasmate.app/integration-openclaw` (extract_text).