### PR TITLE
fix(mcp): click compiled test_id when html_id is absent

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1711,7 +1711,7 @@ pub fn evaluate_definition() -> ToolDefinition {
 pub fn click_definition() -> ToolDefinition {
     ToolDefinition {
         name: "click".to_string(),
-        description: "Click an element on the page by its SOM element ID. Returns the updated page SOM after the click. Fails closed when the compiled SOM marks the target disabled, without mutating session HTML.".to_string(),
+        description: "Click an element on the page by its SOM element ID. Returns the updated page SOM after the click. Resolves the live control by compiled test_id when html_id is absent. Fails closed when the compiled SOM marks the target disabled, without mutating session HTML.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -1985,6 +1985,16 @@ fn compiled_field_name(element: &crate::som::types::Element) -> Option<&str> {
         .filter(|name| !name.is_empty())
 }
 
+fn compiled_test_id(element: &crate::som::types::Element) -> Option<&str> {
+    element
+        .attrs
+        .as_ref()
+        .and_then(|attrs| attrs.get("test_id"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|test_id| !test_id.is_empty())
+}
+
 fn click_target_label(element: &crate::som::types::Element) -> &str {
     element
         .text
@@ -2083,19 +2093,32 @@ pub async fn handle_click(
     }
 
     // Generate JavaScript to simulate click
-    // Resolve by data-plasmate-id, then compiled html_id, then tag/text/value/aria-label fallback.
+    // Resolve by data-plasmate-id, then compiled html_id, then compiled test_id,
+    // then tag/text/value/aria-label fallback.
     let element_id = params.element_id.clone();
     let html_id = serde_json::to_string(&element.html_id).unwrap_or_else(|_| "null".to_string());
+    let test_id =
+        serde_json::to_string(&compiled_test_id(element)).unwrap_or_else(|_| "null".to_string());
     let expected_label =
         serde_json::to_string(click_target_label(element)).unwrap_or_else(|_| "\"\"".to_string());
     let click_js = format!(
         r#"
         (function() {{
             var htmlId = {};
+            var testId = {};
             var expected = {};
             var el = document.querySelector('[data-plasmate-id="{}"]');
             if (!el && htmlId !== null) {{
                 el = document.getElementById(htmlId);
+            }}
+            if (!el && testId) {{
+                el = document.querySelector('[data-testid="' + testId + '"]');
+                if (!el) {{
+                    el = document.querySelector('[data-test="' + testId + '"]');
+                }}
+                if (!el) {{
+                    el = document.querySelector('[data-qa="' + testId + '"]');
+                }}
             }}
 
             if (!el && expected) {{
@@ -2131,7 +2154,7 @@ pub async fn handle_click(
             return JSON.stringify({{ error: 'Element not found in DOM' }});
         }})()
         "#,
-        html_id, expected_label, element_id,
+        html_id, test_id, expected_label, element_id,
     );
 
     let click_result =
@@ -4265,6 +4288,56 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
+    async fn click_resolves_compiled_test_id_when_html_id_is_absent() {
+        let options = stateful_worker_options(Duration::from_secs(5));
+        let sessions = Arc::new(SessionManager::with_worker_options(options));
+        let session_id = sessions.create_session().await.unwrap();
+        let html = "<html><head><title>Pay</title></head><body><main><!-- __fixture_test_id__ --><button data-testid='pay-now'></button></main></body></html>";
+        sessions
+            .with_session(&session_id, |session| {
+                session.target.current_url = Some("https://example.test/pay".to_string());
+                session.target.current_html = Some(html.to_string());
+                session.target.effective_html = Some(html.to_string());
+                session.target.current_som = Some(
+                    plasmate::som::compiler::compile(html, "https://example.test/pay").unwrap(),
+                );
+                session.target.rebuild_node_map();
+            })
+            .await
+            .unwrap();
+        let element_id = sessions
+            .with_session(&session_id, |session| {
+                let som = session.target.current_som.as_ref().unwrap();
+                som.regions
+                    .iter()
+                    .flat_map(|region| region.elements.iter())
+                    .find(|element| {
+                        element.role == ElementRole::Button
+                            && element.html_id.is_none()
+                            && click_target_label(element).is_empty()
+                            && compiled_test_id(element) == Some("pay-now")
+                    })
+                    .map(|element| element.id.clone())
+                    .expect("seeded page must expose the test_id button")
+            })
+            .await
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let clicked = handle_click(
+            &json!({"session_id": session_id, "element_id": element_id}),
+            &client,
+            &sessions,
+        )
+        .await;
+        assert!(clicked.get("isError").is_none(), "{clicked}");
+        let payload = tool_payload(&clicked);
+        assert_eq!(payload["title"], "Pay");
+        assert!(payload["regions"].is_array(), "{payload}");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
     async fn click_disabled_fails_closed_and_preserves_session() {
         let options = stateful_worker_options(Duration::from_secs(5));
         let sessions = Arc::new(SessionManager::with_worker_options(options));
@@ -4693,6 +4766,35 @@ mod tests {
             ..named
         };
         assert_eq!(compiled_field_name(&button), None);
+    }
+
+    #[test]
+    fn compiled_test_id_keeps_nonempty_locator_values() {
+        let button = Element {
+            id: "e_pay".to_string(),
+            role: ElementRole::Button,
+            html_id: None,
+            text: None,
+            label: None,
+            actions: Some(vec!["click".into()]),
+            attrs: Some(json!({"test_id": "pay-now"})),
+            children: None,
+            hints: None,
+            shadow: None,
+        };
+        assert_eq!(compiled_test_id(&button), Some("pay-now"));
+
+        let blank = Element {
+            attrs: Some(json!({"test_id": "  "})),
+            ..button.clone()
+        };
+        assert_eq!(compiled_test_id(&blank), None);
+
+        let missing = Element {
+            attrs: Some(json!({"name": "pay"})),
+            ..button
+        };
+        assert_eq!(compiled_test_id(&missing), None);
     }
 
     #[tokio::test]

--- a/tests/fixtures/js_worker_fixture.rs
+++ b/tests/fixtures/js_worker_fixture.rs
@@ -90,6 +90,22 @@ fn main() {
         }
         return;
     }
+    if input.contains("__fixture_test_id__") {
+        if input.contains("var testId")
+            && input.contains("data-testid")
+            && input.contains("data-qa")
+            && input.contains("pay-now")
+        {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"clicked\":true}}","effective_html":"<html><head><title>Pay</title></head><body><main><!-- __fixture_test_id__ --><button data-testid='pay-now'></button></main></body></html>"}}}}"#
+            );
+        } else {
+            println!(
+                r#"{{"status":"evaluation","value":{{"result":"{{\"error\":\"Element not found in DOM\"}}","effective_html":"<html><body><p>mutated</p></body></html>"}}}}"#
+            );
+        }
+        return;
+    }
     if input.contains("__fixture_compiled_name__") {
         if input.contains("getAttribute('name')")
             && input.contains("fieldName")


### PR DESCRIPTION
## Summary
- Click now resolves live DOM nodes by compiled `test_id` (`data-testid` / `data-test` / `data-qa`) when `html_id` is missing.
- Icon-only and unlabeled controls keep working after `data-plasmate-id` is gone from the live tree.

## Proof
- `cargo test --bin plasmate compiled_test_id`
- `cargo test --bin plasmate click_resolves_`

Governor: NARROW window after #389/#390/#391. This is a distinct click locator (compiled test_id), not an ARIA-role, html_id, name, or docs copy.