### PR TITLE
fix(node-sdk): unwrap evaluate MCP result envelope

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -33,6 +33,37 @@ describe('read selectors', () => {
   });
 });
 
+describe('evaluate payload', () => {
+  it('returns the JS value instead of the MCP result envelope', async () => {
+    const browser = new Plasmate({ binary: 'unused' });
+    const client = browser as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+    client.callTool = async (name, args) => {
+      assert.equal(name, 'evaluate');
+      assert.deepEqual(args, { session_id: 's1', expression: 'document.title' });
+      return { result: 'Example' };
+    };
+
+    assert.equal(await browser.evaluate('s1', 'document.title'), 'Example');
+    browser.close();
+  });
+
+  it('keeps non-envelope payloads unchanged', async () => {
+    const browser = new Plasmate({ binary: 'unused' });
+    const client = browser as unknown as {
+      callTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+    client.callTool = async () => ({ result: 'Example', extra: true });
+
+    assert.deepEqual(await browser.evaluate('s1', 'document.title'), {
+      result: 'Example',
+      extra: true,
+    });
+    browser.close();
+  });
+});
+
 describe('openPage payload', () => {
   it('builds session.som from the flat MCP open_page fields', async () => {
     const browser = new Plasmate({ binary: 'unused' });

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -119,6 +119,19 @@ function somFromOpenPage(result: OpenPagePayload): Som {
   };
 }
 
+function evaluateResult(payload: unknown): unknown {
+  if (
+    payload !== null &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    Object.keys(payload).length === 1 &&
+    Object.prototype.hasOwnProperty.call(payload, 'result')
+  ) {
+    return (payload as { result: unknown }).result;
+  }
+  return payload;
+}
+
 export interface PlasmateOptions {
   /** Path to the plasmate binary. Default: "plasmate" (found in PATH) */
   binary?: string;
@@ -379,10 +392,12 @@ export class Plasmate extends EventEmitter {
    * @param expression - JavaScript expression to evaluate
    */
   async evaluate(sessionId: string, expression: string): Promise<unknown> {
-    return await this.callTool('evaluate', {
-      session_id: sessionId,
-      expression,
-    });
+    return evaluateResult(
+      await this.callTool('evaluate', {
+        session_id: sessionId,
+        expression,
+      }),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Node `evaluate()` returned the MCP `{ result }` envelope, so the documented `const title = await browser.evaluate(session.sessionId, 'document.title')` path did not yield the JS value. Unwrap a single-key `{ result }` payload only.

## Proof

- Focused: `cd sdk/node && npm test` (41 pass)
- Plasmate MCP: `https://docs.plasmate.app` and `https://docs.plasmate.app/sdk-node`

## Governor notes

- Distinct journey: published Node evaluate return-shape vs docs (not an SDK method add, not LangChain navigate, not IDL/querySelector)
- Do not copy onto Python or Go SDKs this run