### PR TITLE
fix(mcp): type_text by compiled name when html_id is absent

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1969,6 +1969,22 @@ fn compiled_link_href(element: &crate::som::types::Element) -> Option<&str> {
         .and_then(|value| value.as_str())
 }
 
+fn compiled_field_name(element: &crate::som::types::Element) -> Option<&str> {
+    if !matches!(
+        element.role,
+        crate::som::types::ElementRole::TextInput | crate::som::types::ElementRole::Textarea
+    ) {
+        return None;
+    }
+    element
+        .attrs
+        .as_ref()
+        .and_then(|attrs| attrs.get("name"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
 fn click_target_label(element: &crate::som::types::Element) -> &str {
     element
         .text
@@ -2285,7 +2301,7 @@ pub fn navigate_to_definition() -> ToolDefinition {
 pub fn type_text_definition() -> ToolDefinition {
     ToolDefinition {
         name: "type_text".to_string(),
-        description: "Type text into a form input or textarea by its SOM element ID. Returns the updated page SOM. Fails closed when the compiled SOM marks the target disabled or readonly, without mutating session HTML.".to_string(),
+        description: "Type text into a form input or textarea by its SOM element ID. Returns the updated page SOM. Resolves the live control by compiled name when html_id is absent. Fails closed when the compiled SOM marks the target disabled or readonly, without mutating session HTML.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -2536,6 +2552,7 @@ pub async fn handle_type_text(
         return error_response(&format!("Element is {reason}: {}", params.element_id));
     }
     let html_id = element.html_id.clone();
+    let field_name = compiled_field_name(element);
 
     // Run JS to type text into the element
     let element_id = params.element_id.clone();
@@ -2543,12 +2560,14 @@ pub async fn handle_type_text(
     let append = params.append;
     let element_id = serde_json::to_string(&element_id).unwrap_or_else(|_| "null".to_string());
     let html_id = serde_json::to_string(&html_id).unwrap_or_else(|_| "null".to_string());
+    let field_name = serde_json::to_string(&field_name).unwrap_or_else(|_| "null".to_string());
     let text = serde_json::to_string(&text).unwrap_or_else(|_| "null".to_string());
     let type_js = format!(
         r#"
             (function() {{
                 var somId = {};
                 var htmlId = {};
+                var fieldName = {};
                 var value = {};
                 var el = null;
                 var identified = document.querySelectorAll('[data-plasmate-id]');
@@ -2560,6 +2579,15 @@ pub async fn handle_type_text(
                 }}
                 if (!el && htmlId !== null) {{
                     el = document.getElementById(htmlId);
+                }}
+                if (!el && fieldName) {{
+                    var fields = document.querySelectorAll('input, textarea');
+                    for (var j = 0; j < fields.length; j++) {{
+                        if ((fields[j].getAttribute('name') || '') === fieldName) {{
+                            el = fields[j];
+                            break;
+                        }}
+                    }}
                 }}
                 if (!el) {{
                     return JSON.stringify({{ error: 'Element not found in DOM' }});
@@ -2578,6 +2606,7 @@ pub async fn handle_type_text(
             "#,
         element_id,
         html_id,
+        field_name,
         text,
         if append { "true" } else { "false" },
     );
@@ -4584,6 +4613,89 @@ mod tests {
             Some(readonly_message.as_str())
         );
         assert_eq!(state_fingerprint(&sessions, &session_id).await, before);
+    }
+
+    #[test]
+    fn type_text_compiled_field_name_keeps_nonempty_input_names() {
+        let named = Element {
+            id: "e_q".to_string(),
+            role: ElementRole::TextInput,
+            html_id: None,
+            text: None,
+            label: None,
+            actions: Some(vec!["type".into()]),
+            attrs: Some(json!({"name": "q"})),
+            children: None,
+            hints: None,
+            shadow: None,
+        };
+        assert_eq!(compiled_field_name(&named), Some("q"));
+
+        let blank = Element {
+            attrs: Some(json!({"name": "  "})),
+            ..named.clone()
+        };
+        assert_eq!(compiled_field_name(&blank), None);
+
+        let button = Element {
+            role: ElementRole::Button,
+            attrs: Some(json!({"name": "go"})),
+            ..named
+        };
+        assert_eq!(compiled_field_name(&button), None);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn type_text_resolves_compiled_name_when_html_id_is_absent() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Search</title></head><body><main><!-- __fixture_compiled_name__ --><input name='q' placeholder='Search'><input name='other'></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_url = Some("https://example.test/search".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/search").unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        let element_id = sessions
+            .with_session(&session_id, |session| {
+                let som = session.target.current_som.as_ref().unwrap();
+                som.regions
+                    .iter()
+                    .flat_map(|region| region.elements.iter())
+                    .find(|element| {
+                        element.role == ElementRole::TextInput
+                            && element.html_id.is_none()
+                            && compiled_field_name(element) == Some("q")
+                    })
+                    .map(|element| element.id.clone())
+                    .expect("seeded page must expose the named search input")
+            })
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let typed = handle_type_text(
+            &json!({
+                "session_id": session_id,
+                "element_id": element_id,
+                "text": "plasmate"
+            }),
+            &client,
+            &sessions,
+        )
+        .await;
+        assert!(typed.get("isError").is_none(), "{typed}");
+        let payload = tool_payload(&typed);
+        assert_eq!(payload["title"], "Search");
+        assert!(payload["regions"].is_array(), "{payload}");
     }
 
     #[test]

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -78,6 +78,21 @@ fn main() {
         }
         return;
     }
+    if input.contains("__fixture_compiled_name__") {
+        if input.contains("getAttribute('name')")
+            && input.contains("fieldName")
+            && input.contains("q")
+        {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"typed\":true}}","effective_html":"<html><head><title>Search</title></head><body><main><!-- __fixture_compiled_name__ --><input name='q' placeholder='Search'><input name='other'></main></body></html>"}}}}"#
+            );
+        } else {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"error\":\"Element not found in DOM\"}}","effective_html":"<html><body><p>mutated</p></body></html>"}}}}"#
+            );
+        }
+        return;
+    }
     if input.contains("__fixture_native_radio__") {
         if input.contains("type === 'radio'") {
             println!(


### PR DESCRIPTION
## Journey
Agents type into compiled SOM text fields. Search and form controls often have `name` but no `html_id`. After a re-render, `data-plasmate-id` is gone, so type_text failed closed as `Element not found in DOM`.

## Change
Resolve live `input`/`textarea` controls from the compiled nonempty `name` attribute after the existing data-plasmate-id and html_id lookups. No handler copies, no inspect-compact fields, no SDK/docs rewrite.

## Proof
Focused: `cargo test --bin plasmate type_text_`
- `type_text_compiled_field_name_keeps_nonempty_input_names` keeps nonempty input/textarea names and rejects whitespace/buttons
- `type_text_resolves_compiled_name_when_html_id_is_absent` fails without the name scan (fixture requires `getAttribute('name')`) and passes after
- `type_text_disabled_or_readonly_fails_closed_and_preserves_session` still passes

Plasmate MCP reads this run: https://plasmate.app and https://docs.plasmate.app