### PR TITLE
fix(som): compile option label as visible option text

### DIFF
--- a/src/som/compiler.rs
+++ b/src/som/compiler.rs
@@ -2729,13 +2729,19 @@ fn extract_select_options(
                 let tag = name.local.as_ref();
                 if tag == "option" {
                     let attrs = attrs.borrow();
-                    let text =
+                    let child_text =
                         heuristics::normalize_text(&get_visible_text_content(child, css_rules));
+                    let text = attrs
+                        .iter()
+                        .find(|a| a.name.local.as_ref() == "label")
+                        .map(|a| heuristics::normalize_text(&a.value))
+                        .filter(|label| !label.is_empty())
+                        .unwrap_or_else(|| child_text.clone());
                     let value = attrs
                         .iter()
                         .find(|a| a.name.local.as_ref() == "value")
                         .map(|a| a.value.to_string())
-                        .unwrap_or_else(|| text.clone());
+                        .unwrap_or(child_text);
                     let selected = attrs.iter().any(|a| a.name.local.as_ref() == "selected");
                     let disabled =
                         group_disabled || attrs.iter().any(|a| a.name.local.as_ref() == "disabled");
@@ -6171,6 +6177,66 @@ mod tests {
             }),
             "plain text must stay a paragraph: {elements:?}"
         );
+    }
+
+    #[test]
+    fn test_option_label_attr_is_compiled_as_visible_text() {
+        let html = r#"<!DOCTYPE html>
+<html><head><title>Plan</title></head>
+<body>
+<main>
+  <select aria-label="Plan">
+    <option value="pro" label="Pro Plan">internal-pro</option>
+    <option label="Free Plan">free</option>
+    <option label="   ">Bare</option>
+    <option>Starter</option>
+  </select>
+</main>
+</body>
+</html>"#;
+
+        let som = compile(html, "https://example.test/pricing").unwrap();
+        let elements: Vec<_> = som
+            .regions
+            .iter()
+            .flat_map(|region| region.elements.iter())
+            .collect();
+        let select = elements
+            .iter()
+            .find(|element| element.role == ElementRole::Select)
+            .expect("plan select should compile");
+        let options = select
+            .attrs
+            .as_ref()
+            .and_then(|attrs| attrs.get("options"))
+            .and_then(|options| options.as_array())
+            .expect("select options should compile");
+
+        let pro = options
+            .iter()
+            .find(|option| option["value"] == "pro")
+            .expect("named pro option should compile");
+        assert_eq!(pro["text"], "Pro Plan");
+        assert_ne!(pro["text"], "internal-pro");
+
+        let free = options
+            .iter()
+            .find(|option| option["value"] == "free")
+            .expect("child-text value should stay the option value");
+        assert_eq!(free["text"], "Free Plan");
+        assert_eq!(free["value"], "free");
+
+        let bare = options
+            .iter()
+            .find(|option| option["value"] == "Bare")
+            .expect("whitespace-only label must not invent visible text");
+        assert_eq!(bare["text"], "Bare");
+
+        let starter = options
+            .iter()
+            .find(|option| option["value"] == "Starter")
+            .expect("unlabelled option should keep child text");
+        assert_eq!(starter["text"], "Starter");
     }
 
     #[test]


### PR DESCRIPTION
## Journey
Agents reading a compiled `<select>` need the same option names users see in the dropdown. Native `<option label>` supplies that visible name.

## Hypothesis
SOM used option child text (or empty text) as `options[].text`, so icon-only / internally-coded options with a `label` attribute were shown as the wrong name. Value still comes from the `value` attribute or child text.

## Change
Prefer a non-empty `label` content attribute for compiled option text. Do not invent text from whitespace-only labels. Do not use `label` as the form value.

## Proof
Focused: `cargo test --lib som::compiler::tests::test_option_label_attr_is_compiled_as_visible_text`

## Plasmate
Fetched `https://plasmate.app` (main) via Plasmate MCP before selecting work. `https://plasmate.dev` returned 404.

## Notes
Builder PR for governor review. Not a copy of optgroup.label IDL, select `.value` IDL, or multiple-select mutation.