### PR TITLE
docs(vercel-ai): point install recovery at live docs not plasmate.dev

### DIFF
--- a/integrations/vercel-ai/README.md
+++ b/integrations/vercel-ai/README.md
@@ -2,7 +2,7 @@
 
 **Plasmate browser tools for the [Vercel AI SDK](https://sdk.vercel.ai)**
 
-Plasmate is a headless browser MCP server that gives AI models structured access to the web via a [Set of Marks (SOM)](https://plasmate.dev/docs/som) representation. This package is a thin wrapper that connects Plasmate to the Vercel AI SDK in one function call.
+Plasmate is a headless browser MCP server that gives AI models structured access to the web via a [Semantic Object Model (SOM)](https://docs.plasmate.app/som) representation. This package is a thin wrapper that connects Plasmate to the Vercel AI SDK in one function call.
 
 ## Install
 
@@ -10,7 +10,7 @@ Plasmate is a headless browser MCP server that gives AI models structured access
 npm install @plasmate/ai ai
 ```
 
-You also need [Plasmate](https://plasmate.dev/docs/install) installed locally:
+You also need [Plasmate](https://docs.plasmate.app/install) installed locally:
 
 ```bash
 npm install -g plasmate

--- a/integrations/vercel-ai/src/index.ts
+++ b/integrations/vercel-ai/src/index.ts
@@ -930,7 +930,7 @@ export async function createPlasmateTools(
   } catch (err) {
     throw new Error(
       `Failed to create Plasmate MCP transport (binary: "${binary}").\n` +
-        `Make sure plasmate is installed: https://plasmate.dev/docs/install\n` +
+        `Make sure plasmate is installed: https://docs.plasmate.app/install\n` +
         `Original error: ${err instanceof Error ? err.message : String(err)}`
     )
   }
@@ -942,7 +942,7 @@ export async function createPlasmateTools(
   } catch (err) {
     throw new Error(
       `Failed to start Plasmate MCP server (binary: "${binary}").\n` +
-        `Make sure plasmate is installed: https://plasmate.dev/docs/install\n` +
+        `Make sure plasmate is installed: https://docs.plasmate.app/install\n` +
         `Original error: ${err instanceof Error ? err.message : String(err)}`
     )
   }

--- a/src/release_manifest.rs
+++ b/src/release_manifest.rs
@@ -1138,6 +1138,40 @@ mod tests {
     }
 
     #[test]
+    fn vercel_ai_docs_point_at_live_install_docs_not_plasmate_dev() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for rel in [
+            "integrations/vercel-ai/README.md",
+            "integrations/vercel-ai/src/index.ts",
+        ] {
+            let content = fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|error| panic!("read Vercel AI docs {rel}: {error}"));
+            assert!(
+                !content.contains("plasmate.dev"),
+                "{rel} still points agents at the 404 plasmate.dev host"
+            );
+            assert!(
+                content.contains("https://docs.plasmate.app/install"),
+                "{rel} should recover via the live install docs"
+            );
+            assert!(
+                !content.contains("Set of Marks"),
+                "{rel} still misnames SOM as Set of Marks"
+            );
+        }
+        let readme = fs::read_to_string(root.join("integrations/vercel-ai/README.md"))
+            .expect("read Vercel AI README");
+        assert!(
+            readme.contains("Semantic Object Model (SOM)"),
+            "README should name SOM as Semantic Object Model"
+        );
+        assert!(
+            readme.contains("https://docs.plasmate.app/som"),
+            "README should link the live SOM reference"
+        );
+    }
+
+    #[test]
     fn openclaw_docs_do_not_point_at_missing_in_tree_files_or_a_closed_tool_list() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         for rel in [


### PR DESCRIPTION
## Journey
Published-docs integration failure: `@plasmate/ai` install recovery pointed at `https://plasmate.dev/docs/install`, which 404s.

## Hypothesis
Agents that fail to start the Plasmate MCP binary follow the error URL, hit 404, and cannot recover. The README also misnames SOM as Set of Marks.

## Change
- Point Vercel AI README and `createPlasmateTools` errors at `https://docs.plasmate.app/install`
- Name SOM as Semantic Object Model and link `https://docs.plasmate.app/som`
- Do not copy onto Go SDK README, schema `$id`, marketing, CrewAI, OpenClaw, or Pi
- Do not change npm/brew install commands

## Proof
Focused, no network:
- `cargo test --lib vercel_ai_docs_point_at_live_install_docs`
- `cargo fmt --check -- src/release_manifest.rs`

Governor lane: published-docs integration failure; not an SDK install-path, SOM-reference field/table rewrite, or OpenClaw/Pi rewrite.

Plasmate MCP: `https://plasmate.app` (extract_text), `https://docs.plasmate.app` (extract_text), `https://plasmate.dev` (extract_text 404), `https://docs.plasmate.app/install` (extract_text), `https://docs.plasmate.app/som` (extract_text).