### PR TITLE
docs(crewai): wrap shipped Python SDK instead of a missing module

### DIFF
--- a/src/release_manifest.rs
+++ b/src/release_manifest.rs
@@ -1114,6 +1114,30 @@ mod tests {
     }
 
     #[test]
+    fn crewai_docs_use_shipped_python_sdk_not_a_missing_in_tree_module() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for rel in [
+            "website/docs/src/integration-crewai.md",
+            "website/docs/integration-crewai.html",
+        ] {
+            let content = fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|error| panic!("read CrewAI docs {rel}: {error}"));
+            assert!(
+                !content.contains("from plasmate.integrations.crewai"),
+                "{rel} still imports a missing CrewAI integration module"
+            );
+            assert!(
+                !content.contains("integrations/crewai/"),
+                "{rel} still points at missing in-tree CrewAI files"
+            );
+            assert!(
+                content.contains("from plasmate import Plasmate"),
+                "{rel} should use the shipped Python SDK"
+            );
+        }
+    }
+
+    #[test]
     fn openclaw_docs_do_not_point_at_missing_in_tree_files_or_a_closed_tool_list() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         for rel in [

--- a/website/docs/integration-crewai.html
+++ b/website/docs/integration-crewai.html
@@ -458,81 +458,52 @@
     </nav>
     <main class="content">
       <h1 id="crewai-integration">CrewAI Integration</h1><p>Give your CrewAI agents structured SOM pages instead of raw HTML scraping. The resulting context size depends on the page and model tokenizer.</p>
-<p>Source: <a href="https://github.com/plasmate-labs/plasmate/tree/master/integrations/crewai"><code>integrations/crewai/</code></a></p>
-<h2 id="installation">Installation</h2><pre><code class="language-bash">pip install plasmate crewai crewai-tools
+<p>This repository does not ship a <code>plasmate.integrations.crewai</code> package. Wrap the shipped <a href="sdk-python">Python SDK</a> as a CrewAI tool.</p>
+<h2 id="installation">Installation</h2><pre><code class="language-bash">pip install plasmate crewai
 </code></pre>
-<h2 id="quick-start">Quick Start</h2><pre><code class="language-python">from crewai import Agent, Task, Crew
-from plasmate.integrations.crewai import PlasmateWebTool
+<p>Requires the <code>plasmate</code> binary on your PATH.</p>
+<h2 id="quick-start">Quick Start</h2><pre><code class="language-python">from typing import Type
 
-# Create the Plasmate browsing tool
-browse = PlasmateWebTool()
+from crewai import Agent, Task, Crew
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from plasmate import Plasmate
 
-# Create an agent with web access
+
+class FetchPageInput(BaseModel):
+    url: str = Field(..., description=&quot;Public URL to fetch as SOM&quot;)
+
+
+class PlasmateFetchTool(BaseTool):
+    name: str = &quot;plasmate_fetch&quot;
+    description: str = (
+        &quot;Fetch a web page and return structured SOM instead of raw HTML.&quot;
+    )
+    args_schema: Type[BaseModel] = FetchPageInput
+
+    def _run(self, url: str) -&gt; str:
+        with Plasmate() as client:
+            return str(client.fetch_page(url))
+
+
 researcher = Agent(
     role=&quot;Web Researcher&quot;,
     goal=&quot;Find and summarize information from the web&quot;,
     backstory=&quot;Expert at extracting key information from web pages.&quot;,
-    tools=[browse],
+    tools=[PlasmateFetchTool()],
 )
 
-# Define a task
 task = Task(
     description=&quot;Research the top stories on Hacker News and summarize them.&quot;,
     expected_output=&quot;A bullet-point summary of the top 5 stories.&quot;,
     agent=researcher,
 )
 
-# Run the crew
 crew = Crew(agents=[researcher], tasks=[task])
 result = crew.kickoff()
 print(result)
 </code></pre>
-<h2 id="available-tools">Available Tools</h2><h3 id="plasmatewebtool">`PlasmateWebTool`</h3><p>Fetches a URL and returns SOM text. Use it in place of <code>ScrapeWebsiteTool</code> when your workflow benefits from semantic regions and indexed actions.</p>
-<pre><code class="language-python">from plasmate.integrations.crewai import PlasmateWebTool
-
-tool = PlasmateWebTool()
-# Agents invoke it automatically when they need web content
-</code></pre>
-<h3 id="plasmatebrowsetool">`PlasmateBrowseTool`</h3><p>Persistent browser session with navigate, click, and type actions for multi-step workflows.</p>
-<pre><code class="language-python">from plasmate.integrations.crewai import PlasmateBrowseTool
-
-tool = PlasmateBrowseTool()
-# Supports: navigate(url), click(index), type(index, text)
-</code></pre>
-<h2 id="why-plasmate-for-crewai">Why Plasmate for CrewAI?</h2><table>
-<thead>
-<tr>
-<th></th>
-<th>ScrapeWebsiteTool</th>
-<th>PlasmateWebTool</th>
-</tr>
-</thead>
-<tbody><tr>
-<td><strong>Output</strong></td>
-<td>Raw HTML/text</td>
-<td>Structured SOM</td>
-</tr>
-<tr>
-<td><strong>Context representation</strong></td>
-<td>Raw HTML/text</td>
-<td>Structured SOM</td>
-</tr>
-<tr>
-<td><strong>Interactive elements</strong></td>
-<td>Lost</td>
-<td>Indexed <code>[N]</code></td>
-</tr>
-<tr>
-<td><strong>Multi-step browsing</strong></td>
-<td>❌</td>
-<td>✅</td>
-</tr>
-<tr>
-<td><strong>Dependencies</strong></td>
-<td>requests + beautifulsoup</td>
-<td><code>plasmate</code> binary</td>
-</tr>
-</tbody></table>
+<h2 id="fetch-vs-scrape">Fetch vs scrape</h2><p>Use <code>Plasmate.fetch_page</code> in place of HTML scrapers when the crew needs semantic regions and actions. Persistent click/type flows use <code>open_page</code> on the same client; see the Python SDK.</p>
 <p>SOM removes non-semantic markup, but token and cost differences vary with the
 pages, prompts, and model tokenizer. Benchmark the full crew workflow before
 planning context or spend.</p>

--- a/website/docs/src/integration-crewai.md
+++ b/website/docs/src/integration-crewai.md
@@ -2,77 +2,64 @@
 
 Give your CrewAI agents structured SOM pages instead of raw HTML scraping. The resulting context size depends on the page and model tokenizer.
 
-Source: [`integrations/crewai/`](https://github.com/plasmate-labs/plasmate/tree/master/integrations/crewai)
+This repository does not ship a `plasmate.integrations.crewai` package. Wrap the shipped [Python SDK](sdk-python) as a CrewAI tool.
 
 ## Installation
 
 ```bash
-pip install plasmate crewai crewai-tools
+pip install plasmate crewai
 ```
+
+Requires the `plasmate` binary on your PATH.
 
 ## Quick Start
 
 ```python
+from typing import Type
+
 from crewai import Agent, Task, Crew
-from plasmate.integrations.crewai import PlasmateWebTool
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from plasmate import Plasmate
 
-# Create the Plasmate browsing tool
-browse = PlasmateWebTool()
 
-# Create an agent with web access
+class FetchPageInput(BaseModel):
+    url: str = Field(..., description="Public URL to fetch as SOM")
+
+
+class PlasmateFetchTool(BaseTool):
+    name: str = "plasmate_fetch"
+    description: str = (
+        "Fetch a web page and return structured SOM instead of raw HTML."
+    )
+    args_schema: Type[BaseModel] = FetchPageInput
+
+    def _run(self, url: str) -> str:
+        with Plasmate() as client:
+            return str(client.fetch_page(url))
+
+
 researcher = Agent(
     role="Web Researcher",
     goal="Find and summarize information from the web",
     backstory="Expert at extracting key information from web pages.",
-    tools=[browse],
+    tools=[PlasmateFetchTool()],
 )
 
-# Define a task
 task = Task(
     description="Research the top stories on Hacker News and summarize them.",
     expected_output="A bullet-point summary of the top 5 stories.",
     agent=researcher,
 )
 
-# Run the crew
 crew = Crew(agents=[researcher], tasks=[task])
 result = crew.kickoff()
 print(result)
 ```
 
-## Available Tools
+## Fetch vs scrape
 
-### `PlasmateWebTool`
-
-Fetches a URL and returns SOM text. Use it in place of `ScrapeWebsiteTool` when your workflow benefits from semantic regions and indexed actions.
-
-```python
-from plasmate.integrations.crewai import PlasmateWebTool
-
-tool = PlasmateWebTool()
-# Agents invoke it automatically when they need web content
-```
-
-### `PlasmateBrowseTool`
-
-Persistent browser session with navigate, click, and type actions for multi-step workflows.
-
-```python
-from plasmate.integrations.crewai import PlasmateBrowseTool
-
-tool = PlasmateBrowseTool()
-# Supports: navigate(url), click(index), type(index, text)
-```
-
-## Why Plasmate for CrewAI?
-
-| | ScrapeWebsiteTool | PlasmateWebTool |
-|---|---|---|
-| **Output** | Raw HTML/text | Structured SOM |
-| **Context representation** | Raw HTML/text | Structured SOM |
-| **Interactive elements** | Lost | Indexed `[N]` |
-| **Multi-step browsing** | ❌ | ✅ |
-| **Dependencies** | requests + beautifulsoup | `plasmate` binary |
+Use `Plasmate.fetch_page` in place of HTML scrapers when the crew needs semantic regions and actions. Persistent click/type flows use `open_page` on the same client; see the Python SDK.
 
 SOM removes non-semantic markup, but token and cost differences vary with the
 pages, prompts, and model tokenizer. Benchmark the full crew workflow before


### PR DESCRIPTION
## Journey
Published-docs integration failure: CrewAI docs imported a module this repository does not ship.

## Hypothesis
Agents copying `from plasmate.integrations.crewai import PlasmateWebTool` cannot install or import that package; `integrations/crewai/` is not in-tree.

## Change
- Point CrewAI docs at `from plasmate import Plasmate` and a local CrewAI `BaseTool` wrapper
- Drop the missing `integrations/crewai/` source link and invented `PlasmateWebTool` / `PlasmateBrowseTool` imports
- Do not copy onto Smolagents, AutoGen, Pi, or OpenClaw pages
- Do not add MCP `tools/list` language

## Proof
Focused, no network:
- `cargo test --lib crewai_docs_use_shipped_python_sdk_not_a_missing_in_tree_module`

Governor lane: published-docs integration failure; not an SDK install-path, SOM-reference, or OpenClaw/Pi rewrite.

Plasmate MCP: `https://plasmate.app` (extract_text), `https://docs.plasmate.app` (extract_text), `https://docs.plasmate.app/integration-mcp` (extract_text), `https://docs.plasmate.app/integration-langchain` (extract_text), `https://docs.crewai.com/en/learn/create-custom-tools` (extract_text).