### PR TITLE
fix(mcp): click compiled ARIA tabs without html_id

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2083,7 +2083,7 @@ pub async fn handle_click(
             }}
 
             if (!el && expected) {{
-                var allEls = document.querySelectorAll('a, button, input[type="submit"], input[type="button"], input[type="reset"], input[type="image"], [role="button"]');
+                var allEls = document.querySelectorAll('a, button, input[type="submit"], input[type="button"], input[type="reset"], input[type="image"], [role="button"], [role="tab"]');
                 for (var i = 0; i < allEls.length; i++) {{
                     var candidate = allEls[i];
                     var candidateLabel = candidate.tagName === 'INPUT'
@@ -4181,6 +4181,56 @@ mod tests {
         assert!(clicked.get("isError").is_none(), "{clicked}");
         let payload = tool_payload(&clicked);
         assert_eq!(payload["title"], "Dialog");
+        assert!(payload["regions"].is_array(), "{payload}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn click_resolves_aria_tab_when_html_id_is_absent() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Settings</title></head><body><main><!-- __fixture_aria_tab__ --><div role='tab'>Overview</div></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_url = Some("https://example.test/settings".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/settings")
+                        .unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        let element_id = sessions
+            .with_session(&session_id, |session| {
+                let som = session.target.current_som.as_ref().unwrap();
+                som.regions
+                    .iter()
+                    .flat_map(|region| region.elements.iter())
+                    .find(|element| {
+                        element.role == ElementRole::Button
+                            && element.html_id.is_none()
+                            && click_target_label(element) == "Overview"
+                    })
+                    .map(|element| element.id.clone())
+                    .expect("seeded page must expose the ARIA tab")
+            })
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let clicked = handle_click(
+            &json!({"session_id": session_id, "element_id": element_id}),
+            &client,
+            &sessions,
+        )
+        .await;
+        assert!(clicked.get("isError").is_none(), "{clicked}");
+        let payload = tool_payload(&clicked);
+        assert_eq!(payload["title"], "Settings");
         assert!(payload["regions"].is_array(), "{payload}");
     }
 

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -66,6 +66,18 @@ fn main() {
         }
         return;
     }
+    if input.contains("__fixture_aria_tab__") {
+        if input.contains(r#"[role=\"tab\"]"#) && input.contains("Overview") {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"clicked\":true}}","effective_html":"<html><head><title>Settings</title></head><body><main><!-- __fixture_aria_tab__ --><div role='tab'>Overview</div></main></body></html>"}}}}"#
+            );
+        } else {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"error\":\"Element not found in DOM\"}}","effective_html":"<html><body><p>mutated</p></body></html>"}}}}"#
+            );
+        }
+        return;
+    }
     if input.contains("__fixture_aria_switch__") {
         if input.contains("role") && input.contains("switch") && input.contains("aria-checked") {
             println!(


### PR DESCRIPTION
## Journey
Agents click compiled SOM buttons. `role=tab` already compiles to `ElementRole::Button`, but click DOM fallback only scanned `a`/`button`/input-buttons/`[role="button"]`, so unlabeled tabs without `html_id` failed closed as `Element not found in DOM`.

## Change
Include `[role="tab"]` in the existing click candidate query. No handler copies, no inspect-compact fields, no SDK/docs rewrite.

## Proof
Focused: `cargo test --bin plasmate click_`
- `click_resolves_aria_tab_when_html_id_is_absent` fails without the selector (fixture requires `[role="tab"]`) and passes after
- 11 click tests passed

Plasmate MCP reads this run: https://plasmate.app and https://docs.plasmate.app