### PR TITLE
fix(node-sdk): keep extract_text payloads as raw strings

### DIFF
--- a/sdk/node/src/client.test.ts
+++ b/sdk/node/src/client.test.ts
@@ -33,6 +33,51 @@ describe('read selectors', () => {
   });
 });
 
+describe('extractText payload', () => {
+  it('keeps JSON-looking and empty extract_text as strings', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'plasmate-node-sdk-'));
+    const fixture = join(directory, 'mcp-fixture.js');
+    writeFileSync(
+      fixture,
+      `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const input = createInterface({ input: process.stdin });
+
+input.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05' } });
+  } else if (request.method === 'tools/call') {
+    const name = request.params.name;
+    const text = name === 'extract_text'
+      ? (request.params.arguments.url === 'empty' ? '' : '{"headline":"ok"}')
+      : JSON.stringify({ title: 'Example' });
+    send({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { content: [{ type: 'text', text }] },
+    });
+  }
+});
+`,
+      'utf8',
+    );
+    chmodSync(fixture, 0o755);
+
+    const browser = new Plasmate({ binary: fixture });
+    try {
+      assert.equal(await browser.extractText('json-page'), '{"headline":"ok"}');
+      assert.equal(await browser.extractText('empty'), '');
+      assert.deepEqual(await browser.fetchPage('fixture'), { title: 'Example' });
+    } finally {
+      browser.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('evaluate payload', () => {
   it('returns the JS value instead of the MCP result envelope', async () => {
     const browser = new Plasmate({ binary: 'unused' });

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -304,6 +304,8 @@ export class Plasmate extends EventEmitter {
     }
 
     const text = result.content?.[0]?.text;
+    if (typeof text !== 'string') return null;
+    if (name === 'extract_text') return text;
     if (!text) return null;
 
     // Try to parse as JSON, fall back to raw text


### PR DESCRIPTION
## Summary
Node `extractText` JSON-parsed the MCP text block. JSON-looking pages became objects and empty pages became `null`, so agents did not get the written content.

Keep `extract_text` as the raw MCP string. Structured tools still JSON.parse.

## Proof
- `cd sdk/node && npm test` — 42 passed, including `keeps JSON-looking and empty extract_text as strings`
- Live Plasmate MCP reads: `https://docs.plasmate.app`, `https://plasmate.app`, `https://docs.plasmate.app/sdk-node`

## Governor notes
Not an IDL/querySelector/inspect-compact/compile-attr copy. Not a method add, evaluate unwrap, click non-http skip, or banned docs rewrite. Distinct from #371: this stops parsing page text, it does not unwrap `{ result }`.