### PR TITLE
fix(som): compile hidden inputs for GET submit tokens

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5617,6 +5617,28 @@ mod tests {
     }
 
     #[test]
+    fn compiled_submit_form_get_navigation_url_includes_hidden_fields() {
+        let som = crate::som::compiler::compile(
+            r##"<html><head><title>Search</title></head><body>
+<form action="/results" method="get">
+  <input type="hidden" name="source" value="web">
+  <input type="HIDDEN" name="token" value="csrf">
+  <input type="hidden" value="dropped">
+  <input name="q" value="plasmate">
+  <button>Search</button>
+</form>
+</body></html>"##,
+            "https://example.test/search",
+        )
+        .expect("fixture HTML should compile");
+        let search = compiled_form_submit_button(&som, "Search");
+        assert_eq!(
+            compiled_submit_form_get_navigation_url(&som, search, "https://example.test/search"),
+            Some("https://example.test/results?source=web&token=csrf&q=plasmate".to_string())
+        );
+    }
+
+    #[test]
     fn compiled_submit_form_get_navigation_url_includes_successful_checkboxes_and_radios() {
         let som = crate::som::compiler::compile(
             r##"<html><head><title>Preferences</title></head><body>

--- a/src/som/compiler.rs
+++ b/src/som/compiler.rs
@@ -1646,7 +1646,7 @@ fn tag_to_role(tag: &str, attrs: &[(String, String)]) -> Option<ElementRole> {
                 "submit" | "button" | "reset" | "image" => Some(ElementRole::Button),
                 "checkbox" => Some(ElementRole::Checkbox),
                 "radio" => Some(ElementRole::Radio),
-                "hidden" => None,
+                "hidden" => Some(ElementRole::TextInput),
                 "text" | "email" | "password" | "search" | "tel" | "url" | "number" | "date"
                 | "time" | "datetime-local" | "month" | "week" | "color" => {
                     Some(ElementRole::TextInput)
@@ -5187,6 +5187,60 @@ mod tests {
                     && element.text.as_deref() == Some("Just text")
             }),
             "plain text must stay a paragraph: {elements:?}"
+        );
+    }
+
+    #[test]
+    fn test_hidden_inputs_compile_named_values() {
+        let html = r#"<!DOCTYPE html>
+<html><head><title>Search</title></head>
+<body>
+<main>
+  <form action="/results" method="get">
+    <input type="HIDDEN" name="source" value="web">
+    <input type="hidden" value="dropped">
+    <input id="q" name="q" type="text" value="plasmate">
+  </form>
+</main>
+</body>
+</html>"#;
+
+        let som = compile(html, "https://example.test/search").unwrap();
+        let elements: Vec<_> = som
+            .regions
+            .iter()
+            .flat_map(|region| region.elements.iter())
+            .collect();
+
+        let source = elements
+            .iter()
+            .find(|element| {
+                element
+                    .attrs
+                    .as_ref()
+                    .and_then(|attrs| attrs.get("name"))
+                    .and_then(|value| value.as_str())
+                    == Some("source")
+            })
+            .expect("named hidden input should compile");
+        assert_eq!(source.role, ElementRole::TextInput);
+        let source_attrs = source
+            .attrs
+            .as_ref()
+            .expect("hidden input attrs should compile");
+        assert_eq!(source_attrs["input_type"], "hidden");
+        assert_eq!(source_attrs["name"], "source");
+        assert_eq!(source_attrs["value"], "web");
+
+        let query = elements
+            .iter()
+            .find(|element| element.html_id.as_deref() == Some("q"))
+            .expect("visible text input should still compile");
+        assert_eq!(query.role, ElementRole::TextInput);
+        assert_eq!(
+            query.actions.as_deref(),
+            Some(["type".to_string(), "clear".to_string()].as_slice()),
+            "visible text inputs must keep type/clear: {query:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

`input type=hidden` compiled to no SOM role, so click GET form submit dropped named hidden fields (source, csrf, locale) while encoding visible controls.

Map hidden inputs to `text_input` with compiled `input_type`/`name`/`value`. Unnamed hidden fields still have no `name`, so they stay out of the query. This is not a file-input type/clear omit copy.

## Proof

Focused:
- `cargo test som::compiler::tests::test_hidden_inputs_compile_named_values -- --exact` — pass
- `cargo test --bin plasmate compiled_submit_form_get` — 11 passed, including `compiled_submit_form_get_navigation_url_includes_hidden_fields`

Plasmate MCP page reads this run: `https://docs.plasmate.app`, `https://plasmate.app`.

Not a copy of #424 (listed-control form owner association) or #206 (file type/clear omit).

## Governor

One small SOM compile + GET encoding recovery. No IDL, inspect-compact, SDK, CLI, or CDP copy.