### PR TITLE
docs(automation): narrow hourly after #389 #390 #391

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-09)
 
-- Window: `612538b` .. `d31704b`
+- Window: `5aa1463` .. `f314bd4`
 - Decision: `NARROW`
-- Merged this run: `0d88253` extract_links relative href resolve (`753b22d`), `b2e54d8` click disabled fail-closed (`a311572`), and `fc034a7` click empty-text aria-label (`d31704b`)
+- Merged this run: `632e7d6` click compiled ARIA tab lookup (`b1ae35d`), `308ed51` AutoGen missing-module docs (`37b07fe`), and `b394072` type_text compiled name lookup (`f314bd4`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -489,12 +489,22 @@ overwrite, reset, or absorb unrelated work.
    Do not copy #387 extract_links relative href resolve onto CLI,
    CDP, or SDKs; do not copy click non-http skip or iframe src
    collection onto CLI/CDP; keep `javascript:` / `mailto:` unchanged.
+   Do not copy #389 click compiled ARIA tab lookup onto adjacent
+   handlers (`clear`, `toggle`, `select_option`) or SDKs; do not
+   extend click to other ARIA roles (`option`, `treeitem`,
+   `menuitem`) or reopen html_id lookup / DOM-miss fail-closed.
+   Do not copy #390 AutoGen missing-module docs onto Smolagents, Pi,
+   OpenClaw, or remaining integration pages; do not invent
+   `integrations/autogen/` or `plasmate.integrations.autogen`.
+   Do not copy #391 type_text compiled name lookup onto adjacent
+   handlers (`clear`, `toggle`, `select_option`, `click`) or SDKs;
+   do not scan button names or reopen html_id lookup.
 - Allowed next (pick one distinct journey): a real missed regression;
    a published-docs integration failure that is not another SDK
    install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI,
-   Browser Use, Scrapy, or LlamaIndex rewrite; or bounded agent-task
-   recovery that is not another IDL getter, querySelector pseudo,
-   inspect-compact field, compile-attr copy, MCP empty-session
+   Browser Use, Scrapy, LlamaIndex, or AutoGen rewrite; or bounded
+   agent-task recovery that is not another IDL getter, querySelector
+   pseudo, inspect-compact field, compile-attr copy, MCP empty-session
    error-text copy, open_page capacity error-text copy, navigate_to
    missing-session error-text copy, close_page idempotent-success copy,
    Python/Node/Go SDK method add, LangChain session-navigate copy,
@@ -502,8 +512,9 @@ overwrite, reset, or absorb unrelated work.
    Node extract_text raw-string keep, click compiled SOM envelope,
    evaluate expression wrap normalize, click compiled area href,
    scroll compiled html_id, click input value label, click empty-text
-   aria-label, click disabled fail-closed, or extract_links relative
-   href resolve.
+   aria-label, click disabled fail-closed, extract_links relative
+   href resolve, click compiled ARIA tab, AutoGen missing-module
+   docs, or type_text compiled name lookup.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Journey
Four-hour governor merged locally-proven #389, #390, and #391 onto master. The next hourly builder must not copy those surfaces.

## Change
NARROW the hourly constraint: prohibit ARIA-tab click copies, AutoGen missing-module docs copies, and type_text compiled-name copies.

## Proof
Docs-only governance update. Focused merge proofs already landed:
- `cargo test --bin plasmate click_` (11 passed, including `click_resolves_aria_tab_when_html_id_is_absent`)
- `cargo test --lib release_manifest::tests::autogen_docs_do_not_import_a_missing_in_tree_module`
- `cargo test --bin plasmate type_text_` (3 passed, including compiled name lookup)

Plasmate MCP reads this run: https://docs.plasmate.app and https://docs.plasmate.app/integration-autogen