### PR TITLE
feat(langchain): reuse session on navigate via navigate_to

### DIFF
--- a/integrations/langchain/langchain_plasmate/tools.py
+++ b/integrations/langchain/langchain_plasmate/tools.py
@@ -41,12 +41,22 @@ class PlasmateBrowser:
         self.session_id: Optional[str] = None
 
     def navigate(self, url: str) -> dict:
-        """Open *url* in a new or replacement session. Returns the SOM."""
+        """Open *url*, reusing the live session when one already exists.
+
+        First call uses ``open_page``. Later calls forward MCP ``navigate_to``
+        so cookies and session state are not dropped by close/reopen.
+        """
         if self.session_id:
-            try:
-                self.client.close_page(self.session_id)
-            except Exception:
-                pass
+            result = self.client._call_tool(
+                "navigate_to",
+                {
+                    "session_id": self.session_id,
+                    "url": url,
+                },
+            )
+            if isinstance(result, dict):
+                return result.get("som", result)
+            return result
         result = self.client.open_page(url)
         self.session_id = result["session_id"]
         return result.get("som", result)
@@ -166,8 +176,9 @@ class PlasmateFetchTool(BaseTool):
 class PlasmateNavigateTool(BaseTool):
     """Navigate to a URL in a persistent browser session.
 
-    Opens (or replaces) the current browser session. Subsequent
-    ``plasmate_click`` and ``plasmate_type`` calls will target this page.
+    Opens a session on the first call and reuses it via ``navigate_to``
+    afterwards. Subsequent ``plasmate_click`` and ``plasmate_type`` calls
+    target this page.
     """
 
     name: str = "plasmate_navigate"

--- a/integrations/langchain/tests/test_tools.py
+++ b/integrations/langchain/tests/test_tools.py
@@ -139,6 +139,43 @@ def test_fetch_tool_async_forwards_fetch_options() -> None:
     )
 
 
+def test_browser_navigate_opens_when_no_session() -> None:
+    client = Mock()
+    som = _som()
+    client.open_page.return_value = {"session_id": "sess-1", "som": som}
+    browser = PlasmateBrowser(client=client)
+
+    result = browser.navigate("https://example.test/")
+
+    client.open_page.assert_called_once_with("https://example.test/")
+    client.close_page.assert_not_called()
+    client._call_tool.assert_not_called()
+    assert browser.session_id == "sess-1"
+    assert result == som
+
+
+def test_browser_navigate_reuses_session_via_navigate_to() -> None:
+    client = Mock()
+    som = _som()
+    client._call_tool.return_value = som
+    browser = PlasmateBrowser(client=client)
+    browser.session_id = "sess-1"
+
+    result = browser.navigate("https://example.test/next")
+
+    client._call_tool.assert_called_once_with(
+        "navigate_to",
+        {
+            "session_id": "sess-1",
+            "url": "https://example.test/next",
+        },
+    )
+    client.close_page.assert_not_called()
+    client.open_page.assert_not_called()
+    assert browser.session_id == "sess-1"
+    assert result == som
+
+
 def test_browser_type_text_calls_mcp_type_text() -> None:
     client = Mock()
     client._call_tool.return_value = _som()


### PR DESCRIPTION
## Summary
LangChain `PlasmateBrowser.navigate` closed and reopened the session on every URL, dropping cookies and other session state.

First call still uses `open_page`. Later calls forward the existing MCP `navigate_to` tool, matching `type_text`'s `_call_tool` pattern. Node/Go SDKs and MCP error text are unchanged.

## Proof
Focused: `cd integrations/langchain && PYTHONPATH=src:../python/src python3 -m pytest tests/test_tools.py -v` (10 passed)

Plasmate MCP reads: `https://docs.plasmate.app`, `https://plasmate.app`, `https://docs.plasmate.app/integration-langchain`

## Governor
Allowed SDK/integration compatibility and bounded agent-task recovery. Not an IDL getter, querySelector pseudo, inspect-compact field, compile-attr copy, MCP error-text copy, or a prohibited docs rewrite (OpenClaw/Pi, CrewAI, Vercel AI, Browser Use, Scrapy, AutoGen, Smolagents). Not a Python/Node/Go SDK method add.