### PR TITLE
feat(python-sdk): expose navigate_to on session clients

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -76,6 +76,7 @@ with Plasmate() as browser:
 ### Stateful (interactive sessions)
 
 - **`open_page(url)`** - Returns dict with `session_id` and `som`
+- **`navigate_to(session_id, url)`** - Load a new URL in the same session, get updated SOM
 - **`evaluate(session_id, expression)`** - Run JS, get result
 - **`click(session_id, element_id)`** - Click element, get updated SOM
 - **`type_text(session_id, element_id, text, *, append=False)`** - Type into an input or textarea, get updated SOM

--- a/sdk/python/src/plasmate/client.py
+++ b/sdk/python/src/plasmate/client.py
@@ -337,6 +337,22 @@ class Plasmate:
         """
         return self._call_tool("open_page", {"url": url})
 
+    def navigate_to(self, session_id: str, url: str) -> dict:
+        """
+        Navigate to a new URL within an existing browser session.
+
+        Args:
+            session_id: Session ID from open_page
+            url: URL to navigate to
+
+        Returns:
+            Updated page SOM for the same session
+        """
+        return self._call_tool("navigate_to", {
+            "session_id": session_id,
+            "url": url,
+        })
+
     def evaluate(self, session_id: str, expression: str) -> Any:
         """
         Execute JavaScript in the page context.
@@ -572,6 +588,13 @@ class AsyncPlasmate:
     async def open_page(self, url: str) -> dict:
         """Open a page in a persistent browser session."""
         return await self._call_tool("open_page", {"url": url})
+
+    async def navigate_to(self, session_id: str, url: str) -> dict:
+        """Navigate to a new URL within an existing browser session."""
+        return await self._call_tool("navigate_to", {
+            "session_id": session_id,
+            "url": url,
+        })
 
     async def evaluate(self, session_id: str, expression: str) -> Any:
         """Execute JavaScript in the page context."""

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -41,6 +41,39 @@ def test_async_read_methods_forward_selector() -> None:
     asyncio.run(exercise())
 
 
+def test_sync_navigate_to_forwards_session_and_url() -> None:
+    browser = Plasmate()
+    calls = Mock(side_effect=[{}])
+    browser._call_tool = calls  # type: ignore[method-assign]
+
+    assert browser.navigate_to("s1", "https://example.test/next") == {}
+
+    assert calls.call_args_list == [
+        call(
+            "navigate_to",
+            {"session_id": "s1", "url": "https://example.test/next"},
+        ),
+    ]
+
+
+def test_async_navigate_to_forwards_session_and_url() -> None:
+    async def exercise() -> None:
+        browser = AsyncPlasmate()
+        calls = AsyncMock(side_effect=[{}])
+        browser._call_tool = calls  # type: ignore[method-assign]
+
+        assert await browser.navigate_to("s1", "https://example.test/next") == {}
+
+        assert calls.call_args_list == [
+            call(
+                "navigate_to",
+                {"session_id": "s1", "url": "https://example.test/next"},
+            ),
+        ]
+
+    asyncio.run(exercise())
+
+
 def test_sync_type_text_forwards_session_target_and_append() -> None:
     browser = Plasmate()
     calls = Mock(side_effect=[{}, {}])


### PR DESCRIPTION
## Summary
Python SDK sessions could `open_page` then `click`/`type_text`, but had no `navigate_to`. Agents had to close and reopen to change URL, dropping the session.

Forward the existing MCP `navigate_to` tool from sync and async clients. Node and Go SDKs are unchanged.

## Proof
Focused: `cd sdk/python && PYTHONPATH=src python3 -m pytest tests/test_client.py -v` (6 passed)

Plasmate MCP reads: `https://docs.plasmate.app`, `https://plasmate.app`, `https://docs.plasmate.app/tools`, `https://docs.plasmate.app/integration-langchain`

## Governor
Allowed SDK compatibility / bounded agent-task recovery. Not an IDL getter, querySelector pseudo, inspect-compact field, compile-attr copy, MCP error-text copy, or a prohibited docs rewrite (OpenClaw/Pi, CrewAI, Vercel AI, Browser Use, Scrapy, AutoGen, Smolagents).