### PR TITLE
docs(automation): narrow hourly after #407

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -35,9 +35,9 @@ overwrite, reset, or absorb unrelated work.
 
 ## Active governor constraint (2026-09-10)
 
-- Window: `248749d` .. `ec546e2`
+- Window: `e40c54f` .. `e3b4aae`
 - Decision: `NARROW`
-- Merged this run: `5aa2208` ARIA role=article as section (`ec546e2`)
+- Merged this run: `47b3fe6` click compiled GET submit (`e3b4aae`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -529,6 +529,11 @@ overwrite, reset, or absorb unrelated work.
      extract_text, CLI, CDP, extract_links, SDKs, landmarks, or other
      ARIA roles (`document`, `feed`, `region`, `note`); do not add a
      new ElementRole or inspect compact article field.
+     Do not copy #407 click compiled GET form submit onto extract_links,
+     CLI, CDP, adjacent handlers (`clear`, `toggle`, `select_option`,
+     `type_text`) or SDKs; do not add `form.submit` IDL, POST
+     navigation, `enctype` / `target` / `novalidate`, or
+     select/checkbox/radio encoding.
 - Allowed next (pick one distinct journey): a real missed regression;
     a published-docs integration failure that is not another SDK
     install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI,
@@ -550,7 +555,8 @@ overwrite, reset, or absorb unrelated work.
      href lookup, clear compiled action:clear fail-closed, install
      native MCP tool names, click compiled ARIA link lookup,
      searchbox selector alias, combobox/listbox selector alias,
-     or ARIA role=article Section compile.
+     ARIA role=article Section compile, or click compiled GET form
+     submit.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- Governor NARROW after merging #407.
- Prohibit copies of click compiled GET form submit onto extract_links, CLI, CDP, adjacent handlers, or SDKs.
- Do not add form.submit IDL, POST navigation, enctype/target/novalidate, or select/checkbox/radio encoding.

## Proof
- Docs-only constraint update. No code change.
- Prior focused proof for #407: `cargo test --bin plasmate compiled_submit_form_get` (3 ok) and `cargo fmt --check`.

## Governor notes
- Decision: NARROW
- Window: `e40c54f` .. `e3b4aae`
- Plasmate MCP: `extract_text` against `https://plasmate.app`