### PR TITLE
fix(mcp): normalize evaluate expressions before wrapping

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1814,6 +1814,25 @@ pub async fn handle_open_page(
     tool_response(delivered_text)
 }
 
+fn normalize_evaluate_expression(expression: &str) -> &str {
+    let mut expression = expression.trim();
+    while let Some(stripped) = expression.strip_suffix(';') {
+        expression = stripped.trim_end();
+    }
+    expression
+}
+
+fn wrap_evaluate_expression(expression: &str) -> Result<String, String> {
+    let expression = normalize_evaluate_expression(expression);
+    if expression.is_empty() {
+        return Err("Evaluate expression is empty".to_string());
+    }
+    Ok(format!(
+        "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
+        expression
+    ))
+}
+
 /// Handle the evaluate tool call.
 ///
 /// Runs JavaScript in a supervised child and leaves the session's last good SOM
@@ -1825,6 +1844,11 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
         Err(e) => {
             return error_response(&format!("Invalid arguments: {}", e));
         }
+    };
+
+    let wrapped_expr = match wrap_evaluate_expression(&params.expression) {
+        Ok(expr) => expr,
+        Err(e) => return error_response(&e),
     };
 
     info!(session_id = %params.session_id, expression_bytes = params.expression.len(), "evaluate");
@@ -1848,11 +1872,6 @@ pub async fn handle_evaluate(arguments: &Value, sessions: &Arc<SessionManager>) 
         }
     };
 
-    let expression = params.expression.clone();
-    let wrapped_expr = format!(
-        "(function() {{ var __r = ({}); return typeof __r === 'object' && __r !== null ? JSON.stringify(__r) : __r; }})()",
-        expression
-    );
     let eval_result =
         run_session_javascript(sessions, effective_html, url, wrapped_expr, false).await;
 
@@ -3595,6 +3614,40 @@ mod tests {
         assert!(survived.get("isError").is_none(), "{survived}");
         assert_eq!(tool_payload(&survived)["result"], "ok");
         assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+    }
+
+    #[test]
+    fn wrap_evaluate_expression_strips_trailing_semicolons() {
+        let wrapped = wrap_evaluate_expression("document.title;").unwrap();
+        assert_eq!(wrapped, wrap_evaluate_expression("document.title").unwrap());
+        assert!(wrapped.contains("(document.title)"));
+        assert!(!wrapped.contains("document.title;"));
+
+        let repeated = wrap_evaluate_expression("  1 + 1 ; ; ").unwrap();
+        assert_eq!(repeated, wrap_evaluate_expression("1 + 1").unwrap());
+        assert!(repeated.contains("(1 + 1)"));
+
+        let inner_semicolon = wrap_evaluate_expression("'hello;'").unwrap();
+        assert!(inner_semicolon.contains("('hello;')"), "{inner_semicolon}");
+    }
+
+    #[tokio::test]
+    async fn evaluate_empty_expression_fails_closed_before_session() {
+        let sessions = Arc::new(SessionManager::new());
+
+        let result = handle_evaluate(
+            &json!({"session_id": "sess-unused", "expression": " ; ; "}),
+            &sessions,
+        )
+        .await;
+
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Evaluate expression is empty"), "{text}");
+        assert!(
+            !text.contains("Session not found"),
+            "empty expressions must fail before session lookup: {text}"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1814,10 +1814,30 @@ pub async fn handle_open_page(
     tool_response(delivered_text)
 }
 
-fn normalize_evaluate_expression(expression: &str) -> &str {
+fn strip_trailing_evaluate_semicolons(expression: &str) -> &str {
     let mut expression = expression.trim();
     while let Some(stripped) = expression.strip_suffix(';') {
         expression = stripped.trim_end();
+    }
+    expression
+}
+
+fn strip_leading_return_keyword(expression: &str) -> Option<&str> {
+    let rest = expression.strip_prefix("return")?;
+    if rest.is_empty() {
+        return Some("");
+    }
+    let first = rest.chars().next()?;
+    if first.is_ascii_alphanumeric() || first == '_' || first == '$' {
+        return None;
+    }
+    Some(rest.trim_start())
+}
+
+fn normalize_evaluate_expression(expression: &str) -> &str {
+    let mut expression = strip_trailing_evaluate_semicolons(expression);
+    if let Some(stripped) = strip_leading_return_keyword(expression) {
+        expression = strip_trailing_evaluate_semicolons(stripped);
     }
     expression
 }
@@ -3631,6 +3651,28 @@ mod tests {
         assert!(inner_semicolon.contains("('hello;')"), "{inner_semicolon}");
     }
 
+    #[test]
+    fn wrap_evaluate_expression_strips_leading_return() {
+        let wrapped = wrap_evaluate_expression("return document.title").unwrap();
+        assert_eq!(wrapped, wrap_evaluate_expression("document.title").unwrap());
+        assert!(wrapped.contains("(document.title)"));
+        assert!(!wrapped.contains("return document.title"));
+
+        let with_semi = wrap_evaluate_expression("  return 1 + 1 ; ").unwrap();
+        assert_eq!(with_semi, wrap_evaluate_expression("1 + 1").unwrap());
+        assert!(with_semi.contains("(1 + 1)"));
+
+        let paren = wrap_evaluate_expression("return(document.title)").unwrap();
+        assert_eq!(paren, wrap_evaluate_expression("(document.title)").unwrap());
+
+        let identifier = wrap_evaluate_expression("returning").unwrap();
+        assert!(identifier.contains("(returning)"), "{identifier}");
+        assert_ne!(identifier, wrap_evaluate_expression("ing").unwrap());
+
+        let quoted = wrap_evaluate_expression("'return document.title'").unwrap();
+        assert!(quoted.contains("('return document.title')"), "{quoted}");
+    }
+
     #[tokio::test]
     async fn evaluate_empty_expression_fails_closed_before_session() {
         let sessions = Arc::new(SessionManager::new());
@@ -3647,6 +3689,25 @@ mod tests {
         assert!(
             !text.contains("Session not found"),
             "empty expressions must fail before session lookup: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluate_bare_return_fails_closed_before_session() {
+        let sessions = Arc::new(SessionManager::new());
+
+        let result = handle_evaluate(
+            &json!({"session_id": "sess-unused", "expression": "return;"}),
+            &sessions,
+        )
+        .await;
+
+        assert_eq!(result["isError"], true);
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Evaluate expression is empty"), "{text}");
+        assert!(
+            !text.contains("Session not found"),
+            "bare return must fail before session lookup: {text}"
         );
     }
 


### PR DESCRIPTION
## Summary
- MCP `evaluate` wraps the agent expression as `(expr)` before JSON serialization.
- A trailing semicolon (`document.title;`) becomes `(document.title;)` and fails as a syntax error.
- A leading `return` (`return document.title`) becomes `(return document.title)` and also fails.
- Normalize trailing semicolons/whitespace and a leading `return` keyword first. Empty input, including bare `return;`, fails closed before session lookup. Identifiers like `returning` and quoted `'return …'` are unchanged.

## Proof
- Focused: `cargo test --bin plasmate wrap_evaluate_expression_strips_trailing_semicolons`
- Focused: `cargo test --bin plasmate wrap_evaluate_expression_strips_leading_return`
- Focused: `cargo test --bin plasmate fails_closed_before_session`
- Existing: `cargo test --bin plasmate evaluate_empty_session_names_navigate_to`

Plasmate MCP page read this run: https://docs.plasmate.app, https://docs.plasmate.app/changelog, https://docs.plasmate.app/integration-autogen, https://docs.plasmate.app/integration-smolagents.

Governor: one small MCP evaluate input recovery. Not an IDL/querySelector, inspect-compact, compile-attr, empty-session error-text, SDK method, Node evaluate envelope unwrap, or click SOM envelope copy.