### PR TITLE
docs(automation): narrow hourly after #376

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-08)
 
-- Window: `e4a6b2c` .. `0e2c469`
+- Window: `59e19da` .. `a57a109`
 - Decision: `NARROW`
-- Merged this run: `7566aba` Node extract_text raw MCP string (`0e2c469`)
+- Merged this run: `1da467c` click compiled SOM envelope (`a57a109`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -460,6 +460,10 @@ overwrite, reset, or absorb unrelated work.
    fetch_page, extract_links, evaluate, or other tools that
    still JSON.parse structured MCP payloads; do not change
    the extract_text MCP wire format.
+   Do not copy #376 click compiled SOM envelope onto
+   `type_text`, `clear`, `toggle`, `select_option`, `scroll`,
+   `navigate_to`, or SDKs; do not change those truncated
+   title/url/regions/webmcp payloads as a one-surface copy.
 - Allowed next (pick one distinct journey): a real missed regression;
    a published-docs integration failure that is not another SDK
    install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI,
@@ -469,8 +473,8 @@ overwrite, reset, or absorb unrelated work.
    error-text copy, open_page capacity error-text copy, navigate_to
    missing-session error-text copy, close_page idempotent-success copy,
    Python/Node/Go SDK method add, LangChain session-navigate copy,
-   Node evaluate envelope unwrap, click non-http scheme skip, or
-   Node extract_text raw-string keep.
+   Node evaluate envelope unwrap, click non-http scheme skip,
+   Node extract_text raw-string keep, or click compiled SOM envelope.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Merged #376 click compiled SOM envelope after focused local proof.
- Narrow hourly: do not copy that envelope onto adjacent MCP handlers.

## Proof
- Focused on #376: `cargo test --bin plasmate click_returns_compiled_som_envelope`
- Existing: `cargo test --bin plasmate click_resolves_compiled_html_id`

Plasmate MCP page read this run: https://plasmate.app and https://docs.plasmate.app.

Governor: NARROW after #376. Not an IDL/querySelector, inspect-compact, compile-attr, empty-session, SDK method, or Node extract_text copy.