### PR TITLE
docs(automation): narrow hourly lane after #417

### DIFF
--- a/docs/automation/HOURLY_BUILDER_LOOP.md
+++ b/docs/automation/HOURLY_BUILDER_LOOP.md
@@ -33,11 +33,11 @@ frequency.
 If these gates are not met, report a no-change or blocked run. Never stash,
 overwrite, reset, or absorb unrelated work.
 
-## Active governor constraint (2026-09-11)
+## Active governor constraint (2026-09-12)
 
-- Window: `73efbef` .. `a79a568`
+- Window: `2b5286b` .. `17b369e`
 - Decision: `NARROW`
-- Merged this run: `7c7e122` navigate_to relative URL (`bf75c0a`), `15dd3ba` click same-document fragment (`f02c089`), `8f18fde` click GET submit form owner id (`a79a568`)
+- Merged this run: `17b369e` article selector alias (`e94838a`)
 - Prohibited next: another compiled `attrs.options` / `attrs.caption` /
   `attrs.items` / `attrs.rows` one-surface copy in parser, SDK, CLI, or MCP
   text extractors. Do not reopen `#` selector matching (region id, SOM
@@ -541,9 +541,13 @@ overwrite, reset, or absorb unrelated work.
      `navigate_to`, extract_links, CLI, CDP, or SDKs; do not reopen
      click non-http skip or treat path/query changes as same-document.
      Do not copy #411 click compiled GET submit form owner id onto
-     extract_links, CLI, CDP, adjacent handlers (`clear`, `toggle`,
-     `select_option`, `type_text`) or SDKs; do not add `form.submit`
-     IDL, POST navigation, or select/checkbox/radio encoding.
+      extract_links, CLI, CDP, adjacent handlers (`clear`, `toggle`,
+      `select_option`, `type_text`) or SDKs; do not add `form.submit`
+      IDL, POST navigation, or select/checkbox/radio encoding.
+     Do not copy #417 `article` content-region selector alias or shared
+      MCP selector schema text onto other region aliases (`sidebar`,
+      `complementary`, `banner`, `contentinfo`), CLI `--selector` help,
+      CDP, extract_links-only role lists, or additional MCP tools.
 - Allowed next (pick one distinct journey): a real missed regression;
     a published-docs integration failure that is not another SDK
     install-path, SOM-reference, OpenClaw/Pi, CrewAI, Vercel AI,
@@ -567,8 +571,9 @@ overwrite, reset, or absorb unrelated work.
      searchbox selector alias, combobox/listbox selector alias,
      ARIA role=article Section compile, click compiled GET form
      submit, navigate_to session-relative URL join, click
-     same-document fragment skip-fetch, or click compiled GET
-     submit form owner id.
+      same-document fragment skip-fetch, click compiled GET
+      submit form owner id, or article content-region selector
+      alias.
 
 ## Preferred lanes
 


### PR DESCRIPTION
## Summary
- record governor decision `NARROW` after merging #417
- prohibit copying the `article` content-region selector alias onto other region aliases, CLI, CDP, or extra MCP schemas

## Proof
- `git diff --check`
- docs-only governance constraint update; no runtime change

Governor merge in this same run. Do not leave this PR open.