### PR TITLE
fix(som): compile ARIA role=form as a form region

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5931,6 +5931,32 @@ mod tests {
     }
 
     #[test]
+    fn compiled_submit_form_get_follows_aria_role_form() {
+        let som = crate::som::compiler::compile(
+            r##"<html><head><title>Search</title></head><body>
+<div role="form" action="/results" method="get">
+  <input name="q" value="rust som">
+  <button>Search</button>
+</div>
+<button>Go</button>
+</body></html>"##,
+            "https://example.test/search",
+        )
+        .expect("fixture HTML should compile");
+        let search = compiled_form_submit_button(&som, "Search");
+        let go = compiled_page_button(&som, "Go");
+
+        assert_eq!(
+            compiled_submit_form_get_navigation_url(&som, search, "https://example.test/search"),
+            Some("https://example.test/results?q=rust+som".to_string())
+        );
+        assert_eq!(
+            compiled_submit_form_get_navigation_url(&som, go, "https://example.test/search"),
+            None
+        );
+    }
+
+    #[test]
     fn compiled_submit_form_get_navigation_url_resolves_action_against_document_base() {
         let html = r##"<html><head><!-- <base href="/ignored/"> --><base href="/app/"><title>Search</title></head><body>
 <form action="results" method="get">

--- a/src/som/compiler.rs
+++ b/src/som/compiler.rs
@@ -640,7 +640,10 @@ fn collect_regions(
         }
 
         // Check for form regions
-        if heuristics::is_form_region(tag) {
+        if heuristics::is_form_region(tag)
+            || (heuristics::has_form_role(&attr_pairs)
+                && !contains_descendant_tag(node, &["form"], 8))
+        {
             let count = region_counts.entry("form".to_string()).or_insert(0);
             let rid = generate_region_id("form", *count);
             *count += 1;
@@ -3307,6 +3310,69 @@ mod tests {
         assert_eq!(form.action.as_deref(), Some("/login"));
         assert_eq!(form.method.as_deref(), Some("POST"));
         assert!(form.elements.len() >= 3);
+    }
+
+    #[test]
+    fn test_aria_role_form_compiles_as_form_region() {
+        let html = r#"<!DOCTYPE html>
+<html><head><title>Search</title></head>
+<body>
+<div role="form" action="/results" method="get" aria-label="Filters">
+  <input name="q" value="rust som">
+  <button>Search</button>
+</div>
+<div role="group" aria-label="Not a form">
+  <input name="other" value="skip">
+  <button>Go</button>
+</div>
+<div role="form">
+  <form action="/nested" method="post" aria-label="Native">
+    <input name="email" value="ops@example.test">
+    <button>Sign in</button>
+  </form>
+</div>
+</body>
+</html>"#;
+
+        let som = compile(html, "https://example.test/search").unwrap();
+        let forms: Vec<_> = som
+            .regions
+            .iter()
+            .filter(|region| region.role == RegionRole::Form)
+            .collect();
+        assert_eq!(
+            forms.len(),
+            2,
+            "aria form and nested native form: {forms:?}"
+        );
+
+        let aria_form = forms
+            .iter()
+            .find(|region| region.label.as_deref() == Some("Filters"))
+            .expect("ARIA role=form should compile as a form region");
+        assert_eq!(aria_form.action.as_deref(), Some("/results"));
+        assert_eq!(aria_form.method.as_deref(), Some("GET"));
+        assert!(
+            aria_form.elements.iter().any(|element| {
+                element.role == ElementRole::Button && element.text.as_deref() == Some("Search")
+            }),
+            "ARIA form should keep its submit control: {aria_form:?}"
+        );
+
+        let native = forms
+            .iter()
+            .find(|region| region.label.as_deref() == Some("Native"))
+            .expect("nested native form should stay a form region");
+        assert_eq!(native.action.as_deref(), Some("/nested"));
+        assert_eq!(native.method.as_deref(), Some("POST"));
+
+        assert!(
+            !som.regions.iter().any(|region| {
+                region.role == RegionRole::Form && region.label.as_deref() == Some("Not a form")
+            }),
+            "role=group must not compile as a form region: {:?}",
+            som.regions
+        );
     }
 
     #[test]

--- a/src/som/heuristics.rs
+++ b/src/som/heuristics.rs
@@ -259,6 +259,16 @@ pub fn is_form_region(tag: &str) -> bool {
     tag == "form"
 }
 
+/// True when ARIA `role` includes the `form` landmark token.
+pub fn has_form_role(attrs: &[(String, String)]) -> bool {
+    attrs.iter().any(|(name, value)| {
+        name == "role"
+            && value
+                .split_whitespace()
+                .any(|role| role.eq_ignore_ascii_case("form"))
+    })
+}
+
 /// Heuristic: check if a node looks like a navigation region
 /// (e.g., a list of links near the top of the page).
 pub fn looks_like_navigation(link_count: usize, total_children: usize) -> bool {


### PR DESCRIPTION
## Summary
Compile ARIA `role=form` as a Form region so agents can recover SPA filter/search surfaces that omit a native `<form>` tag.

- `selector=form` now matches those regions
- compiled GET submit follows `action`/`method` on the ARIA form
- a wrapping `role=form` that already contains a native `<form>` leaves the nested form in charge
- `role=group` is unchanged

## Proof
Focused local tests (not full suite):

```
cargo test aria_role_form
```

- `som::compiler::tests::test_aria_role_form_compiles_as_form_region`
- `mcp::tools::tests::compiled_submit_form_get_follows_aria_role_form`

## Governor notes
One product change. Distinct from native `<form>` handling, `#179` `<search>` landmarks, and GET-submit copies onto CLI/CDP/SDKs.