### PR TITLE
fix(mcp): click empty-text buttons by compiled aria-label

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2042,7 +2042,7 @@ pub async fn handle_click(
     }
 
     // Generate JavaScript to simulate click
-    // Resolve by data-plasmate-id, then compiled html_id, then tag/text/value fallback.
+    // Resolve by data-plasmate-id, then compiled html_id, then tag/text/value/aria-label fallback.
     let element_id = params.element_id.clone();
     let html_id = serde_json::to_string(&element.html_id).unwrap_or_else(|_| "null".to_string());
     let expected_label =
@@ -2064,6 +2064,9 @@ pub async fn handle_click(
                     var candidateLabel = candidate.tagName === 'INPUT'
                         ? (candidate.value || candidate.getAttribute('alt') || '').trim()
                         : (candidate.textContent || '').trim();
+                    if (!candidateLabel) {{
+                        candidateLabel = (candidate.getAttribute('aria-label') || '').trim();
+                    }}
                     if (candidateLabel === expected) {{
                         el = candidate;
                         break;
@@ -4104,6 +4107,55 @@ mod tests {
         assert!(clicked.get("isError").is_none(), "{clicked}");
         let payload = tool_payload(&clicked);
         assert_eq!(payload["title"], "Pay");
+        assert!(payload["regions"].is_array(), "{payload}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn click_resolves_button_aria_label_when_textcontent_is_empty() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Dialog</title></head><body><main><!-- __fixture_button_aria_label__ --><button aria-label='Close'></button></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_url = Some("https://example.test/dialog".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/dialog").unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        let element_id = sessions
+            .with_session(&session_id, |session| {
+                let som = session.target.current_som.as_ref().unwrap();
+                som.regions
+                    .iter()
+                    .flat_map(|region| region.elements.iter())
+                    .find(|element| {
+                        element.role == ElementRole::Button
+                            && element.html_id.is_none()
+                            && click_target_label(element) == "Close"
+                    })
+                    .map(|element| element.id.clone())
+                    .expect("seeded page must expose the aria-labelled button")
+            })
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let clicked = handle_click(
+            &json!({"session_id": session_id, "element_id": element_id}),
+            &client,
+            &sessions,
+        )
+        .await;
+        assert!(clicked.get("isError").is_none(), "{clicked}");
+        let payload = tool_payload(&clicked);
+        assert_eq!(payload["title"], "Dialog");
         assert!(payload["regions"].is_array(), "{payload}");
     }
 

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -54,6 +54,18 @@ fn main() {
         }
         return;
     }
+    if input.contains("__fixture_button_aria_label__") {
+        if input.contains("getAttribute('aria-label')") && input.contains("Close") {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"clicked\":true}}","effective_html":"<html><head><title>Dialog</title></head><body><main><!-- __fixture_button_aria_label__ --><button aria-label='Close'></button></main></body></html>"}}}}"#
+            );
+        } else {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"error\":\"Element not found in DOM\"}}","effective_html":"<html><body><p>mutated</p></body></html>"}}}}"#
+            );
+        }
+        return;
+    }
     if input.contains("__fixture_aria_switch__") {
         if input.contains("role") && input.contains("switch") && input.contains("aria-checked") {
             println!(


### PR DESCRIPTION
## Summary
Agents fail when clicking icon-only buttons: SOM compiles `aria-label` as the accessible name, but click DOM fallback only compared `textContent` / input `value`/`alt`.

This run matches compiled `aria-label` when those labels are empty. Distinct from #383 (input `value`/`alt`). Does not copy onto `clear` / `toggle` / `select_option` or SDKs.

## Proof
Focused: `cargo test --bin plasmate click_resolves_button_aria_label_when_textcontent_is_empty`

## Plasmate
Fetched https://docs.plasmate.app and https://docs.plasmate.app/changelog