### PR TITLE
docs(install): name native MCP tools on the install page

### DIFF
--- a/src/release_manifest.rs
+++ b/src/release_manifest.rs
@@ -1274,6 +1274,38 @@ mod tests {
     }
 
     #[test]
+    fn install_docs_name_native_mcp_tools_not_aliases() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let md =
+            fs::read_to_string(root.join("website/docs/src/install.md")).expect("read install.md");
+        assert!(
+            !md.contains("`fetch`, `navigate`, `click`, and `type`"),
+            "install.md still advertises non-existent MCP tool aliases"
+        );
+        assert!(
+            md.contains("`fetch_page`")
+                && md.contains("`navigate_to`")
+                && md.contains("`type_text`"),
+            "install.md should name fetch_page, navigate_to, and type_text"
+        );
+
+        let html =
+            fs::read_to_string(root.join("website/docs/install.html")).expect("read install.html");
+        assert!(
+            !html.contains(
+                "<code>fetch</code>, <code>navigate</code>, <code>click</code>, and <code>type</code>"
+            ),
+            "install.html still advertises non-existent MCP tool aliases"
+        );
+        assert!(
+            html.contains("<code>fetch_page</code>")
+                && html.contains("<code>navigate_to</code>")
+                && html.contains("<code>type_text</code>"),
+            "install.html should name fetch_page, navigate_to, and type_text"
+        );
+    }
+
+    #[test]
     fn vercel_ai_docs_point_at_live_install_docs_not_plasmate_dev() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         for rel in [

--- a/website/docs/install.html
+++ b/website/docs/install.html
@@ -475,7 +475,7 @@ brew install plasmate
 plasmate fetch https://example.com
 </code></pre>
 <p>If you see SOM output, you&#39;re good to go.</p>
-<h2 id="mcp-server-claude-code-cursor-windsurf">MCP Server (Claude Code / Cursor / Windsurf)</h2><p>Plasmate ships an MCP server that exposes <code>fetch</code>, <code>navigate</code>, <code>click</code>, and <code>type</code> as tools for any MCP-compatible AI client.</p>
+<h2 id="mcp-server-claude-code-cursor-windsurf">MCP Server (Claude Code / Cursor / Windsurf)</h2><p>Plasmate ships an MCP server that exposes <code>fetch_page</code>, <code>navigate_to</code>, <code>click</code>, and <code>type_text</code> as tools for any MCP-compatible AI client.</p>
 <h3 id="claude-code-one-liner">Claude Code (one-liner)</h3><pre><code class="language-bash">claude mcp add plasmate -- npx plasmate-mcp
 </code></pre>
 <h3 id="claude-desktop-cursor-windsurf">Claude Desktop / Cursor / Windsurf</h3><p>Add to your MCP config (e.g. <code>~/.claude/settings.json</code> or the app&#39;s MCP settings):</p>

--- a/website/docs/src/install.md
+++ b/website/docs/src/install.md
@@ -30,7 +30,7 @@ If you see SOM output, you're good to go.
 
 ## MCP Server (Claude Code / Cursor / Windsurf)
 
-Plasmate ships an MCP server that exposes `fetch`, `navigate`, `click`, and `type` as tools for any MCP-compatible AI client.
+Plasmate ships an MCP server that exposes `fetch_page`, `navigate_to`, `click`, and `type_text` as tools for any MCP-compatible AI client.
 
 ### Claude Code (one-liner)
 


### PR DESCRIPTION
## Journey
Published-docs integration failure: `https://docs.plasmate.app/install` tells agents the MCP server exposes `fetch`, `navigate`, `click`, and `type`. Those names are not the native tools.

## Hypothesis
Agents that follow the install page call non-existent MCP tools and never recover to `fetch_page` / `navigate_to` / `type_text`.

## Change
- Name `fetch_page`, `navigate_to`, `click`, and `type_text` on the install page source and published HTML.
- Do not change pip/npm/brew install paths, `npx plasmate-mcp`, Vercel AI, Go SDK, CrewAI, OpenClaw, Pi, or other integration pages.

## Proof
Focused, no network:
- `cargo test --lib install_docs_name_native_mcp_tools_not_aliases -- --nocapture`
- `cargo fmt --check -- src/release_manifest.rs`

Governor lane: published-docs integration failure; not an SDK install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI, Browser Use, Scrapy, LlamaIndex, or AutoGen rewrite.

Plasmate MCP: `https://plasmate.app` (extract_text), `https://docs.plasmate.app` (fetch_page), `https://docs.plasmate.app/install` (extract_text), `https://docs.plasmate.app/tools` (extract_text).