### PR TITLE
docs(llamaindex): point agents at shipped SDK not missing llama-index-readers-plasmate

### DIFF
--- a/src/release_manifest.rs
+++ b/src/release_manifest.rs
@@ -1166,6 +1166,46 @@ mod tests {
     }
 
     #[test]
+    fn llamaindex_docs_use_shipped_python_sdk_not_a_missing_reader_package() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for rel in [
+            "website/docs/src/integration-llamaindex.md",
+            "website/docs/integration-llamaindex.html",
+        ] {
+            let content = fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|error| panic!("read LlamaIndex docs {rel}: {error}"));
+            assert!(
+                !content.contains("pip install plasmate llama-index-readers-plasmate"),
+                "{rel} still installs a missing llama-index-readers-plasmate package"
+            );
+            assert!(
+                !content.contains("PlasmateWebReader("),
+                "{rel} still constructs a missing PlasmateWebReader"
+            );
+            assert!(
+                !content.contains("from llama_index.readers.plasmate"),
+                "{rel} still imports a missing llama_index.readers.plasmate module"
+            );
+            assert!(
+                !content.contains("github.com/run-llama/llama_index/pull/21144"),
+                "{rel} still points at the closed unmerged LlamaIndex reader PR"
+            );
+            assert!(
+                content.contains("from plasmate import Plasmate"),
+                "{rel} should use the shipped Python SDK"
+            );
+            assert!(
+                content.contains("extract_text"),
+                "{rel} should show the shipped extract_text helper"
+            );
+            assert!(
+                content.contains("llama_index.core"),
+                "{rel} should wrap shipped SDK output in llama_index.core.Document"
+            );
+        }
+    }
+
+    #[test]
     fn scrapy_docs_use_shipped_python_sdk_not_a_missing_middleware_package() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         for rel in [

--- a/website/docs/integration-llamaindex.html
+++ b/website/docs/integration-llamaindex.html
@@ -457,73 +457,34 @@
       </div>
     </nav>
     <main class="content">
-      <h1 id="llamaindex-integration">LlamaIndex Integration</h1><p>Use Plasmate as a document reader in your LlamaIndex RAG pipelines, returning structured SOM instead of raw HTML. Output size and token use vary by page and tokenizer.</p>
-<p>Source: <a href="https://github.com/run-llama/llama_index/pull/21144"><code>llama-index-readers-plasmate</code></a></p>
-<h2 id="installation">Installation</h2><pre><code class="language-bash">pip install plasmate llama-index-readers-plasmate
+      <h1 id="llamaindex-integration">LlamaIndex Integration</h1><p>Use the shipped <a href="sdk-python">Python SDK</a> to load web pages into LlamaIndex RAG pipelines as clean SOM text instead of raw HTML. Output size and token use vary by page and tokenizer.</p>
+<p>This repository does not ship <code>llama-index-readers-plasmate</code> or <code>PlasmateWebReader</code>. Call <code>Plasmate.extract_text</code> and wrap the result in <code>llama_index.core.Document</code>.</p>
+<h2 id="installation">Installation</h2><pre><code class="language-bash">pip install plasmate llama-index
 </code></pre>
-<h2 id="quick-start">Quick Start</h2><pre><code class="language-python">from llama_index.readers.plasmate import PlasmateWebReader
+<p>Requires the <code>plasmate</code> binary on your PATH.</p>
+<h2 id="quick-start">Quick Start</h2><pre><code class="language-python">from llama_index.core import Document, VectorStoreIndex
+from plasmate import Plasmate
 
-reader = PlasmateWebReader()
-documents = reader.load_data(urls=[
-    &quot;https://example.com&quot;,
-    &quot;https://docs.python.org/3/&quot;,
-])
+with Plasmate() as client:
+    text = client.extract_text(&quot;https://example.com&quot;, selector=&quot;main&quot;)
 
-# Use in your RAG pipeline
-from llama_index.core import VectorStoreIndex
+documents = [
+    Document(text=text, metadata={&quot;url&quot;: &quot;https://example.com&quot;}),
+]
 index = VectorStoreIndex.from_documents(documents)
 query_engine = index.as_query_engine()
 response = query_engine.query(&quot;What is this page about?&quot;)
 </code></pre>
-<h2 id="why-plasmate-for-rag">Why Plasmate for RAG?</h2><p>Standard web readers (<code>SimpleWebPageReader</code>, <code>BeautifulSoupWebReader</code>) return raw HTML or basic text extraction. Plasmate returns structured semantic content:</p>
+<p>When the index also needs title or SOM sizes, call <code>fetch_page</code> on the same client and copy those fields into <code>Document.metadata</code>. Persistent click/type flows use <code>open_page</code>; see the Python SDK.</p>
+<h2 id="why-plasmate-for-rag">Why Plasmate for RAG?</h2><p>Standard web readers (<code>SimpleWebPageReader</code>, <code>BeautifulSoupWebReader</code>) return raw HTML or basic text extraction. The shipped SDK returns compiled page text:</p>
 <ul>
-<li><strong>Compact by design</strong> -  non-semantic markup is removed; benchmark embedding and query costs on your corpus</li>
-<li><strong>Preserved document hierarchy</strong> -  headings, sections, lists stay structured</li>
-<li><strong>Clean text extraction</strong> -  no scripts, styles, or layout noise</li>
-<li><strong>Metadata included</strong> -  title, language, byte sizes, element counts</li>
+<li><strong>Compact by design</strong> - non-semantic markup is removed; benchmark embedding and query costs on your corpus</li>
+<li><strong>Region filters</strong> - <code>selector=&quot;main&quot;</code> strips nav/footer before indexing</li>
+<li><strong>Clean text extraction</strong> - no scripts, styles, or layout noise</li>
+<li><strong>Optional structure</strong> - <code>fetch_page</code> still exposes title, language, and byte sizes when you need them</li>
 </ul>
-<h2 id="configuration">Configuration</h2><pre><code class="language-python">PlasmateWebReader(
-    binary=&quot;plasmate&quot;,    # Path to plasmate binary
-    timeout=30,           # Timeout per page in seconds
-    budget=None,          # Optional SOM token budget
-    javascript=True,      # Enable JS execution
-)
-</code></pre>
-<h2 id="document-metadata">Document Metadata</h2><p>Each loaded document includes metadata:</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody><tr>
-<td><code>url</code></td>
-<td>Source URL</td>
-</tr>
-<tr>
-<td><code>title</code></td>
-<td>Page title</td>
-</tr>
-<tr>
-<td><code>html_bytes</code></td>
-<td>Original HTML size</td>
-</tr>
-<tr>
-<td><code>som_bytes</code></td>
-<td>SOM output size</td>
-</tr>
-<tr>
-<td><code>element_count</code></td>
-<td>Total SOM elements</td>
-</tr>
-<tr>
-<td><code>compression_ratio</code></td>
-<td>HTML → SOM ratio</td>
-</tr>
-</tbody></table>
+<p>There is no shipped LlamaIndex reader class, <code>load_data()</code> helper, or automatic HTML fallback.</p>
 <h2 id="links">Links</h2><ul>
-<li><a href="https://github.com/run-llama/llama_index/pull/21144">GitHub PR #21144</a></li>
 <li><a href="https://docs.llamaindex.ai">LlamaIndex Docs</a></li>
 <li><a href="sdk-python">Plasmate Python SDK</a></li>
 </ul>

--- a/website/docs/src/integration-llamaindex.md
+++ b/website/docs/src/integration-llamaindex.md
@@ -1,68 +1,48 @@
 # LlamaIndex Integration
 
-Use Plasmate as a document reader in your LlamaIndex RAG pipelines, returning structured SOM instead of raw HTML. Output size and token use vary by page and tokenizer.
+Use the shipped [Python SDK](sdk-python) to load web pages into LlamaIndex RAG pipelines as clean SOM text instead of raw HTML. Output size and token use vary by page and tokenizer.
 
-Source: [`llama-index-readers-plasmate`](https://github.com/run-llama/llama_index/pull/21144)
+This repository does not ship `llama-index-readers-plasmate` or `PlasmateWebReader`. Call `Plasmate.extract_text` and wrap the result in `llama_index.core.Document`.
 
 ## Installation
 
 ```bash
-pip install plasmate llama-index-readers-plasmate
+pip install plasmate llama-index
 ```
+
+Requires the `plasmate` binary on your PATH.
 
 ## Quick Start
 
 ```python
-from llama_index.readers.plasmate import PlasmateWebReader
+from llama_index.core import Document, VectorStoreIndex
+from plasmate import Plasmate
 
-reader = PlasmateWebReader()
-documents = reader.load_data(urls=[
-    "https://example.com",
-    "https://docs.python.org/3/",
-])
+with Plasmate() as client:
+    text = client.extract_text("https://example.com", selector="main")
 
-# Use in your RAG pipeline
-from llama_index.core import VectorStoreIndex
+documents = [
+    Document(text=text, metadata={"url": "https://example.com"}),
+]
 index = VectorStoreIndex.from_documents(documents)
 query_engine = index.as_query_engine()
 response = query_engine.query("What is this page about?")
 ```
 
+When the index also needs title or SOM sizes, call `fetch_page` on the same client and copy those fields into `Document.metadata`. Persistent click/type flows use `open_page`; see the Python SDK.
+
 ## Why Plasmate for RAG?
 
-Standard web readers (`SimpleWebPageReader`, `BeautifulSoupWebReader`) return raw HTML or basic text extraction. Plasmate returns structured semantic content:
+Standard web readers (`SimpleWebPageReader`, `BeautifulSoupWebReader`) return raw HTML or basic text extraction. The shipped SDK returns compiled page text:
 
-- **Compact by design** -  non-semantic markup is removed; benchmark embedding and query costs on your corpus
-- **Preserved document hierarchy** -  headings, sections, lists stay structured
-- **Clean text extraction** -  no scripts, styles, or layout noise
-- **Metadata included** -  title, language, byte sizes, element counts
+- **Compact by design** - non-semantic markup is removed; benchmark embedding and query costs on your corpus
+- **Region filters** - `selector="main"` strips nav/footer before indexing
+- **Clean text extraction** - no scripts, styles, or layout noise
+- **Optional structure** - `fetch_page` still exposes title, language, and byte sizes when you need them
 
-## Configuration
-
-```python
-PlasmateWebReader(
-    binary="plasmate",    # Path to plasmate binary
-    timeout=30,           # Timeout per page in seconds
-    budget=None,          # Optional SOM token budget
-    javascript=True,      # Enable JS execution
-)
-```
-
-## Document Metadata
-
-Each loaded document includes metadata:
-
-| Field | Description |
-|-------|-------------|
-| `url` | Source URL |
-| `title` | Page title |
-| `html_bytes` | Original HTML size |
-| `som_bytes` | SOM output size |
-| `element_count` | Total SOM elements |
-| `compression_ratio` | HTML → SOM ratio |
+There is no shipped LlamaIndex reader class, `load_data()` helper, or automatic HTML fallback.
 
 ## Links
 
-- [GitHub PR #21144](https://github.com/run-llama/llama_index/pull/21144)
 - [LlamaIndex Docs](https://docs.llamaindex.ai)
 - [Plasmate Python SDK](sdk-python)


### PR DESCRIPTION
## Summary
Live LlamaIndex docs installed `llama-index-readers-plasmate` and imported `PlasmateWebReader` from closed unmerged run-llama/llama_index#21144. This repository does not ship that reader.

Recover onto the shipped Python SDK: `Plasmate.extract_text` wrapped in `llama_index.core.Document` for RAG indexing.

## Proof
Focused: `cargo test llamaindex_docs_use_shipped_python_sdk_not_a_missing_reader_package`

Plasmate MCP reads: `https://docs.plasmate.app`, `https://plasmate.app`, `https://docs.plasmate.app/integration-llamaindex`

## Governor
Allowed published-docs integration failure that is not an SDK install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI, Browser Use, or Scrapy rewrite.