### PR TITLE
feat(som): improve selector aliases

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -39,6 +39,8 @@ pub struct ToolDefinition {
     pub input_schema: Value,
 }
 
+const SOM_SELECTOR_DESCRIPTION: &str = "Filter to a page region (main, nav/navigation, header, footer, aside, content/article, form, dialog), element role (button, link, text_input, select, etc.), action surface (interactive, action:click, action:type, action:select), or #element-id. Strips irrelevant regions/elements to reduce tokens.";
+
 /// Parameters for fetch_page tool.
 #[derive(Debug, Deserialize)]
 struct FetchPageParams {
@@ -431,7 +433,7 @@ pub fn fetch_page_definition() -> ToolDefinition {
                 },
                 "selector": {
                     "type": "string",
-                    "description": "Filter to a page region (main, nav, header, footer, aside, content, form, dialog), element role (button, link, text_input, select, etc.), action surface (interactive, action:click, action:type, action:select), or #element-id. Strips irrelevant regions/elements to reduce tokens."
+                    "description": SOM_SELECTOR_DESCRIPTION
                 }
             },
             "required": ["url"]
@@ -457,7 +459,7 @@ pub fn extract_text_definition() -> ToolDefinition {
                 },
                 "selector": {
                     "type": "string",
-                    "description": "Filter before extracting text: page region (main, nav, header, footer, aside, content, form, dialog), element role (button, link, text_input, select, etc.), action surface (interactive, action:click, action:type, action:select), or #element-id."
+                    "description": SOM_SELECTOR_DESCRIPTION
                 }
             },
             "required": ["url"]
@@ -714,7 +716,7 @@ pub fn extract_links_definition() -> ToolDefinition {
                 },
                 "selector": {
                     "type": "string",
-                    "description": "Filter before extracting links: page region (main, nav, header, footer, aside, content, form, dialog), element role (link), action surface (interactive, action:click), or #element-id."
+                    "description": SOM_SELECTOR_DESCRIPTION
                 }
             },
             "required": ["url"]
@@ -3969,6 +3971,21 @@ mod tests {
 
         assert!(docs.contains(&format!("| `{registered_name}` |")));
         assert!(!docs.contains("| `screenshot` |"));
+    }
+
+    #[test]
+    fn selector_tool_schemas_document_region_aliases() {
+        for definition in [
+            fetch_page_definition(),
+            extract_text_definition(),
+            extract_links_definition(),
+        ] {
+            let description = definition.input_schema["properties"]["selector"]["description"]
+                .as_str()
+                .expect("selector schema should have a description");
+            assert!(description.contains("nav/navigation"));
+            assert!(description.contains("content/article"));
+        }
     }
 
     fn stateful_worker_fixture() -> PathBuf {

--- a/src/som/filter.rs
+++ b/src/som/filter.rs
@@ -10,7 +10,7 @@ use super::types::{Element, ElementRole, RegionRole, ShadowRoot, Som};
 ///
 /// Supported selectors:
 /// - Region roles: `main`, `nav`/`navigation`, `aside`, `header`, `footer`,
-///   `form`, `dialog`, `content`
+///   `form`, `dialog`, `content`/`article`
 /// - Element roles: `link`, `button`, `text_input` / `textbox` / `searchbox` /
 ///   `input`, `textarea`, `select` / `combobox` / `listbox`, `checkbox`,
 ///   `radio`, `heading`, `image`, `list`, `table`, `paragraph`, `section`,
@@ -34,7 +34,7 @@ pub fn apply_selector(som: &Som, selector: &str) -> Som {
         "footer" => Some(RegionRole::Footer),
         "form" => Some(RegionRole::Form),
         "dialog" => Some(RegionRole::Dialog),
-        "content" => Some(RegionRole::Content),
+        "content" | "article" => Some(RegionRole::Content),
         _ => None,
     };
 
@@ -577,6 +577,15 @@ mod tests {
         let filtered = apply_selector(&som, " main ");
         assert_eq!(filtered.regions.len(), 1);
         assert_eq!(filtered.regions[0].role, RegionRole::Main);
+    }
+
+    #[test]
+    fn test_selector_article_alias_matches_content_region() {
+        let mut som = make_test_som();
+        som.regions[1].role = RegionRole::Content;
+        let filtered = apply_selector(&som, "article");
+        assert_eq!(filtered.regions.len(), 1);
+        assert_eq!(filtered.regions[0].role, RegionRole::Content);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept `article` as an alias for the SOM `content` region selector
- document `nav`/`navigation` and `content`/`article` aliases in all selector-bearing MCP tool schemas
- add focused regression coverage for behavior and advertised schema

## Proof
- `~/.cargo/bin/cargo test som::filter::tests::test_selector_article_alias_matches_content_region`
- `~/.cargo/bin/cargo test mcp::tools::tests::selector_tool_schemas_document_region_aliases`
- `git diff --check`

This is a small autonomous builder change for governor review.